### PR TITLE
Ensure there is an active page when calculating pages

### DIFF
--- a/app/src/thunks/tableThunks.ts
+++ b/app/src/thunks/tableThunks.ts
@@ -698,5 +698,9 @@ const calculatePages = (numberOfPages, offset) => {
 		});
 	}
 
+  if (pages.every(page => page.active === false)) {
+    pages[0].active = true;
+  }
+
 	return pages;
 };


### PR DESCRIPTION
When (re-)calculating table page properties, it could happen that no page gets marked as active. However, the application assumes that there is always an active page. This fixes that.

Helps with #211