### PR TITLE
Improve new event stepper buttons

### DIFF
--- a/app/src/components/events/partials/wizards/NewEventWizard.tsx
+++ b/app/src/components/events/partials/wizards/NewEventWizard.tsx
@@ -57,6 +57,7 @@ const NewEventWizard = ({
 		{
 			translation: "EVENTS.EVENTS.NEW.METADATA.CAPTION",
 			name: "metadata",
+			hidden: false,
 		},
 		{
 			translation: "EVENTS.EVENTS.DETAILS.TABS.EXTENDED-METADATA",
@@ -66,6 +67,7 @@ const NewEventWizard = ({
 		{
 			translation: "EVENTS.EVENTS.NEW.SOURCE.CAPTION",
 			name: "source",
+			hidden: false,
 		},
 		{
 			translation: "EVENTS.EVENTS.NEW.UPLOAD_ASSET.CAPTION",
@@ -78,14 +80,17 @@ const NewEventWizard = ({
 		{
 			translation: "EVENTS.EVENTS.NEW.PROCESSING.CAPTION",
 			name: "processing",
+			hidden: false,
 		},
 		{
 			translation: "EVENTS.EVENTS.NEW.ACCESS.CAPTION",
 			name: "access",
+			hidden: false,
 		},
 		{
 			translation: "EVENTS.EVENTS.NEW.SUMMARY.CAPTION",
 			name: "summary",
+			hidden: false,
 		},
 	];
 

--- a/app/src/components/events/partials/wizards/NewSeriesWizard.tsx
+++ b/app/src/components/events/partials/wizards/NewSeriesWizard.tsx
@@ -40,6 +40,7 @@ const NewSeriesWizard = ({
 		{
 			translation: "EVENTS.SERIES.NEW.METADATA.CAPTION",
 			name: "metadata",
+			hidden: false,
 		},
 		{
 			translation: "EVENTS.EVENTS.DETAILS.TABS.EXTENDED-METADATA",
@@ -49,14 +50,17 @@ const NewSeriesWizard = ({
 		{
 			translation: "EVENTS.SERIES.NEW.ACCESS.CAPTION",
 			name: "access",
+			hidden: false,
 		},
 		{
 			translation: "EVENTS.SERIES.NEW.THEME.CAPTION",
 			name: "theme",
+			hidden: false,
 		},
 		{
 			translation: "EVENTS.SERIES.NEW.SUMMARY.CAPTION",
 			name: "summary",
+			hidden: false,
 		},
 	];
 

--- a/app/src/components/shared/wizard/CustomStepIcon.tsx
+++ b/app/src/components/shared/wizard/CustomStepIcon.tsx
@@ -3,12 +3,17 @@ import cn from "classnames";
 import { FaCircle, FaDotCircle } from "react-icons/fa";
 import React from "react";
 
+type customStepIconProps = {
+	active: boolean,
+	completed: boolean,
+}
+
 /**
  * Component that renders icons of Stepper depending on completeness of steps
  */
-const CustomStepIcon = (props: any) => {
-	const classes = useStepIconStyles();
+const CustomStepIcon = (props: customStepIconProps) => {
 	const { completed } = props;
+	const classes = useStepIconStyles(props);
 
 	return (
 		<div className={cn(classes.root)}>

--- a/app/src/components/shared/wizard/WizardStepper.tsx
+++ b/app/src/components/shared/wizard/WizardStepper.tsx
@@ -74,7 +74,7 @@ const WizardStepper = ({
 							</StepLabel>
 						</StepButton>
 					</Step>
-				) : null
+				) : <></>
 			)}
 		</Stepper>
 	);

--- a/app/src/components/shared/wizard/WizardStepperEvent.tsx
+++ b/app/src/components/shared/wizard/WizardStepperEvent.tsx
@@ -85,7 +85,7 @@ const WizardStepperEvent = ({
 							</StepLabel>
 						</StepButton>
 					</Step>
-				) : null
+				) : <></>
 			)}
 		</Stepper>
 	);

--- a/app/src/components/shared/wizard/WizardStepperEvent.tsx
+++ b/app/src/components/shared/wizard/WizardStepperEvent.tsx
@@ -36,35 +36,24 @@ const WizardStepperEvent = ({
 // @ts-expect-error TS(7006): Parameter 'key' implicitly has an 'any' type.
 	const handleOnClick = async (key) => {
 		if (isSummaryReachable(key, steps, completed)) {
-			if (steps[page].name === "source") {
-				let dateCheck = await checkConflicts(formik.values);
-				if (!dateCheck) {
-					return;
+
+			if (completed[key]) {
+				await setPage(key);
+			}
+
+			let previousPageIndex = key - 1 > 0 ? key - 1 : 0;
+			while (previousPageIndex >= 0) {
+				if (steps[previousPageIndex].hidden) {
+					previousPageIndex = previousPageIndex - 1;
+				} else {
+					break;
 				}
 			}
-
-			if (
-				steps[page].name === "processing" &&
-				!formik.values.processingWorkflow
-			) {
-				return;
-			}
-
-			let aclCheck = await checkAcls(formik.values.acls);
-			if (!aclCheck) {
-				return;
-			}
-
-			if (formik.isValid) {
-				let updatedCompleted = completed;
-				updatedCompleted[page] = true;
-				setCompleted(updatedCompleted);
+			if (completed[previousPageIndex]) {
 				await setPage(key);
 			}
 		}
 	};
-
-	const disabled = !(formik.dirty && formik.isValid);
 
 	return (
 		<Stepper
@@ -79,7 +68,7 @@ const WizardStepperEvent = ({
 			{steps.map((label, key) =>
 				!label.hidden ? (
 					<Step key={label.translation} completed={completed[key]}>
-						<StepButton onClick={() => handleOnClick(key)} disabled={disabled}>
+						<StepButton onClick={() => handleOnClick(key)}>
 							<StepLabel StepIconComponent={CustomStepIcon}>
 								{t(label.translation)}
 							</StepLabel>

--- a/app/src/utils/wizardUtils.ts
+++ b/app/src/utils/wizardUtils.ts
@@ -1,4 +1,4 @@
-import { makeStyles } from "@material-ui/core";
+import { Theme, makeStyles } from "@material-ui/core";
 
 // Base style for Stepper component
 export const useStepperStyle = makeStyles((theme) => ({
@@ -9,7 +9,11 @@ export const useStepperStyle = makeStyles((theme) => ({
 }));
 
 // Style of icons used in Stepper
-export const useStepIconStyles = makeStyles({
+type stepIconStyleProps = {
+	active: boolean,
+	completed: boolean,
+}
+export const useStepIconStyles = makeStyles<Theme, stepIconStyleProps>(theme => ({
 	root: {
 		height: 22,
 		alignItems: "center",
@@ -18,8 +22,9 @@ export const useStepIconStyles = makeStyles({
 		color: "#92a0ab",
 		width: "20px",
 		height: "20px",
+		transform: (props: stepIconStyleProps) => props.active ? "scale(1.3)" : "scale(1.0)",
 	},
-});
+}));
 
 /* This method checks if the summary page is reachable.
  * If the clicked page is some other page than summary then no check is needed.


### PR DESCRIPTION
Clicking on the circles in the top part of the new event dialog only works sometimes. This commit makes it more consistent, by removing some validation logic where it really does not belong. This should allow users to click on the circles in the top to go to previously completed steps as well as the current step. However, the old ui, it does not allow users to click on the circle of the next step to validate the current step.

Includes #255.