### PR TITLE
Change anchors to buttons

### DIFF
--- a/app/src/components/Header.js
+++ b/app/src/components/Header.js
@@ -294,14 +294,14 @@ const MenuLang = () => {
 			{/* one list item for each available language */}
 			{languages.map((language, key) => (
 				<li key={key}>
-					<a onClick={() => changeLanguage(language.code)}>
+					<button className="button-like-anchor" onClick={() => changeLanguage(language.code)}>
 						<img
 							className="lang-flag"
 							src={language.flag}
 							alt={language.code}
 						/>
 						{language.long}
-					</a>
+					</button>
 				</li>
 			))}
 		</ul>
@@ -392,16 +392,16 @@ const MenuHelp = ({
 						</li>
 					)}
 				<li>
-					<a onClick={() => showHotKeys()}>
+					<button className="button-like-anchor" onClick={() => showHotKeys()}>
 						<span>{t("HELP.HOTKEY_CHEAT_SHEET")}</span>
-					</a>
+					</button>
 				</li>
 				{/* Adoter registration Modal */}
 				{hasAccess("ROLE_ADMIN", user) && (
 					<li>
-						<a onClick={() => showAdoptersRegistrationModal()}>
+						<button className="button-like-anchor" onClick={() => showAdoptersRegistrationModal()}>
 							<span>{t("HELP.ADOPTER_REGISTRATION")}</span>
-						</a>
+						</button>
 					</li>
 				)}
 			</ul>
@@ -414,9 +414,9 @@ const MenuUser = () => {
 	return (
 		<ul className="dropdown-ul">
 			<li>
-				<a onClick={() => logout()}>
+				<button className="button-like-anchor" onClick={() => logout()}>
 					<span className="logout-icon">{t("LOGOUT")}</span>
-				</a>
+				</button>
 			</li>
 		</ul>
 	);

--- a/app/src/components/configuration/partials/ThemesActionsCell.js
+++ b/app/src/components/configuration/partials/ThemesActionsCell.js
@@ -49,9 +49,9 @@ const ThemesActionsCell = ({
 		<>
 			{/* edit themes */}
 			{hasAccess("ROLE_UI_THEMES_EDIT", user) && (
-				<a
+				<button
 					onClick={() => showThemeDetails()}
-					className="more"
+					className="button-like-anchor more"
 					title={t("CONFIGURATION.THEMES.TABLE.TOOLTIP.DETAILS")}
 				/>
 			)}
@@ -66,9 +66,9 @@ const ThemesActionsCell = ({
 
 			{/* delete themes */}
 			{hasAccess("ROLE_UI_THEMES_DELETE", user) && (
-				<a
+				<button
 					onClick={() => setDeleteConfirmation(true)}
-					className="remove ng-scope ng-isolate-scope"
+					className="button-like-anchor remove ng-scope ng-isolate-scope"
 					title={t("CONFIGURATION.THEMES.TABLE.TOOLTIP.DELETE")}
 				/>
 			)}

--- a/app/src/components/configuration/partials/wizard/ThemeDetailsModal.js
+++ b/app/src/components/configuration/partials/wizard/ThemeDetailsModal.js
@@ -20,7 +20,7 @@ const ThemeDetailsModal = ({ handleClose, themeId, themeName }) => {
 				className="modal wizard modal-animation"
 			>
 				<header>
-					<a className="fa fa-times close-modal" onClick={() => close()} />
+					<button className="button-like-anchor fa fa-times close-modal" onClick={() => close()} />
 					<h2>
 						{t("CONFIGURATION.THEMES.DETAILS.EDITCAPTION", { name: themeName })}
 					</h2>

--- a/app/src/components/events/Events.js
+++ b/app/src/components/events/Events.js
@@ -272,31 +272,31 @@ const Events = ({
 								<ul className="dropdown-ul">
 									{hasAccess("ROLE_UI_EVENTS_DELETE", user) && (
 										<li>
-											<a onClick={() => setDeleteModal(true)}>
+											<button className="button-like-anchor" onClick={() => setDeleteModal(true)}>
 												{t("BULK_ACTIONS.DELETE.EVENTS.CAPTION")}
-											</a>
+											</button>
 										</li>
 									)}
 									{hasAccess("ROLE_UI_TASKS_CREATE", user) && (
 										<li>
-											<a onClick={() => setStartTaskModal(true)}>
+											<button className="button-like-anchor" onClick={() => setStartTaskModal(true)}>
 												{t("BULK_ACTIONS.SCHEDULE_TASK.CAPTION")}
-											</a>
+											</button>
 										</li>
 									)}
 									{hasAccess("ROLE_UI_EVENTS_DETAILS_SCHEDULING_EDIT", user) &&
 										hasAccess("ROLE_UI_EVENTS_DETAILS_METADATA_EDIT", user) && (
 											<li>
-												<a onClick={() => setEditScheduledEventsModal(true)}>
+												<button className="button-like-anchor" onClick={() => setEditScheduledEventsModal(true)}>
 													{t("BULK_ACTIONS.EDIT_EVENTS.CAPTION")}
-												</a>
+												</button>
 											</li>
 										)}
 									{hasAccess("ROLE_UI_EVENTS_DETAILS_METADATA_EDIT", user) && (
 										<li>
-											<a onClick={() => setEditMetadataEventsModal(true)}>
+											<button className="button-like-anchor" onClick={() => setEditMetadataEventsModal(true)}>
 												{t("BULK_ACTIONS.EDIT_EVENTS_METADATA.CAPTION")}
-											</a>
+											</button>
 										</li>
 									)}
 								</ul>

--- a/app/src/components/events/Series.js
+++ b/app/src/components/events/Series.js
@@ -225,9 +225,9 @@ const Series = ({
 								<ul className="dropdown-ul">
 									{hasAccess("ROLE_UI_SERIES_DELETE", user) && (
 										<li>
-											<a onClick={() => setDeleteSeriesModal(true)}>
+											<button className="button-like-anchor" onClick={() => setDeleteSeriesModal(true)}>
 												{t("BULK_ACTIONS.DELETE.SERIES.CAPTION")}
-											</a>
+											</button>
 										</li>
 									)}
 								</ul>

--- a/app/src/components/events/partials/EventActionCell.js
+++ b/app/src/components/events/partials/EventActionCell.js
@@ -120,18 +120,18 @@ const EventActionCell = ({
 
 			{/* Open event details */}
 			{hasAccess("ROLE_UI_EVENTS_DETAILS_VIEW", user) && (
-				<a
+				<button
 					onClick={() => onClickEventDetails()}
-					className="more"
+					className="button-like-anchor more"
 					title={t("EVENTS.EVENTS.TABLE.TOOLTIP.DETAILS")}
 				/>
 			)}
 
 			{/* If event belongs to a series then the corresponding series details can be opened */}
 			{!!row.series && hasAccess("ROLE_UI_SERIES_DETAILS_VIEW", user) && (
-				<a
+				<button
 					onClick={() => onClickSeriesDetails()}
-					className="more-series"
+					className="button-like-anchor more-series"
 					title={t("EVENTS.SERIES.TABLE.TOOLTIP.DETAILS")}
 				/>
 			)}
@@ -139,9 +139,9 @@ const EventActionCell = ({
 			{/* Delete an event */}
 			{/*TODO: needs to be checked if event is published */}
 			{hasAccess("ROLE_UI_EVENTS_DELETE", user) && (
-				<a
+				<button
 					onClick={() => setDeleteConfirmation(true)}
-					className="remove"
+					className="button-like-anchor remove"
 					title={t("EVENTS.EVENTS.TABLE.TOOLTIP.DELETE")}
 				/>
 			)}
@@ -174,19 +174,19 @@ const EventActionCell = ({
 
 			{/* If the event has comments and no open comments then the comment tab of event details can be opened directly */}
 			{row.has_comments && !row.has_open_comments && (
-				<a
+				<button
 					onClick={() => onClickComments()}
 					title={t("EVENTS.EVENTS.TABLE.TOOLTIP.COMMENTS")}
-					className="comments"
+					className="button-like-anchor comments"
 				/>
 			)}
 
 			{/* If the event has comments and open comments then the comment tab of event details can be opened directly */}
 			{row.has_comments && row.has_open_comments && (
-				<a
+				<button
 					onClick={() => onClickComments()}
 					title={t("EVENTS.EVENTS.TABLE.TOOLTIP.COMMENTS")}
-					className="comments-open"
+					className="button-like-anchor comments-open"
 				/>
 			)}
 
@@ -194,27 +194,27 @@ const EventActionCell = ({
                 details can be opened directly */}
 			{row.workflow_state === "PAUSED" &&
 				hasAccess("ROLE_UI_EVENTS_DETAILS_WORKFLOWS_EDIT", user) && (
-					<a
+					<button
 						title={t("EVENTS.EVENTS.TABLE.TOOLTIP.PAUSED_WORKFLOW")}
 						onClick={() => onClickWorkflow()}
-						className="fa fa-warning"
+						className="button-like-anchor fa fa-warning"
 					/>
 				)}
 
 			{/* Open assets tab of event details directly*/}
 			{hasAccess("ROLE_UI_EVENTS_DETAILS_ASSETS_VIEW", user) && (
-				<a
+				<button
 					onClick={() => onClickAssets()}
 					title={t("EVENTS.EVENTS.TABLE.TOOLTIP.ASSETS")}
-					className="fa fa-folder-open"
+					className="button-like-anchor fa fa-folder-open"
 				/>
 			)}
 			{/* Open dialog for embedded code*/}
 			{hasAccess("ROLE_UI_EVENTS_EMBEDDING_CODE_VIEW", user) && (
-				<a
+				<button
 					onClick={() => showEmbeddingCodeModal()}
 					title={t("EVENTS.EVENTS.TABLE.TOOLTIP.EMBEDDING_CODE")}
-					className="fa fa-link"
+					className="button-like-anchor fa fa-link"
 				/>
 			)}
 

--- a/app/src/components/events/partials/EventsDateCell.js
+++ b/app/src/components/events/partials/EventsDateCell.js
@@ -30,13 +30,13 @@ const EventsDateCell = ({
 
 	return (
 		// Link template for start date of event
-		<a
-			className="crosslink"
+		<button
+			className="button-like-anchor crosslink"
 			title={t("EVENTS.EVENTS.TABLE.TOOLTIP.START")}
 			onClick={() => addFilter(row.date)}
 		>
 			{t("dateFormats.date.short", { date: new Date(row.date) })}
-		</a>
+		</button>
 	);
 };
 

--- a/app/src/components/events/partials/EventsLocationCell.js
+++ b/app/src/components/events/partials/EventsLocationCell.js
@@ -30,13 +30,13 @@ const EventsLocationCell = ({
 
 	return (
 		// Link template for location of event
-		<a
-			className="crosslink"
+		<button
+			className="button-like-anchor crosslink"
 			title={t("EVENTS.EVENTS.TABLE.TOOLTIP.LOCATION")}
 			onClick={() => addFilter(row.location)}
 		>
 			{row.location}
-		</a>
+		</button>
 	);
 };
 

--- a/app/src/components/events/partials/EventsPresentersCell.js
+++ b/app/src/components/events/partials/EventsPresentersCell.js
@@ -34,14 +34,14 @@ const EventsPresentersCell = ({
 		// Link template for presenter of event
 		// Repeat for each presenter
 		row.presenters.map((presenter, key) => (
-			<a
-				className="metadata-entry"
+			<button
+				className="button-like-anchor metadata-entry"
 				key={key}
 				title={t("EVENTS.EVENTS.TABLE.TOOLTIP.PRESENTER")}
 				onClick={() => addFilter(presenter)}
 			>
 				{presenter}
-			</a>
+			</button>
 		))
 	);
 };

--- a/app/src/components/events/partials/EventsSeriesCell.js
+++ b/app/src/components/events/partials/EventsSeriesCell.js
@@ -31,13 +31,13 @@ const EventsSeriesCell = ({
 	return (
 		!!row.series && (
 			// Link template for series of event
-			<a
-				className="crosslink"
+			<button
+				className="button-like-anchor crosslink"
 				title={t("EVENTS.EVENTS.TABLE.TOOLTIP.SERIES")}
 				onClick={() => addFilter(row.series)}
 			>
 				{row.series.title}
-			</a>
+			</button>
 		)
 	);
 };

--- a/app/src/components/events/partials/EventsStatusCell.js
+++ b/app/src/components/events/partials/EventsStatusCell.js
@@ -29,13 +29,13 @@ const EventsStatusCell = ({
 	};
 
 	return (
-		<a
-			className="crosslink"
+		<button
+			className="button-like-anchor crosslink"
 			onClick={() => addFilter(row.event_status)}
 			title={t("EVENTS.EVENTS.TABLE.TOOLTIP.STATUS")}
 		>
 			{t(row.displayable_status)}
-		</a>
+		</button>
 	);
 };
 

--- a/app/src/components/events/partials/EventsTechnicalDateCell.js
+++ b/app/src/components/events/partials/EventsTechnicalDateCell.js
@@ -30,13 +30,13 @@ const EventsTechnicalDateCell = ({
 
 	return (
 		// Link template for technical date of event
-		<a
-			className="crosslink"
+		<button
+			className="button-like-anchor crosslink"
 			title={t("EVENTS.EVENTS.TABLE.TOOLTIP.START")}
 			onClick={() => addFilter()}
 		>
 			{t("dateFormats.date.short", { date: new Date(row.technical_start) })}
-		</a>
+		</button>
 	);
 };
 

--- a/app/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetAttachments.js
+++ b/app/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetAttachments.js
@@ -98,8 +98,8 @@ const EventDetailsAssetAttachments = ({
 														: null}
 												</td>
 												<td>
-													<a
-														className="details-link"
+													<button
+														className="button-like-anchor details-link"
 														onClick={() =>
 															openSubTab("attachment-details", item.id)
 														}
@@ -109,7 +109,7 @@ const EventDetailsAssetAttachments = ({
 																"EVENTS.EVENTS.DETAILS.ASSETS.DETAILS"
 															) /* Details */
 														}
-													</a>
+													</button>
 												</td>
 											</tr>
 										))}

--- a/app/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetCatalogs.js
+++ b/app/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetCatalogs.js
@@ -94,8 +94,8 @@ const EventDetailsAssetCatalogs = ({
 														: null}
 												</td>
 												<td>
-													<a
-														className="details-link"
+													<button
+														className="button-like-anchor details-link"
 														onClick={() =>
 															openSubTab("catalog-details", item.id)
 														}
@@ -105,7 +105,7 @@ const EventDetailsAssetCatalogs = ({
 																"EVENTS.EVENTS.DETAILS.ASSETS.DETAILS"
 															) /* Details */
 														}
-													</a>
+													</button>
 												</td>
 											</tr>
 										))}

--- a/app/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetMedia.js
+++ b/app/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetMedia.js
@@ -84,8 +84,8 @@ const EventDetailsAssetMedia = ({
 														: null}
 												</td>
 												<td>
-													<a
-														className="details-link"
+													<button
+														className="button-like-anchor details-link"
 														onClick={() => openSubTab("media-details", item.id)}
 													>
 														{
@@ -93,7 +93,7 @@ const EventDetailsAssetMedia = ({
 																"EVENTS.EVENTS.DETAILS.ASSETS.DETAILS"
 															) /* Details */
 														}
-													</a>
+													</button>
 												</td>
 											</tr>
 										))}

--- a/app/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetPublications.js
+++ b/app/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetPublications.js
@@ -90,8 +90,8 @@ const EventDetailsAssetPublications = ({
 														: null}
 												</td>
 												<td>
-													<a
-														className="details-link"
+													<button
+														className="button-like-anchor details-link"
 														onClick={() =>
 															openSubTab("publication-details", item.id)
 														}
@@ -101,7 +101,7 @@ const EventDetailsAssetPublications = ({
 																"EVENTS.EVENTS.DETAILS.ASSETS.DETAILS"
 															) /* Details */
 														}
-													</a>
+													</button>
 												</td>
 											</tr>
 										))}

--- a/app/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetsAddAsset.js
+++ b/app/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetsAddAsset.js
@@ -111,8 +111,8 @@ const EventDetailsAssetsAddAsset = ({
 															</td>
 															{/*Button to remove asset*/}
 															<td className="fit">
-																<a
-																	className="remove"
+																<button
+																	className="button-like-anchor remove"
 																	onClick={() => {
 																		formik.setFieldValue(asset.id, null);
 																		document.getElementById(asset.id).value =

--- a/app/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetsTab.js
+++ b/app/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetsTab.js
@@ -103,8 +103,8 @@ const EventDetailsAssetsTab = ({
 														"ROLE_UI_EVENTS_DETAILS_ASSETS_EDIT",
 														user
 													) && (
-														<a
-															className="details-link"
+														<button
+															className="button-like-anchor details-link"
 															onClick={() =>
 																openSubTab(
 																	"add-asset",
@@ -115,7 +115,7 @@ const EventDetailsAssetsTab = ({
 															}
 														>
 															{t("EVENTS.EVENTS.NEW.UPLOAD_ASSET.ADD")}
-														</a>
+														</button>
 													)}
 											</th>
 										</tr>
@@ -132,8 +132,8 @@ const EventDetailsAssetsTab = ({
 											<td>{assets.attachments}</td>
 											<td>
 												{assets.attachments > 0 && (
-													<a
-														className="details-link"
+													<button
+														className="button-like-anchor details-link"
 														onClick={() =>
 															openSubTab("asset-attachments", "attachment")
 														}
@@ -143,7 +143,7 @@ const EventDetailsAssetsTab = ({
 																"EVENTS.EVENTS.DETAILS.ASSETS.DETAILS"
 															) /* Details */
 														}
-													</a>
+													</button>
 												)}
 											</td>
 										</tr>
@@ -158,8 +158,8 @@ const EventDetailsAssetsTab = ({
 											<td>{assets.catalogs}</td>
 											<td>
 												{assets.catalogs > 0 && (
-													<a
-														className="details-link"
+													<button
+														className="button-like-anchor details-link"
 														onClick={() =>
 															openSubTab("asset-catalogs", "catalog")
 														}
@@ -169,7 +169,7 @@ const EventDetailsAssetsTab = ({
 																"EVENTS.EVENTS.DETAILS.ASSETS.DETAILS"
 															) /* Details */
 														}
-													</a>
+													</button>
 												)}
 											</td>
 										</tr>
@@ -184,8 +184,8 @@ const EventDetailsAssetsTab = ({
 											<td>{assets.media}</td>
 											<td>
 												{assets.media > 0 && (
-													<a
-														className="details-link"
+													<button
+														className="button-like-anchor details-link"
 														onClick={() => openSubTab("asset-media", "media")}
 													>
 														{
@@ -193,7 +193,7 @@ const EventDetailsAssetsTab = ({
 																"EVENTS.EVENTS.DETAILS.ASSETS.DETAILS"
 															) /* Details */
 														}
-													</a>
+													</button>
 												)}
 											</td>
 										</tr>
@@ -208,8 +208,8 @@ const EventDetailsAssetsTab = ({
 											<td>{assets.publications}</td>
 											<td>
 												{assets.publications > 0 && (
-													<a
-														className="details-link"
+													<button
+														className="button-like-anchor details-link"
 														onClick={() =>
 															openSubTab("asset-publications", "publication")
 														}
@@ -219,7 +219,7 @@ const EventDetailsAssetsTab = ({
 																"EVENTS.EVENTS.DETAILS.ASSETS.DETAILS"
 															) /* Details */
 														}
-													</a>
+													</button>
 												)}
 											</td>
 										</tr>

--- a/app/src/components/events/partials/ModalTabsAndPages/EventDetailsCommentsTab.js
+++ b/app/src/components/events/partials/ModalTabsAndPages/EventDetailsCommentsTab.js
@@ -147,25 +147,25 @@ const EventDetailsCommentsTab = ({
 												"ROLE_UI_EVENTS_DETAILS_COMMENTS_DELETE",
 												user
 											) && (
-												<a
+												<button
 													onClick={() => deleteComment(comment)}
-													className="delete"
+													className="button-like-anchor delete"
 												>
 													{t("EVENTS.EVENTS.DETAILS.COMMENTS.DELETE")}
-												</a>
+												</button>
 											)}
 											{hasAccess(
 												"ROLE_UI_EVENTS_DETAILS_COMMENTS_REPLY",
 												user
 											) && (
-												<a
+												<button
 													onClick={
 														() => replyTo(comment, key) /* enters reply mode */
 													}
-													className="reply"
+													className="button-like-anchor reply"
 												>
 													{t("EVENTS.EVENTS.DETAILS.COMMENTS.REPLY")}
-												</a>
+												</button>
 											)}
 											<span
 												className="resolve"
@@ -202,15 +202,15 @@ const EventDetailsCommentsTab = ({
 															"ROLE_UI_EVENTS_DETAILS_COMMENTS_DELETE",
 															user
 														) && (
-															<a
+															<button
 																onClick={() =>
 																	deleteReply(comment, reply, replyKey)
 																}
-																className="delete"
+																className="button-like-anchor delete"
 															>
 																<i className="fa fa-times-circle" />
 																{t("EVENTS.EVENTS.DETAILS.COMMENTS.DELETE")}
-															</a>
+															</button>
 														)}
 													</div>
 												))

--- a/app/src/components/events/partials/ModalTabsAndPages/EventDetailsTabHierarchyNavigation.js
+++ b/app/src/components/events/partials/ModalTabsAndPages/EventDetailsTabHierarchyNavigation.js
@@ -24,8 +24,8 @@ const EventDetailsTabHierarchyNavigation = ({
 	/* Hierarchy navigation */
 	return (
 		<nav className="scope" style={style_nav}>
-			<a
-				className="breadcrumb-link scope"
+			<button
+				className="button-like-anchor breadcrumb-link scope"
 				style={
 					hierarchyDepth === 0
 						? style_nav_hierarchy
@@ -37,10 +37,10 @@ const EventDetailsTabHierarchyNavigation = ({
 				{hierarchyDepth > 0 && (
 					<span style={style_nav_hierarchy_inactive}> > </span>
 				)}
-			</a>
+			</button>
 			{hierarchyDepth > 0 && (
-				<a
-					className="breadcrumb-link scope"
+				<button
+					className="button-like-anchor breadcrumb-link scope"
 					style={
 						hierarchyDepth === 1
 							? style_nav_hierarchy
@@ -52,16 +52,16 @@ const EventDetailsTabHierarchyNavigation = ({
 					{hierarchyDepth > 1 && (
 						<span style={style_nav_hierarchy_inactive}> > </span>
 					)}
-				</a>
+				</button>
 			)}
 			{hierarchyDepth > 1 && (
-				<a
-					className="breadcrumb-link scope"
+				<button
+					className="button-like-anchor breadcrumb-link scope"
 					style={style_nav_hierarchy}
 					onClick={() => openSubTab(subTabArgument2)}
 				>
 					{t(translationKey2)}
-				</a>
+				</button>
 			)}
 		</nav>
 	);

--- a/app/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowDetails.js
+++ b/app/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowDetails.js
@@ -217,8 +217,8 @@ const EventDetailsWorkflowDetails = ({
 													) /* Operations */
 												}
 											</span>
-											<a
-												className="details-link"
+											<button
+												className="button-like-anchor details-link"
 												onClick={() => openSubTab("workflow-operations")}
 											>
 												{
@@ -226,7 +226,7 @@ const EventDetailsWorkflowDetails = ({
 														"EVENTS.EVENTS.DETAILS.WORKFLOWS.DETAILS"
 													) /* Details */
 												}
-											</a>
+											</button>
 										</li>
 										<li>
 											<span>
@@ -236,8 +236,8 @@ const EventDetailsWorkflowDetails = ({
 													) /* Errors & Warnings */
 												}
 											</span>
-											<a
-												className="details-link"
+											<button
+												className="button-like-anchor details-link"
 												onClick={() => openSubTab("errors-and-warnings")}
 											>
 												{
@@ -245,7 +245,7 @@ const EventDetailsWorkflowDetails = ({
 														"EVENTS.EVENTS.DETAILS.WORKFLOWS.DETAILS"
 													) /* Details */
 												}
-											</a>
+											</button>
 										</li>
 									</ul>
 								</div>
@@ -313,13 +313,13 @@ const EventDetailsWorkflowDetails = ({
 													) /* Operations */
 												}
 											</span>
-											<a className="details-link">
+											<button className="button-like-anchor details-link">
 												{
 													t(
 														"EVENTS.EVENTS.DETAILS.WORKFLOWS.DETAILS"
 													) /* Details */
 												}
-											</a>
+											</button>
 										</li>
 										<li>
 											<span>
@@ -329,13 +329,13 @@ const EventDetailsWorkflowDetails = ({
 													) /* Errors & Warnings */
 												}
 											</span>
-											<a className="details-link">
+											<button className="button-like-anchor details-link">
 												{
 													t(
 														"EVENTS.EVENTS.DETAILS.WORKFLOWS.DETAILS"
 													) /* Details */
 												}
-											</a>
+											</button>
 										</li>
 									</ul>
 								</div>

--- a/app/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowErrors.js
+++ b/app/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowErrors.js
@@ -119,8 +119,8 @@ const EventDetailsWorkflowErrors = ({
 
 														{/* link to 'Error Details'  sub-Tab */}
 														<td>
-															<a
-																className="details-link"
+															<button
+																className="button-like-anchor details-link"
 																onClick={() =>
 																	openSubTab("workflow-error-details", item.id)
 																}
@@ -130,7 +130,7 @@ const EventDetailsWorkflowErrors = ({
 																		"EVENTS.EVENTS.DETAILS.MEDIA.DETAILS"
 																	) /*  Details */
 																}
-															</a>
+															</button>
 														</td>
 													</tr>
 												))

--- a/app/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowOperations.js
+++ b/app/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowOperations.js
@@ -98,8 +98,8 @@ const EventDetailsWorkflowOperations = ({
 
 													{/* link to 'Operation Details'  sub-Tab */}
 													<td>
-														<a
-															className="details-link"
+														<button
+															className="button-like-anchor details-link"
 															onClick={() =>
 																openSubTab("workflow-operation-details", key)
 															}
@@ -109,7 +109,7 @@ const EventDetailsWorkflowOperations = ({
 																	"EVENTS.EVENTS.DETAILS.MEDIA.DETAILS"
 																) /* Details */
 															}
-														</a>
+														</button>
 													</td>
 												</tr>
 											))}

--- a/app/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowTab.js
+++ b/app/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowTab.js
@@ -209,46 +209,46 @@ const EventDetailsWorkflowTab = ({
 																<td>
 																	{item.status ===
 																		"EVENTS.EVENTS.DETAILS.WORKFLOWS.OPERATION_STATUS.RUNNING" && (
-																		<a
+																		<button
 																			onClick={() =>
 																				workflowAction(item.id, "STOP")
 																			}
-																			className="stop fa-fw"
+																			className="button-like-anchor stop fa-fw"
 																			title={t(
 																				"EVENTS.EVENTS.DETAILS.WORKFLOWS.TOOLTIP.STOP"
 																			)}
 																		>
 																			{/* STOP */}
-																		</a>
+																		</button>
 																	)}
 																	{item.status ===
 																		"EVENTS.EVENTS.DETAILS.WORKFLOWS.OPERATION_STATUS.PAUSED" && (
-																		<a
+																		<button
 																			onClick={() =>
 																				workflowAction(item.id, "NONE")
 																			}
-																			className="fa fa-hand-stop-o fa-fw"
+																			className="button-like-anchor fa fa-hand-stop-o fa-fw"
 																			style={{ color: "red" }}
 																			title={t(
 																				"EVENTS.EVENTS.DETAILS.WORKFLOWS.TOOLTIP.ABORT"
 																			)}
 																		>
 																			{/* Abort */}
-																		</a>
+																		</button>
 																	)}
 																	{item.status ===
 																		"EVENTS.EVENTS.DETAILS.WORKFLOWS.OPERATION_STATUS.PAUSED" && (
-																		<a
+																		<button
 																			onClick={() =>
 																				workflowAction(item.id, "RETRY")
 																			}
-																			className="fa fa-refresh fa-fw"
+																			className="button-like-anchor fa fa-refresh fa-fw"
 																			title={t(
 																				"EVENTS.EVENTS.DETAILS.WORKFLOWS.TOOLTIP.RETRY"
 																			)}
 																		>
 																			{/* Retry */}
-																		</a>
+																		</button>
 																	)}
 																	{(item.status ===
 																		"EVENTS.EVENTS.DETAILS.WORKFLOWS.OPERATION_STATUS.SUCCEEDED" ||
@@ -258,21 +258,21 @@ const EventDetailsWorkflowTab = ({
 																			"EVENTS.EVENTS.DETAILS.WORKFLOWS.OPERATION_STATUS.STOPPED") &&
 																		!isCurrentWorkflow(item.id) &&
 																		isRoleWorkflowDelete && (
-																			<a
+																			<button
 																				onClick={() => deleteWorkflow(item.id)}
-																				className="remove fa-fw"
+																				className="button-like-anchor remove fa-fw"
 																				title={t(
 																					"EVENTS.EVENTS.DETAILS.WORKFLOWS.TOOLTIP.DELETE"
 																				)}
 																			>
 																				{/* DELETE */}
-																			</a>
+																			</button>
 																		)}
 																</td>
 															)}
 															<td>
-																<a
-																	className="details-link"
+																<button
+																	className="button-like-anchor details-link"
 																	onClick={() =>
 																		openSubTab("workflow-details", item.id)
 																	}
@@ -282,7 +282,7 @@ const EventDetailsWorkflowTab = ({
 																			"EVENTS.EVENTS.DETAILS.MEDIA.DETAILS"
 																		) /* Details */
 																	}
-																</a>
+																</button>
 															</td>
 														</tr>
 													))}

--- a/app/src/components/events/partials/ModalTabsAndPages/NewAccessPage.js
+++ b/app/src/components/events/partials/ModalTabsAndPages/NewAccessPage.js
@@ -246,9 +246,9 @@ const NewAccessPage = ({
 																						)}
 																						{/*Remove policy*/}
 																						<td>
-																							<a
+																							<button
 																								onClick={() => remove(index)}
-																								className="remove"
+																								className="button-like-anchor remove"
 																							/>
 																						</td>
 																					</tr>
@@ -269,7 +269,7 @@ const NewAccessPage = ({
 																			<tr>
 																				{/*Add additional policy row*/}
 																				<td colSpan="5">
-																					<a
+																					<button
 																						onClick={() => {
 																							push({
 																								role: "",
@@ -279,12 +279,13 @@ const NewAccessPage = ({
 																							});
 																							checkAcls(formik.values.acls);
 																						}}
+                                            className="button-like-anchor"
 																					>
 																						+{" "}
 																						{t(
 																							"EVENTS.SERIES.NEW.ACCESS.ACCESS_POLICY.NEW"
 																						)}
-																					</a>
+																					</button>
 																				</td>
 																			</tr>
 																		)}

--- a/app/src/components/events/partials/ModalTabsAndPages/NewAssetUploadPage.js
+++ b/app/src/components/events/partials/ModalTabsAndPages/NewAssetUploadPage.js
@@ -82,8 +82,8 @@ const NewAssetUploadPage = ({
 													</td>
 													{/*Button to remove asset*/}
 													<td className="fit">
-														<a
-															className="remove"
+														<button
+															className="button-like-anchor remove"
 															onClick={() => {
 																formik.setFieldValue(asset.id, null);
 																document.getElementById(asset.id).value = "";

--- a/app/src/components/events/partials/ModalTabsAndPages/NewSourcePage.js
+++ b/app/src/components/events/partials/ModalTabsAndPages/NewSourcePage.js
@@ -292,8 +292,8 @@ const Upload = ({ formik }) => {
 												</div>
 											</td>
 											<td className="fit">
-												<a
-													className="remove"
+												<button
+													className="button-like-anchor remove"
 													onClick={() => {
 														formik.setFieldValue(
 															`uploadAssetsTrack.${key}.file`,

--- a/app/src/components/events/partials/PublishedCell.js
+++ b/app/src/components/events/partials/PublishedCell.js
@@ -36,9 +36,9 @@ const PublishCell = ({ row }) => {
 		<div className="popover-wrapper" ref={containerPublications}>
 			{row.publications.length ? (
 				<>
-					<a className="popover-wrapper__trigger">
+					<button className="button-like-anchor popover-wrapper__trigger">
 						<span onClick={() => setShowPopup(!showPopup)}>{t("YES")}</span>
-					</a>
+					</button>
 					{showPopup && (
 						<div className="js-popover popover">
 							<div className="popover__header" />
@@ -58,9 +58,9 @@ const PublishCell = ({ row }) => {
 												<span>{t(publication.name)}</span>
 											</a>
 										) : (
-											<a key={key} className="popover__list-item">
+											<button key={key} className="button-like-anchor popover__list-item">
 												<span>{t(publication.name)}</span>
-											</a>
+											</button>
 										)
 									) : null
 								)}

--- a/app/src/components/events/partials/SeriesActionsCell.js
+++ b/app/src/components/events/partials/SeriesActionsCell.js
@@ -74,9 +74,9 @@ const SeriesActionsCell = ({
 		<>
 			{/* series details */}
 			{hasAccess("ROLE_UI_SERIES_DETAILS_VIEW", user) && (
-				<a
+				<button
 					onClick={() => showSeriesDetailsModal()}
-					className="more-series"
+					className="button-like-anchor more-series"
 					title={t("EVENTS.SERIES.TABLE.TOOLTIP.DETAILS")}
 				/>
 			)}
@@ -91,9 +91,9 @@ const SeriesActionsCell = ({
 
 			{/* delete series */}
 			{hasAccess("ROLE_UI_SERIES_DELETE", user) && (
-				<a
+				<button
 					onClick={() => showDeleteConfirmation()}
-					className="remove"
+					className="button-like-anchor remove"
 					title={t("EVENTS.SERIES.TABLE.TOOLTIP.DELETE")}
 				/>
 			)}

--- a/app/src/components/events/partials/modals/DeleteEventsModal.js
+++ b/app/src/components/events/partials/modals/DeleteEventsModal.js
@@ -63,7 +63,7 @@ const DeleteEventsModal = ({ close, selectedRows, deleteMultipleEvent }) => {
 				style={{ display: "block" }}
 			>
 				<header>
-					<a onClick={close} className="fa fa-times close-modal" />
+					<button onClick={close} className="button-like-anchor fa fa-times close-modal" />
 					<h2>{t("BULK_ACTIONS.DELETE.EVENTS.CAPTION")}</h2>
 				</header>
 

--- a/app/src/components/events/partials/modals/DeleteSeriesModal.js
+++ b/app/src/components/events/partials/modals/DeleteSeriesModal.js
@@ -110,7 +110,7 @@ const DeleteSeriesModal = ({ close, selectedRows, deleteMultipleSeries }) => {
 				style={{ display: "block" }}
 			>
 				<header>
-					<a onClick={() => close()} className="fa fa-times close-modal" />
+					<button onClick={() => close()} className="button-like-anchor fa fa-times close-modal" />
 					<h2>{t("BULK_ACTIONS.DELETE.SERIES.CAPTION")}</h2>
 				</header>
 

--- a/app/src/components/events/partials/modals/EditMetadataEventsModal.js
+++ b/app/src/components/events/partials/modals/EditMetadataEventsModal.js
@@ -118,7 +118,7 @@ const EditMetadataEventsModal = ({
 			<div className="modal-animation modal-overlay" />
 			<section className="modal wizard modal-animation">
 				<header>
-					<a className="fa fa-times close-modal" onClick={() => close()} />
+					<button className="button-like-anchor fa fa-times close-modal" onClick={() => close()} />
 					<h2>{t("BULK_ACTIONS.EDIT_EVENTS_METADATA.CAPTION")}</h2>
 				</header>
 

--- a/app/src/components/events/partials/modals/EditScheduledEventsModal.js
+++ b/app/src/components/events/partials/modals/EditScheduledEventsModal.js
@@ -110,7 +110,7 @@ const EditScheduledEventsModal = ({
 			<div className="modal-animation modal-overlay" />
 			<section className="modal wizard modal-animation">
 				<header>
-					<a className="fa fa-times close-modal" onClick={() => close()} />
+					<button className="button-like-anchor fa fa-times close-modal" onClick={() => close()} />
 					<h2>{t("BULK_ACTIONS.EDIT_EVENTS.CAPTION")}</h2>
 				</header>
 

--- a/app/src/components/events/partials/modals/EmbeddingCodeModal.js
+++ b/app/src/components/events/partials/modals/EmbeddingCodeModal.js
@@ -77,8 +77,8 @@ const EmbeddingCodeModal = ({ close, eventId }) => {
 			<div className="modal-animation modal-overlay" />
 			<section className="modal modal-animation" id="embedding-code">
 				<header>
-					<a
-						className="fa fa-times close-modal"
+					<button
+						className="button-like-anchor fa fa-times close-modal"
 						onClick={() => handleClose()}
 					/>
 					<h2>{t("CONFIRMATIONS.ACTIONS.SHOW.EMBEDDING_CODE")}</h2>

--- a/app/src/components/events/partials/modals/EventDetails.js
+++ b/app/src/components/events/partials/modals/EventDetails.js
@@ -159,50 +159,50 @@ const EventDetails = ({
 		<>
 			<nav className="modal-nav" id="modal-nav">
 				{hasAccess(tabs[0].accessRole, user) && (
-					<a className={cn({ active: page === 0 })} onClick={() => openTab(0)}>
+					<button className={"button-like-anchor " + cn({ active: page === 0 })} onClick={() => openTab(0)}>
 						{t(tabs[0].tabNameTranslation)}
-					</a>
+					</button>
 				)}
 				{!tabs[1].hidden && hasAccess(tabs[1].accessRole, user) && (
-					<a className={cn({ active: page === 1 })} onClick={() => openTab(1)}>
+					<button className={"button-like-anchor " + cn({ active: page === 1 })} onClick={() => openTab(1)}>
 						{t(tabs[1].tabNameTranslation)}
-					</a>
+					</button>
 				)}
 				{hasAccess(tabs[2].accessRole, user) && (
-					<a className={cn({ active: page === 2 })} onClick={() => openTab(2)}>
+					<button className={"button-like-anchor " + cn({ active: page === 2 })} onClick={() => openTab(2)}>
 						{t(tabs[2].tabNameTranslation)}
-					</a>
+					</button>
 				)}
 				{hasAccess(tabs[3].accessRole, user) && (
-					<a className={cn({ active: page === 3 })} onClick={() => openTab(3)}>
+					<button className={"button-like-anchor " + cn({ active: page === 3 })} onClick={() => openTab(3)}>
 						{t(tabs[3].tabNameTranslation)}
-					</a>
+					</button>
 				)}
 				{!tabs[4].hidden && hasAccess(tabs[4].accessRole, user) && (
-					<a className={cn({ active: page === 4 })} onClick={() => openTab(4)}>
+					<button className={"button-like-anchor " + cn({ active: page === 4 })} onClick={() => openTab(4)}>
 						{t(tabs[4].tabNameTranslation)}
-					</a>
+					</button>
 				)}
 				{hasAccess(tabs[5].accessRole, user) && (
-					<a className={cn({ active: page === 5 })} onClick={() => openTab(5)}>
+					<button className={"button-like-anchor " + cn({ active: page === 5 })} onClick={() => openTab(5)}>
 						{t(tabs[5].tabNameTranslation)}
-					</a>
+					</button>
 				)}
 				{hasAccess(tabs[6].accessRole, user) && (
-					<a className={cn({ active: page === 6 })} onClick={() => openTab(6)}>
+					<button className={"button-like-anchor " + cn({ active: page === 6 })} onClick={() => openTab(6)}>
 						{t(tabs[6].tabNameTranslation)}
-					</a>
+					</button>
 				)}
 				{hasAccess(tabs[7].accessRole, user) && (
-					<a className={cn({ active: page === 7 })} onClick={() => openTab(7)}>
+					<button className={"button-like-anchor " + cn({ active: page === 7 })} onClick={() => openTab(7)}>
 						{t(tabs[7].tabNameTranslation)}
-					</a>
+					</button>
 				)}
 
 				{!tabs[8].hidden && hasAccess(tabs[8].accessRole, user) && (
-					<a className={cn({ active: page === 8 })} onClick={() => openTab(8)}>
+					<button className={"button-like-anchor " + cn({ active: page === 8 })} onClick={() => openTab(8)}>
 						{t(tabs[8].tabNameTranslation)}
-					</a>
+					</button>
 				)}
 			</nav>
 			{/* Initialize overall modal */}

--- a/app/src/components/events/partials/modals/EventDetailsModal.js
+++ b/app/src/components/events/partials/modals/EventDetailsModal.js
@@ -41,7 +41,7 @@ const EventDetailsModal = ({
 					className="modal wizard modal-animation"
 				>
 					<header>
-						<a className="fa fa-times close-modal" onClick={() => close()} />
+						<button className="button-like-anchor fa fa-times close-modal" onClick={() => close()} />
 						<h2>
 							{
 								t("EVENTS.EVENTS.DETAILS.HEADER", {

--- a/app/src/components/events/partials/modals/SeriesDetails.js
+++ b/app/src/components/events/partials/modals/SeriesDetails.js
@@ -95,34 +95,34 @@ const SeriesDetails = ({
 			{/* navigation for navigating between tabs */}
 			<nav className="modal-nav" id="modal-nav">
 				{hasAccess(tabs[0].accessRole, user) && (
-					<a className={cn({ active: page === 0 })} onClick={() => openTab(0)}>
+					<button className={"button-like-anchor " + cn({ active: page === 0 })} onClick={() => openTab(0)}>
 						{t(tabs[0].tabNameTranslation)}
-					</a>
+					</button>
 				)}
 				{!tabs[1].hidden && hasAccess(tabs[1].accessRole, user) && (
-					<a className={cn({ active: page === 1 })} onClick={() => openTab(1)}>
+					<button className={"button-like-anchor " + cn({ active: page === 1 })} onClick={() => openTab(1)}>
 						{t(tabs[1].tabNameTranslation)}
-					</a>
+					</button>
 				)}
 				{hasAccess(tabs[2].accessRole, user) && (
-					<a className={cn({ active: page === 2 })} onClick={() => openTab(2)}>
+					<button className={"button-like-anchor " + cn({ active: page === 2 })} onClick={() => openTab(2)}>
 						{t(tabs[2].tabNameTranslation)}
-					</a>
+					</button>
 				)}
 				{hasAccess(tabs[3].accessRole, user) && (
-					<a className={cn({ active: page === 3 })} onClick={() => openTab(3)}>
+					<button className={"button-like-anchor " + cn({ active: page === 3 })} onClick={() => openTab(3)}>
 						{t(tabs[3].tabNameTranslation)}
-					</a>
+					</button>
 				)}
 				{!tabs[4].hidden && hasAccess(tabs[4].accessRole, user) && (
-					<a className={cn({ active: page === 4 })} onClick={() => openTab(4)}>
+					<button className={"button-like-anchor " + cn({ active: page === 4 })} onClick={() => openTab(4)}>
 						{t(tabs[4].tabNameTranslation)}
-					</a>
+					</button>
 				)}
 				{feeds.length > 0 && (
-					<a className={cn({ active: page === 5 })} onClick={() => openTab(5)}>
+					<button className={"button-like-anchor " + cn({ active: page === 5 })} onClick={() => openTab(5)}>
 						{t(tabs[5].tabNameTranslation)}
-					</a>
+					</button>
 				)}
 			</nav>
 

--- a/app/src/components/events/partials/modals/SeriesDetailsModal.js
+++ b/app/src/components/events/partials/modals/SeriesDetailsModal.js
@@ -28,7 +28,7 @@ const SeriesDetailsModal = ({ handleClose, seriesTitle, seriesId }) => {
 			<div className="modal-animation modal-overlay" />
 			<section className="modal modal-animation" id="series-details-modal">
 				<header>
-					<a className="fa fa-times close-modal" onClick={() => close()} />
+					<button className="button-like-anchor fa fa-times close-modal" onClick={() => close()} />
 					<h2>
 						{t("EVENTS.SERIES.DETAILS.HEADER", { resourceId: seriesTitle })}
 					</h2>

--- a/app/src/components/events/partials/modals/StartTaskModal.js
+++ b/app/src/components/events/partials/modals/StartTaskModal.js
@@ -72,7 +72,7 @@ const StartTaskModal = ({ close, postTasks }) => {
 			<div className="modal-animation modal-overlay" />
 			<section className="modal wizard modal-animation">
 				<header>
-					<a className="fa fa-times close-modal" onClick={() => close()} />
+					<button className="button-like-anchor fa fa-times close-modal" onClick={() => close()} />
 					<h2>{t("BULK_ACTIONS.SCHEDULE_TASK.CAPTION")}</h2>
 				</header>
 

--- a/app/src/components/recordings/partials/RecordingsActionCell.js
+++ b/app/src/components/recordings/partials/RecordingsActionCell.js
@@ -44,8 +44,8 @@ const RecordingsActionCell = ({
 		<>
 			{/* view details location/recording */}
 			{hasAccess("ROLE_UI_LOCATIONS_DETAILS_VIEW", user) && (
-				<a
-					className="more"
+				<button
+					className="button-like-anchor more"
 					title={t("RECORDINGS.RECORDINGS.TABLE.TOOLTIP.DETAILS")}
 					onClick={() => showRecordingDetails()}
 				/>
@@ -60,8 +60,8 @@ const RecordingsActionCell = ({
 
 			{/* delete location/recording */}
 			{hasAccess("ROLE_UI_LOCATIONS_DELETE", user) && (
-				<a
-					className="remove"
+				<button
+					className="button-like-anchor remove"
 					title={t("RECORDINGS.RECORDINGS.TABLE.TOOLTIP.DELETE")}
 					onClick={() => setDeleteConfirmation(true)}
 				/>

--- a/app/src/components/recordings/partials/modal/RecordingDetailsModal.js
+++ b/app/src/components/recordings/partials/modal/RecordingDetailsModal.js
@@ -21,8 +21,8 @@ const RecordingDetailsModal = ({ close, recordingId }) => {
 				className="modal wizard modal-animation"
 			>
 				<header>
-					<a
-						className="fa fa-times close-modal"
+					<button
+						className="button-like-anchor fa fa-times close-modal"
 						onClick={() => handleClose()}
 					/>
 					<h2>

--- a/app/src/components/shared/ConfirmModal.js
+++ b/app/src/components/shared/ConfirmModal.js
@@ -32,8 +32,8 @@ const ConfirmModal = ({
 				style={{ fontSize: "14px" }}
 			>
 				<header>
-					<a
-						className="fa fa-times close-modal"
+					<button
+						className="button-like-anchor fa fa-times close-modal"
 						onClick={() => handleClose()}
 					/>
 					<h2>{t("CONFIRMATIONS.ACTIONS.CONFIRMATION")}</h2>

--- a/app/src/components/shared/EditTableViewModal.js
+++ b/app/src/components/shared/EditTableViewModal.js
@@ -81,8 +81,8 @@ const EditTableViewModal = ({
 						id="edit-table-view-modal"
 					>
 						<header>
-							<a
-								className="fa fa-times close-modal"
+							<button
+								className="button-like-anchor fa fa-times close-modal"
 								onClick={() => {
 									clearData();
 									close();
@@ -120,8 +120,8 @@ const EditTableViewModal = ({
 													column ? (
 														<li className="drag-item" key={key}>
 															<div className="title">{t(column.label)}</div>
-															<a
-																className="move-item add"
+															<button
+																className="button-like-anchor move-item add"
 																onClick={() => changeColumn(column, false)}
 															/>
 														</li>
@@ -156,8 +156,8 @@ const EditTableViewModal = ({
 																		<div className="title">
 																			{t(column.label)}
 																		</div>
-																		<a
-																			className="move-item remove"
+																		<button
+																			className="button-like-anchor move-item remove"
 																			onClick={() => changeColumn(column, true)}
 																		/>
 																	</div>

--- a/app/src/components/shared/HotKeyCheatSheet.js
+++ b/app/src/components/shared/HotKeyCheatSheet.js
@@ -17,8 +17,8 @@ const HotKeyCheatSheet = ({ close }) => {
 			<div className="modal-animation modal-overlay" />
 			<div className="modal modal-animation">
 				<header>
-					<a
-						className="fa fa-times close-modal"
+					<button
+						className="button-like-anchor fa fa-times close-modal"
 						onClick={() => handleClose()}
 					/>
 					<h2>{t("HOTKEYS.CHEAT_SHEET.TITLE")}</h2>

--- a/app/src/components/shared/NewResourceModal.js
+++ b/app/src/components/shared/NewResourceModal.js
@@ -28,7 +28,10 @@ const NewResourceModal = ({ handleClose, showModal, resource }) => {
 					id="add-event-modal"
 				>
 					<header>
-						<a className="fa fa-times close-modal" onClick={() => close()} />
+						<button
+              className="button-like-anchor fa fa-times close-modal"
+              onClick={() => close()}
+            />
 						{resource === "events" && <h2>{t("EVENTS.EVENTS.NEW.CAPTION")}</h2>}
 						{resource === "series" && <h2>{t("EVENTS.SERIES.NEW.CAPTION")}</h2>}
 						{resource === "themes" && (

--- a/app/src/components/shared/Notifications.js
+++ b/app/src/components/shared/Notifications.js
@@ -30,9 +30,9 @@ const Notifications = ({
 	const renderNotification = (notification, key) => (
 		<li key={key}>
 			<div className={cn(notification.type, "alert sticky")}>
-				<a
+				<button
 					onClick={() => closeNotification(notification.id)}
-					className="fa fa-times close"
+					className="button-like-anchor fa fa-times close"
 				/>
 				<p>{t(notification.message)}</p>
 			</div>

--- a/app/src/components/shared/RegistrationModal.js
+++ b/app/src/components/shared/RegistrationModal.js
@@ -88,9 +88,9 @@ const RegistrationModal = ({ close }) => {
 				className="modal active modal-open modal-animation"
 			>
 				<header>
-					<a
+					<button
 						onClick={() => handleClose()}
-						className="fa fa-times close-modal"
+						className="button-like-anchor fa fa-times close-modal"
 					/>
 					<h2>{t("ADOPTER_REGISTRATION.MODAL.CAPTION")}</h2>
 				</header>

--- a/app/src/components/shared/Table.js
+++ b/app/src/components/shared/Table.js
@@ -159,7 +159,12 @@ const Table = ({
 			<div className="action-bar">
 				<ul>
 					<li>
-						<a onClick={() => showEditTableViewModal()}>{t("TABLE_EDIT")}</a>
+						<button
+              onClick={() => showEditTableViewModal()}
+              className="button-like-anchor"
+            >
+                {t("TABLE_EDIT")}
+            </button>
 					</li>
 				</ul>
 			</div>
@@ -286,7 +291,12 @@ const Table = ({
 						<ul className="dropdown-ul">
 							{sizeOptions.map((size, key) => (
 								<li key={key}>
-									<a onClick={() => changePageSize(size)}>{size}</a>
+									<button
+                    onClick={() => changePageSize(size)}
+                    className="button-like-anchor"
+                  >
+                    {size}
+                  </button>
 								</li>
 							))}
 						</ul>
@@ -295,24 +305,24 @@ const Table = ({
 
 				{/* Pagination and navigation trough pages */}
 				<div className="pagination">
-					<a
-						className={cn("prev", { disabled: !isNavigatePrevious() })}
+					<button
+						className={"button-like-anchor " + cn("prev", { disabled: !isNavigatePrevious() })}
 						onClick={() => goToPage(pageOffset - 1)}
 					/>
 					{directAccessible.map((page, key) =>
 						page.active ? (
-							<a key={key} className="active">
+							<button key={key} className="button-like-anchor active">
 								{page.label}
-							</a>
+							</button>
 						) : (
-							<a key={key} onClick={() => goToPage(page.number)}>
+							<button key={key} className="button-like-anchor" onClick={() => goToPage(page.number)}>
 								{page.label}
-							</a>
+							</button>
 						)
 					)}
 
-					<a
-						className={cn("next", { disabled: !isNavigateNext() })}
+					<button
+						className={"button-like-anchor " + cn("next", { disabled: !isNavigateNext() })}
 						onClick={() => goToPage(pageOffset + 1)}
 					/>
 				</div>

--- a/app/src/components/shared/TableFilterProfiles.js
+++ b/app/src/components/shared/TableFilterProfiles.js
@@ -123,8 +123,8 @@ const TableFiltersProfiles = ({
 						// if settingsMode is true the list with all saved profiles is shown
 						<div className="filters-list">
 							<header>
-								<a
-									className="icon close"
+								<button
+									className="button-like-anchor icon close"
 									onClick={() => setFilterSettings(!showFilterSettings)}
 								/>
 								<h4>{t("TABLE_FILTERS.PROFILES.FILTERS_HEADER")}</h4>
@@ -137,23 +137,24 @@ const TableFiltersProfiles = ({
 									// repeat for each profile in profiles filtered for currently shown resource (else-case)
 									currentProfiles.map((profile, key) => (
 										<li key={key}>
-											<a
+											<button
 												title="profile.description"
 												onClick={() => chooseFilterProfile(profile.filterMap)}
+                        className="button-like-anchor"
 											>
 												{profile.name.substr(0, 70)}
-											</a>
+											</button>
 											{/* Settings icon to edit profile */}
-											<a
+											<button
 												onClick={() => editFilterProfile(profile)}
 												title={t("TABLE_FILTERS.PROFILES.EDIT")}
-												className="icon edit"
+												className="button-like-anchor icon edit"
 											/>
 											{/* Remove icon to remove profile */}
-											<a
+											<button
 												onClick={() => removeFilterProfile(profile)}
 												title={t("TABLE_FILTERS.PROFILES.REMOVE")}
-												className="icon remove"
+												className="button-like-anchor icon remove"
 											/>
 										</li>
 									))
@@ -164,12 +165,12 @@ const TableFiltersProfiles = ({
 							{/* settingsMode is switched and save dialog is opened*/}
 							<div className="input-container">
 								<div className="btn-container">
-									<a
-										className="save"
+									<button
+										className="button-like-anchor save"
 										onClick={() => setSettingsMode(!settingsMode)}
 									>
 										{t("TABLE_FILTERS.PROFILES.SAVE_FILTERS").substr(0, 70)}
-									</a>
+									</button>
 								</div>
 							</div>
 						</div>
@@ -177,8 +178,8 @@ const TableFiltersProfiles = ({
 						// if settingsMode is false then show editing dialog of selected filter profile
 						<div className="filter-details">
 							<header>
-								<a
-									className="icon close"
+								<button
+									className="button-like-anchor icon close"
 									onClick={() => {
 										setFilterSettings(!showFilterSettings);
 										setSettingsMode(true);
@@ -216,15 +217,15 @@ const TableFiltersProfiles = ({
 							<div className="input-container">
 								{/* Buttons for saving and canceling editing */}
 								<div className="btn-container">
-									<a onClick={cancelEditProfile} className="cancel">
+									<button onClick={cancelEditProfile} className="button-like-anchor cancel">
 										{t("CANCEL")}
-									</a>
-									<a
+									</button>
+									<button
 										onClick={saveProfile}
-										className={cn("save", { disabled: !validName })}
+										className={"button-like-anchor " + cn("save", { disabled: !validName })}
 									>
 										{t("SAVE")}
-									</a>
+									</button>
 								</div>
 							</div>
 						</div>

--- a/app/src/components/shared/TableFilters.js
+++ b/app/src/components/shared/TableFilters.js
@@ -259,12 +259,13 @@ const TableFilters = ({
 												}
 											</span>
 											{/* Remove icon in blue area around filter */}
-											<a
+											<button
 												title={t("TABLE_FILTERS.REMOVE")}
 												onClick={() => removeFilter(filter)}
+                        className="button-like-anchor"
 											>
 												<i className="fa fa-times" />
-											</a>
+											</button>
 										</span>
 									);
 								}

--- a/app/src/components/shared/modals/ModalNavigation.js
+++ b/app/src/components/shared/modals/ModalNavigation.js
@@ -16,13 +16,13 @@ const ModalNavigation = ({ tabInformation, page, openTab, user }) => {
 			{tabInformation.map(
 				(tab, key) =>
 					hasAccess(tab.accessRole, user) && (
-						<a
+						<button
 							key={key}
-							className={cn({ active: page === key })}
+							className={"button-like-anchor " + cn({ active: page === key })}
 							onClick={() => openTab(key)}
 						>
 							{t(tab.tabTranslation)}
-						</a>
+						</button>
 					)
 			)}
 		</nav>

--- a/app/src/components/shared/modals/ResourceDetailsAccessPolicyTab.js
+++ b/app/src/components/shared/modals/ResourceDetailsAccessPolicyTab.js
@@ -537,11 +537,11 @@ const ResourceDetailsAccessPolicyTab = ({
 																							) && (
 																								<td>
 																									{!transactions.read_only && (
-																										<a
+																										<button
 																											onClick={() =>
 																												remove(index)
 																											}
-																											className="remove"
+																											className="button-like-anchor remove"
 																										/>
 																									)}
 																								</td>
@@ -555,16 +555,17 @@ const ResourceDetailsAccessPolicyTab = ({
 																				hasAccess(editAccessRole, user) && (
 																					<tr>
 																						<td colSpan="5">
-																							<a
+																							<button
 																								onClick={() =>
 																									push(createPolicy(""))
 																								}
+                                                className="button-like-anchor"
 																							>
 																								+{" "}
 																								{t(
 																									"EVENTS.EVENTS.DETAILS.ACCESS.ACCESS_POLICY.NEW"
 																								)}
-																							</a>
+																							</button>
 																						</td>
 																					</tr>
 																				)}

--- a/app/src/components/shared/wizard/RenderMultiField.js
+++ b/app/src/components/shared/wizard/RenderMultiField.js
@@ -142,9 +142,9 @@ const EditMultiSelect = ({
 					fieldValue.map((item, key) => (
 						<span className="ng-multi-value" key={key}>
 							{item}
-							<a onClick={() => removeItem(key)}>
+							<button className="button-like-anchor" onClick={() => removeItem(key)}>
 								<i className="fa fa-times" />
-							</a>
+							</button>
 						</span>
 					))}
 			</div>
@@ -181,9 +181,9 @@ const EditMultiValue = ({
 				fieldValue.map((item, key) => (
 					<span className="ng-multi-value" key={key}>
 						{item}
-						<a onClick={() => removeItem(key)}>
+						<button className="button-like-anchor" onClick={() => removeItem(key)}>
 							<i className="fa fa-times" />
-						</a>
+						</button>
 					</span>
 				))}
 		</>

--- a/app/src/components/shared/wizard/SelectContainer.js
+++ b/app/src/components/shared/wizard/SelectContainer.js
@@ -178,7 +178,7 @@ const SelectContainer = ({ resource, formikField, manageable = true }) => {
 						{resource.searchable && (
 							<>
 								{/* search bar */}
-								<a className="clear" onClick={() => clearSearchField()} />
+								<button className="button-like-anchor clear" onClick={() => clearSearchField()} />
 								<input
 									type="text"
 									id="search"

--- a/app/src/components/systems/partials/ServicesActionsCell.js
+++ b/app/src/components/systems/partials/ServicesActionsCell.js
@@ -26,8 +26,8 @@ const ServicesActionCell = ({
 	return (
 		row.status !== "SYSTEMS.SERVICES.STATUS.NORMAL" &&
 		hasAccess("ROLE_UI_SERVICES_STATUS_EDIT", user) && (
-			<a
-				className="sanitize fa fa-undo"
+			<button
+				className="button-like-anchor sanitize fa fa-undo"
 				onClick={() => onClickRestart()}
 				title={t("SYSTEMS.SERVICES.TABLE.SANITIZE")}
 			/>

--- a/app/src/components/users/partials/AclsActionsCell.js
+++ b/app/src/components/users/partials/AclsActionsCell.js
@@ -39,9 +39,9 @@ const AclsActionsCell = ({ row, deleteAcl, fetchAclDetails, user }) => {
 		<>
 			{/* edit/show ACL details */}
 			{hasAccess("ROLE_UI_ACLS_EDIT", user) && (
-				<a
+				<button
 					onClick={() => showAclDetails()}
-					className="more"
+					className="button-like-anchor more"
 					title={t("USERS.ACLS.TABLE.TOOLTIP.DETAILS")}
 				/>
 			)}
@@ -52,9 +52,9 @@ const AclsActionsCell = ({ row, deleteAcl, fetchAclDetails, user }) => {
 
 			{/* delete ACL */}
 			{hasAccess("ROLE_UI_ACLS_DELETE", user) && (
-				<a
+				<button
 					onClick={() => setDeleteConfirmation(true)}
-					className="remove"
+					className="button-like-anchor remove"
 					title={t("USERS.ACLS.TABLE.TOOLTIP.DETAILS")}
 				/>
 			)}

--- a/app/src/components/users/partials/GroupsActionsCell.js
+++ b/app/src/components/users/partials/GroupsActionsCell.js
@@ -39,9 +39,9 @@ const GroupsActionsCell = ({ row, deleteGroup, fetchGroupDetails, user }) => {
 		<>
 			{/*edit/show group */}
 			{hasAccess("ROLE_UI_GROUPS_EDIT", user) && (
-				<a
+				<button
 					onClick={() => showGroupDetails()}
-					className="more"
+					className="button-like-anchor more"
 					title={t("USERS.GROUPS.TABLE.TOOLTIP.DETAILS")}
 				/>
 			)}
@@ -53,9 +53,9 @@ const GroupsActionsCell = ({ row, deleteGroup, fetchGroupDetails, user }) => {
 
 			{/* delete group */}
 			{hasAccess("ROLE_UI_GROUPS_DELETE", user) && (
-				<a
+				<button
 					onClick={() => setDeleteConfirmation(true)}
-					className="remove"
+					className="button-like-anchor remove"
 					title={t("USERS.GROUPS.TABLE.TOOLTIP.DETAILS")}
 				/>
 			)}

--- a/app/src/components/users/partials/UsersActionsCell.js
+++ b/app/src/components/users/partials/UsersActionsCell.js
@@ -39,9 +39,9 @@ const UsersActionCell = ({ row, deleteUser, fetchUserDetails, user }) => {
 		<>
 			{/* edit/show user details */}
 			{hasAccess("ROLE_UI_USERS_EDIT", user) && (
-				<a
+				<button
 					onClick={() => showUserDetails()}
-					className="more"
+					className="button-like-anchor more"
 					title={t("USERS.USERS.TABLE.TOOLTIP.DETAILS")}
 				/>
 			)}
@@ -52,9 +52,9 @@ const UsersActionCell = ({ row, deleteUser, fetchUserDetails, user }) => {
 
 			{row.manageable && hasAccess("ROLE_UI_USERS_DELETE", user) && (
 				<>
-					<a
+					<button
 						onClick={() => setDeleteConfirmation(true)}
-						className="remove"
+						className="button-like-anchor remove"
 						title={t("USERS.USERS.TABLE.TOOLTIP.DETAILS")}
 					/>
 

--- a/app/src/components/users/partials/modal/AclDetailsModal.js
+++ b/app/src/components/users/partials/modal/AclDetailsModal.js
@@ -27,8 +27,8 @@ const AclDetailsModal = ({ close, aclName }) => {
 				style={modalStyle}
 			>
 				<header>
-					<a
-						className="fa fa-times close-modal"
+					<button
+						className="button-like-anchor fa fa-times close-modal"
 						onClick={() => handleClose()}
 					/>
 					<h2>{t("USERS.ACLS.DETAILS.HEADER", { name: aclName })}</h2>

--- a/app/src/components/users/partials/modal/GroupDetailsModal.js
+++ b/app/src/components/users/partials/modal/GroupDetailsModal.js
@@ -27,8 +27,8 @@ const GroupDetailsModal = ({ close, groupName }) => {
 				style={modalStyle}
 			>
 				<header>
-					<a
-						className="fa fa-times close-modal"
+					<button
+						className="button-like-anchor fa fa-times close-modal"
 						onClick={() => handleClose()}
 					/>
 					<h2>{t("USERS.GROUPS.DETAILS.EDITCAPTION", { name: groupName })}</h2>

--- a/app/src/components/users/partials/modal/UserDetailsModal.js
+++ b/app/src/components/users/partials/modal/UserDetailsModal.js
@@ -26,8 +26,8 @@ const UserDetailsModal = ({ close, username }) => {
 				style={modalStyle}
 			>
 				<header>
-					<a
-						className="fa fa-times close-modal"
+					<button
+						className="button-like-anchor fa fa-times close-modal"
 						onClick={() => handleClose()}
 					/>
 					<h2>

--- a/app/src/components/users/partials/wizard/AclAccessPage.js
+++ b/app/src/components/users/partials/wizard/AclAccessPage.js
@@ -261,9 +261,9 @@ const AclAccessPage = ({
 																						{/*Remove policy*/}
 																						{isAccess && (
 																							<td>
-																								<a
+																								<button
 																									onClick={() => remove(index)}
-																									className="remove"
+																									className="button-like-anchor remove"
 																								/>
 																							</td>
 																						)}
@@ -283,7 +283,7 @@ const AclAccessPage = ({
 																				<tr>
 																					{/*Add additional policy row*/}
 																					<td colSpan="5">
-																						<a
+																						<button
 																							onClick={() => {
 																								push({
 																									role: "",
@@ -293,13 +293,14 @@ const AclAccessPage = ({
 																								});
 																								checkAcls(formik.values.acls);
 																							}}
+                                              className="button-like-anchor"
 																						>
 																							{" "}
 																							+{" "}
 																							{t(
 																								"USERS.ACLS.NEW.ACCESS.ACCESS_POLICY.NEW"
 																							)}
-																						</a>
+																						</button>
 																					</td>
 																				</tr>
 																			)}

--- a/app/src/components/users/partials/wizard/NewUserWizard.js
+++ b/app/src/components/users/partials/wizard/NewUserWizard.js
@@ -39,19 +39,19 @@ const NewUserWizard = ({ close, usernames, postNewUser }) => {
 		<>
 			{/*Head navigation*/}
 			<nav className="modal-nav" id="modal-nav" style={navStyle}>
-				<a
-					className={cn("wider", { active: tab === 0 })}
+				<button
+					className={"button-like-anchor " + cn("wider", { active: tab === 0 })}
 					onClick={() => openTab(0)}
 				>
 					{t("USERS.USERS.DETAILS.TABS.USER")}
-				</a>
-				<a
-					className={cn("wider", { active: tab === 1 })}
+				</button>
+				<button
+					className={"button-like-anchor " + cn("wider", { active: tab === 1 })}
 					onClick={() => openTab(1)}
 					title={t("USERS.USERS.DETAILS.DESCRIPTION.ROLES")}
 				>
 					{t("USERS.USERS.DETAILS.TABS.ROLES")}
-				</a>
+				</button>
 			</nav>
 
 			{/* Initialize overall form */}

--- a/app/src/components/users/partials/wizard/UserEffectiveRolesTab.js
+++ b/app/src/components/users/partials/wizard/UserEffectiveRolesTab.js
@@ -32,7 +32,7 @@ const UserEffectiveRolesTab = ({ formik }) => {
 					<p>{t("USERS.USERS.DETAILS.DESCRIPTION.EFFECTIVEROLES")}</p>
 
 					{/* list  all roles a user got */}
-					<a className="clear" onClick={() => clearSearchField()} />
+					<button className="button-like-anchor clear" onClick={() => clearSearchField()} />
 					<input
 						type="text"
 						id="search_effective"

--- a/app/src/styles/components/_alerts.scss
+++ b/app/src/styles/components/_alerts.scss
@@ -148,6 +148,7 @@
         margin-top: 9px;
         @include transition($alert-transition);
         text-decoration: none;
+        color: inherit;
     }
 
     p {

--- a/app/src/styles/components/_dropdowns.scss
+++ b/app/src/styles/components/_dropdowns.scss
@@ -101,20 +101,19 @@
         > li {
             text-decoration: none;
             text-shadow: 0 1px 0 $white;
-            color: $medium-prim-color;
-            font-size: 12px;
-            line-height: 20px;
-            font-weight: 600;
-            cursor: default;
             display: block;
             position: relative;
             @include transition(all 200ms);
 
-            a {
+            button {
                 display: block;
                 padding: 12px 15px;
+                width: 100%;
+                text-align: left;
+                font-size: inherit;
+                line-height: 20px;
 
-                &:hover {
+                &:hover, &:focus {
                     color: #666666;
                     background: #f2f2f2;
                 }
@@ -203,11 +202,11 @@
                     margin-top: -20px;
                 }
 
-                a {
+                button {
                     display: block;
                     padding: 4px 15px;
 
-                    &:hover {
+                    &:hover, &:focus {
                         color: #666666;
                         background: #f2f2f2;
                     }

--- a/app/src/styles/components/_menu-dropdown.scss
+++ b/app/src/styles/components/_menu-dropdown.scss
@@ -50,7 +50,7 @@
     border-radius: $border-radius;
     box-shadow: $box-shadow;
 
-    a {
+    a, button {
         overflow: visible;
         display: block;
         padding: $link-padding;
@@ -59,8 +59,12 @@
         @include transition-timing-function(ease-in);
         text-overflow: ellipsis;
         white-space: nowrap;
+        font-weight: $weight-semibold;
+        height: 32px;
+        width: 100%;
+        text-align: left;
 
-        &:hover {
+        &:hover, &:focus {
             background: $link-hover-color;
         }
     }

--- a/app/src/styles/components/_multi-select.scss
+++ b/app/src/styles/components/_multi-select.scss
@@ -77,7 +77,8 @@
             width: 100% !important;
         }
 
-        a.clear {
+        button.clear {
+            height: inherit;
             margin-top: 10px;
             float: right;
             @include btn(white);

--- a/app/src/styles/components/_tables.scss
+++ b/app/src/styles/components/_tables.scss
@@ -214,11 +214,14 @@
         vertical-align: middle;
 
         // Action icons
-        > a {
+        > a, > button {
             display: inline-block;
             margin-right: 10px;
             vertical-align: middle;
             position: relative;
+            border-radius: inherit;
+            color: #1d5888;
+            padding: unset;
 
             &.remove {
                 @include build-icon(auto, auto, remove-icon, 17px, 17px);

--- a/app/src/styles/components/data-filter/_filter-profiles.scss
+++ b/app/src/styles/components/data-filter/_filter-profiles.scss
@@ -49,7 +49,7 @@
             line-height: 30px;
             padding-left: 10px;
         }
-        > a {
+        > button {
             float: right;
             padding-right: 5px;
             padding-top: 5px;
@@ -136,7 +136,12 @@
                 padding-right: 5px;
             }
 
-            > a { word-wrap: break-word; &.active { color: $l-blue; }  }
+            > button {
+              word-wrap: break-word;
+              font-size: inherit;
+
+              &.active { color: $l-blue; }
+            }
 
         } // li
     }
@@ -191,12 +196,14 @@
             @include btn(white);
             margin-right: 3px;
             float: left;
+            height: inherit;
         } // cancel
 
         .save {
             @include btn(green);
             text-shadow: none;
             float: right;
+            height: inherit;
         } // save
     } // input-container
 

--- a/app/src/styles/components/modals/_header.scss
+++ b/app/src/styles/components/modals/_header.scss
@@ -39,11 +39,12 @@
         font-size: 17px;
     }
 
-    > a {
+    > button {
         float: right;
         font-size: 18px;
         margin-top: 10px;
         margin-right: -8px;
+        color: inherit;
     }
 }
 

--- a/app/src/styles/components/modals/_modal-base.scss
+++ b/app/src/styles/components/modals/_modal-base.scss
@@ -136,7 +136,8 @@
         width: 100% !important;
     }
 
-    a.clear {
+    button.clear {
+        height: inherit;
         width: 46px;
         margin-top: 5px;
         float: right;

--- a/app/src/styles/components/modals/_modal-components.scss
+++ b/app/src/styles/components/modals/_modal-components.scss
@@ -108,6 +108,8 @@
                     cursor: pointer;
                     color: $l-blue;
                     display: inline-block;
+                    line-height: inherit;
+                    padding: initial;
                 }
 
                 .delete {
@@ -396,9 +398,6 @@
     }
 
     button {
-        margin: 0 3px;
-        height: 32px;
-        min-width: 80px;
 
         &:first-child {
            margin-left: 0;

--- a/app/src/styles/components/modals/_nav.scss
+++ b/app/src/styles/components/modals/_nav.scss
@@ -29,7 +29,7 @@
     background: $modal-nav-bg-color;
     border-bottom: 1px solid $modal-nav-border-color;
 
-    > a {
+    > button {
         $width: 100px;
         width: $width;
         display: inline-block;
@@ -38,7 +38,7 @@
         overflow: hidden;
         padding: 14px 5px;
         box-sizing: border-box;
-        height : $height; 
+        height : $height;
         line-height: $line-height;
         color: $modal-nav-link-color;
         font-size: 13px;

--- a/app/src/styles/extensions/components/_tables.scss
+++ b/app/src/styles/extensions/components/_tables.scss
@@ -72,7 +72,7 @@
         }
     }
 
-    a {
+    button {
         $highlight-blue: #3aa5ef;
 
         color: $highlight-blue;

--- a/app/src/styles/main.scss
+++ b/app/src/styles/main.scss
@@ -171,7 +171,7 @@ a.disabled, button.disabled, div.disabled {
   color: #fff;
   border-radius: 4px;
 
-  a {
+  button {
     color: white;
     font-weight: bold;
   }
@@ -369,7 +369,7 @@ div.table-filter {
       padding: 2px;
     }
 
-    span a i {
+    span button i {
       color: white;
     }
 
@@ -486,15 +486,15 @@ input.disabled, select.disabled {
 
     .pagination {
 
-      a {
+      button {
         padding: 7px 10px;
       }
 
-      a.wide {
+      button.wide {
         width: inline;
       }
 
-      a:hover:not(.active) {
+      button:hover:not(.active) {
         background: -webkit-gradient(linear, 0% 0%, 0% 100%, from(#fefefe), to(#f0f0f0));
         background: -moz-linear-gradient(0% 0% 270deg, #fefefe, #f0f0f0);
       }

--- a/app/src/styles/mixins/_button.scss
+++ b/app/src/styles/mixins/_button.scss
@@ -232,12 +232,24 @@
 
 // Standard button styles
 button {
-    height: $btn-height;
-    font-size: 12px;
-    font-weight: 600;
-    color: #fff;
-    border-radius: $main-border-radius;
     display: inline-block;
+    height: $btn-height;
+    border-radius: $main-border-radius;
+    color: #fff;
+    font-size: 12px;
+    font-weight: $weight-semibold;
+}
+
+// Need to be added for moving from anchor to button tags
+.button-like-anchor {
+    height: initial;
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-weight: inherit;
+    font-family: inherit;
+
+    color: #069;
 }
 
 // Buttons

--- a/app/src/styles/views/_core.scss
+++ b/app/src/styles/views/_core.scss
@@ -140,7 +140,7 @@ body {
             margin: 0 auto;
             text-align: center;
 
-            a {
+            button {
                 display: inline-block;
                 padding: 7px 10px;
                 margin-right: 4px;

--- a/app/src/styles/views/modals/_event-series.scss
+++ b/app/src/styles/views/modals/_event-series.scss
@@ -150,7 +150,7 @@
                     border: none;
                 }
 
-                a {
+                button {
                     float: right;
                 }
             }


### PR DESCRIPTION
This switches a ton of anchor tags for button tags, thereby removing a ton of ESLint warnings and
hopefully preparing the Admin UI for future
accessibility updates.

Since this is supposed to be just a semantic update, everything should look the same as before, particularly every clickable thing.

Does not fix the warnings in TimeSeriesStatistics.js because I don't currently know how to display the associated UI and thus can't check any changes.

Resolves #100