### PR TITLE
Fix commands in docs for proxy server

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ It will also start a backend server with dummy data at localhost:5000.
 
 To test with real data, instead run:
 
-    npm proxy-server
+    npm proxy-server *opencast_digest_username* *opencast_digest_password*
 
 This will start a proxy server at localhost:5000. It will automatically proxy
 requests to a Opencast instance at localhost:8080.
 You can then start the client in a different tab by running:
 
-    npm client
+    npm run client
 
 
 


### PR DESCRIPTION
The commands for running the proxy server in the README are wrong/incomplete. This should help users with running the correct commands for their setup.