### PR TITLE
Fix proxy not working with typescript

### DIFF
--- a/app/src/setupProxy.js
+++ b/app/src/setupProxy.js
@@ -1,5 +1,5 @@
 const { createProxyMiddleware } = require("http-proxy-middleware");
-module.exports = function (app: any) {
+module.exports = function (app) {
 	app.use(
 		"/admin-ng/j_spring_security_check",
 		createProxyMiddleware({

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -1,4 +1,8 @@
 {
+  "exclude": [
+    "node_modules",
+    "dist"
+  ],
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig to read more about this file */
 
@@ -40,7 +44,7 @@
 
     /* JavaScript Support */
     "allowJs": false,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
-    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+    "checkJs": false,                                  /* Enable error reporting in type-checked JavaScript files. */
     // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
 
     /* Emit */

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "exclude": [
-    "node_modules",
-    "dist"
+    "node_modules"
   ],
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig to read more about this file */


### PR DESCRIPTION
"setupProxy" relies on CRA auto-magic, but the magic will only work if it has the ".js" extension. And then I also changed something in the tsconfig that seems unrelated to me and now it works...?

Fixes #210 . 