### PR TITLE
Fix table column names

### DIFF
--- a/modules/admin-ui-picard/app/src/components/shared/Table.js
+++ b/modules/admin-ui-picard/app/src/components/shared/Table.js
@@ -138,13 +138,11 @@ const Table = ({
 	};
 
 	const sortByColumn = (colName) => {
-		requestSort(colName);
+		const direction = requestSort(colName);
 		setSortBy(colName);
-		if (sortConfig) {
-			reverseTable(sortConfig.direction);
-		} else {
-			reverseTable("ASC");
-		}
+		// Usually we could just use *sortConfig* here, but it seems that does not
+		// get updated until the next rerender
+		reverseTable(direction);
 	};
 
 	const showEditTableViewModal = async () => {
@@ -398,6 +396,7 @@ const useSortRows = (resources, config = null) => {
 			direction = "DESC";
 		}
 		setSortConfig({ key, direction });
+		return direction;
 	};
 
 	return { resources: sortedResources, requestSort, sortConfig };

--- a/modules/admin-ui-picard/app/src/configs/tableConfigs/eventsTableConfig.js
+++ b/modules/admin-ui-picard/app/src/configs/tableConfigs/eventsTableConfig.js
@@ -29,14 +29,14 @@ export const eventsTableConfig = {
 		},
 		{
 			template: "EventsPresentersCell",
-			name: "presenters",
+			name: "presenter",
 			label: "EVENTS.EVENTS.TABLE.PRESENTERS",
 			sortable: true,
 			translate: false,
 		},
 		{
 			template: "EventsSeriesCell",
-			name: "series",
+			name: "series_name",
 			label: "EVENTS.EVENTS.TABLE.SERIES",
 			sortable: true,
 			translate: false,

--- a/modules/admin-ui-picard/app/src/configs/tableConfigs/seriesTableConfig.js
+++ b/modules/admin-ui-picard/app/src/configs/tableConfigs/seriesTableConfig.js
@@ -36,7 +36,7 @@ export const seriesTableConfig = {
 		},
 		{
 			template: "SeriesDateTimeCell",
-			name: "creation_date",
+			name: "createdDateTime",
 			label: "EVENTS.SERIES.TABLE.CREATED",
 			sortable: true,
 		},


### PR DESCRIPTION
includes #39, should only be merged after it.

Partially adresses #57. Pagination should not fail anymore, and previously unsortable columns should now be sortable again.

Fixes various table column names for events and series that have changed over the years. This should make sorting for those columns work again.