### PR TITLE
Make active circle in upload progress distinct

### DIFF
--- a/app/src/components/shared/wizard/CustomStepIcon.tsx
+++ b/app/src/components/shared/wizard/CustomStepIcon.tsx
@@ -3,12 +3,17 @@ import cn from "classnames";
 import { FaCircle, FaDotCircle } from "react-icons/fa";
 import React from "react";
 
+type customStepIconProps = {
+	active: boolean,
+	completed: boolean,
+}
+
 /**
  * Component that renders icons of Stepper depending on completeness of steps
  */
-const CustomStepIcon = (props: any) => {
-	const classes = useStepIconStyles();
+const CustomStepIcon = (props: customStepIconProps) => {
 	const { completed } = props;
+	const classes = useStepIconStyles(props);
 
 	return (
 		<div className={cn(classes.root)}>

--- a/app/src/components/shared/wizard/WizardStepper.tsx
+++ b/app/src/components/shared/wizard/WizardStepper.tsx
@@ -74,7 +74,7 @@ const WizardStepper = ({
 							</StepLabel>
 						</StepButton>
 					</Step>
-				) : null
+				) : <></>
 			)}
 		</Stepper>
 	);

--- a/app/src/components/shared/wizard/WizardStepperEvent.tsx
+++ b/app/src/components/shared/wizard/WizardStepperEvent.tsx
@@ -85,7 +85,7 @@ const WizardStepperEvent = ({
 							</StepLabel>
 						</StepButton>
 					</Step>
-				) : null
+				) : <></>
 			)}
 		</Stepper>
 	);

--- a/app/src/utils/wizardUtils.ts
+++ b/app/src/utils/wizardUtils.ts
@@ -1,4 +1,4 @@
-import { makeStyles } from "@material-ui/core";
+import { Theme, makeStyles } from "@material-ui/core";
 
 // Base style for Stepper component
 export const useStepperStyle = makeStyles((theme) => ({
@@ -9,7 +9,11 @@ export const useStepperStyle = makeStyles((theme) => ({
 }));
 
 // Style of icons used in Stepper
-export const useStepIconStyles = makeStyles({
+type stepIconStyleProps = {
+	active: boolean,
+	completed: boolean,
+}
+export const useStepIconStyles = makeStyles<Theme, stepIconStyleProps>(theme => ({
 	root: {
 		height: 22,
 		alignItems: "center",
@@ -18,8 +22,9 @@ export const useStepIconStyles = makeStyles({
 		color: "#92a0ab",
 		width: "20px",
 		height: "20px",
+		transform: (props: stepIconStyleProps) => props.active ? "scale(1.3)" : "scale(1.0)",
 	},
-});
+}));
 
 /* This method checks if the summary page is reachable.
  * If the clicked page is some other page than summary then no check is needed.


### PR DESCRIPTION
Fixes #62 

Styles the circle in the progress bar at the top of the upload event dialog, to make it clear in which step we are. Similarly to the old ui, it just makes the circle a little bit larger.

![Bildschirmfoto vom 2023-11-20 12-00-56](https://github.com/opencast/opencast-admin-interface/assets/14070005/4736e2b7-a1a9-4685-8224-9defa1ae8b80)
