### PR TITLE
Fix empty statistics page

### DIFF
--- a/modules/admin-ui-picard/app/src/thunks/statisticsThunks.js
+++ b/modules/admin-ui-picard/app/src/thunks/statisticsThunks.js
@@ -181,6 +181,7 @@ export const fetchStatistics = (
 						// put statistics list into redux store
 						dispatch(loadStatisticsSuccess(newStatistics, false));
 					}
+					dispatch(loadStatisticsSuccess(newStatistics, false));
 				})
 				.catch((response) => {
 					// put unfinished statistics list into redux store but set flag that an error occurred


### PR DESCRIPTION
Fixes #54 

Without a statistics provider, the "Statistics" page only shows a blank page. This is because one of the related redux states does not get properly set in case of an empty array. This fixes that.