### PR TITLE
Fix eslint warnings about comments in jsx

### DIFF
--- a/app/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetsAddAsset.js
+++ b/app/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetsAddAsset.js
@@ -83,7 +83,8 @@ const EventDetailsAssetsAddAsset = ({
 																	? t(asset.displayOverride)
 																	: t(asset.title)}
 																<span className="ui-helper-hidden">
-																	({asset.type} "{asset.flavorType}//
+                                  { // eslint-disable-next-line react/jsx-no-comment-textnodes
+                                  } ({asset.type} "{asset.flavorType}//
 																	{asset.flavorSubType}")
 																</span>
 															</td>

--- a/app/src/components/events/partials/ModalTabsAndPages/NewAssetUploadPage.js
+++ b/app/src/components/events/partials/ModalTabsAndPages/NewAssetUploadPage.js
@@ -59,7 +59,8 @@ const NewAssetUploadPage = ({
 															? t(asset.displayOverride)
 															: t(asset.title)}
 														<span className="ui-helper-hidden">
-															({asset.type} "{asset.flavorType}//
+                              { // eslint-disable-next-line react/jsx-no-comment-textnodes
+                              } ({asset.type} "{asset.flavorType}//
 															{asset.flavorSubType}")
 														</span>
 													</td>

--- a/app/src/components/events/partials/wizards/NewEventSummary.js
+++ b/app/src/components/events/partials/wizards/NewEventSummary.js
@@ -96,7 +96,8 @@ const NewEventSummary = ({
 													<td>
 														{asset.translate}
 														<span className="ui-helper-hidden">
-															({asset.type} "{asset.flavorType}//
+                              { // eslint-disable-next-line react/jsx-no-comment-textnodes
+                              } ({asset.type} "{asset.flavorType}//
 															{asset.flavorSubType}")
 														</span>
 													</td>
@@ -129,7 +130,8 @@ const NewEventSummary = ({
 																asset["displayOverride.SHORT"]
 															)}
 															<span className="ui-helper-hidden">
-																({asset.type} "{asset.flavorType}//
+                                { // eslint-disable-next-line react/jsx-no-comment-textnodes
+                                } ({asset.type} "{asset.flavorType}//
 																{asset.flavorSubType}")
 															</span>
 														</td>


### PR DESCRIPTION
Fixes `jsx-no-comments warnings by disabling them, as the double slash in this case is not for comments, but for a string.

Helps with #42.