### PR TITLE
Fix mixed_text metadata fields without collection

### DIFF
--- a/app/src/components/events/partials/ModalTabsAndPages/DetailsExtendedMetadataTab.tsx
+++ b/app/src/components/events/partials/ModalTabsAndPages/DetailsExtendedMetadataTab.tsx
@@ -139,7 +139,7 @@ const DetailsExtendedMetadataTab = ({
 																		<td className="editable">
 																			{/* Render single value or multi value editable input */}
 																			{field.type === "mixed_text" &&
-																			field.collection.length !== 0 ? (
+																			field.collection?.length !== 0 ? (
 																				<Field
 																					name={field.id}
 																					fieldInfo={field}

--- a/app/src/components/events/partials/ModalTabsAndPages/DetailsMetadataTab.tsx
+++ b/app/src/components/events/partials/ModalTabsAndPages/DetailsMetadataTab.tsx
@@ -129,6 +129,7 @@ const DetailsMetadataTab = ({
 																<td className="editable">
 																	{/* Render single value or multi value editable input */}
 																	{field.type === "mixed_text" &&
+																	field.collection &&
 																	field.collection.length !== 0 ? (
 																		<Field
 																			name={field.id}

--- a/app/src/components/events/partials/ModalTabsAndPages/DetailsMetadataTab.tsx
+++ b/app/src/components/events/partials/ModalTabsAndPages/DetailsMetadataTab.tsx
@@ -129,8 +129,7 @@ const DetailsMetadataTab = ({
 																<td className="editable">
 																	{/* Render single value or multi value editable input */}
 																	{field.type === "mixed_text" &&
-																	field.collection &&
-																	field.collection.length !== 0 ? (
+																	field.collection?.length !== 0 ? (
 																		<Field
 																			name={field.id}
 																			fieldInfo={field}

--- a/app/src/components/events/partials/ModalTabsAndPages/NewMetadataExtendedPage.tsx
+++ b/app/src/components/events/partials/ModalTabsAndPages/NewMetadataExtendedPage.tsx
@@ -79,7 +79,7 @@ const NewMetadataExtendedPage = ({
 																) : (
 																	<td className="editable ng-isolated-scope">
 																		{field.type === "mixed_text" &&
-																		field.collection.length !== 0 ? (
+																		field.collection?.length !== 0 ? (
 																			<Field
 																				name={catalog.flavor + "_" + field.id}
 																				fieldInfo={field}

--- a/app/src/components/events/partials/ModalTabsAndPages/NewMetadataPage.tsx
+++ b/app/src/components/events/partials/ModalTabsAndPages/NewMetadataPage.tsx
@@ -41,7 +41,7 @@ const NewMetadataPage = ({
 													<td className="editable ng-isolated-scope">
 														{/* Render single value or multi value input */}
 														{field.type === "mixed_text" &&
-														field.collection.length !== 0 ? (
+														field.collection?.length !== 0 ? (
 															<Field
 																name={field.id}
 																fieldInfo={field}


### PR DESCRIPTION
We have disabled the listproviders for some mixed_text fields in the episode and series metadata for performance reasons, meaning that those fields don't have a collection, which is a valid config for the old Admin UI. However, this currently breaks the new one:
![image](https://github.com/opencast/opencast-admin-interface/assets/11960278/42f47227-3b24-4ada-9a7b-b88e6e2242fe)

Simply checking if field.collection is defined before checking its length should fix this.

Warning: I didn't test this because I didn't want to deal with figuring out how to do this against my local Opencast instance. But this is simple enough, so it should be fine...right?

Edit: I'm also unsure which branch to point this at to get it into Opencast as soon as possible, maybe you can advise me on that?