### PR TITLE
Don't render "invalid date" in table cells

### DIFF
--- a/app/src/components/events/partials/EventsEndCell.tsx
+++ b/app/src/components/events/partials/EventsEndCell.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from "react-i18next";
 import React from "react";
+import { renderValidDate } from "../../../utils/dateUtils";
 
 /**
  * This component renders the end cells of events in the table view
@@ -11,7 +12,7 @@ const EventsEndCell = ({
 
 	return (
 		// Link template for start date of event
-		<span>{t("dateFormats.time.short", { time: new Date(row.end_date) })}</span>
+		<span>{t("dateFormats.time.short", { time: renderValidDate(row.end_date) })}</span>
 	);
 };
 export default EventsEndCell;

--- a/app/src/components/events/partials/EventsStartCell.tsx
+++ b/app/src/components/events/partials/EventsStartCell.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from "react-i18next";
 import React from "react";
+import { renderValidDate } from "../../../utils/dateUtils";
 
 /**
  * This component renders the start cells of events in the table view
@@ -12,7 +13,7 @@ const EventsStartCell = ({
 	return (
 		// Link template for start date of event
 		<span>
-			{t("dateFormats.time.short", { time: new Date(row.start_date) })}
+			{t("dateFormats.time.short", { time: renderValidDate(row.start_date) })}
 		</span>
 	);
 };

--- a/app/src/components/events/partials/SeriesDateTimeCell.tsx
+++ b/app/src/components/events/partials/SeriesDateTimeCell.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
+import { renderValidDate } from "../../../utils/dateUtils";
 
 /**
  * This component renders the creation date cells of series in the table view
@@ -13,7 +14,7 @@ const SeriesDateTimeCell = ({
 		// Link template for creation date of series
 		<span>
 			{t("dateFormats.dateTime.short", {
-				dateTime: new Date(row.creation_date),
+				dateTime: renderValidDate(row.creation_date),
 			})}
 		</span>
 	);

--- a/app/src/components/recordings/partials/RecordingsUpdateCell.tsx
+++ b/app/src/components/recordings/partials/RecordingsUpdateCell.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
+import { renderValidDate } from "../../../utils/dateUtils";
 
 /**
  * This component renders the updated cells of recordings in the table view
@@ -11,7 +12,7 @@ const RecordingsUpdateCell = ({
 
 	return (
 		<span>
-			{t("dateFormats.dateTime.short", { dateTime: new Date(row.update) })}
+			{t("dateFormats.dateTime.short", { dateTime: renderValidDate(row.update) })}
 		</span>
 	);
 };

--- a/app/src/components/systems/partials/JobsStartedCell.tsx
+++ b/app/src/components/systems/partials/JobsStartedCell.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
+import { renderValidDate } from "../../../utils/dateUtils";
 
 /**
  * This component renders the started date cells of jobs in the table view
@@ -11,7 +12,7 @@ const JobsStartedCell = ({
 
 	return (
 		<span>
-			{t("dateFormats.dateTime.short", { dateTime: new Date(row.started) })}
+			{t("dateFormats.dateTime.short", { dateTime: renderValidDate(row.started) })}
 		</span>
 	);
 };

--- a/app/src/components/systems/partials/MeanQueueTimeCell.tsx
+++ b/app/src/components/systems/partials/MeanQueueTimeCell.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
+import { renderValidDate } from "../../../utils/dateUtils";
 
 /**
  * This component renders the mean queue time cells of systems in the table view
@@ -11,7 +12,7 @@ const MeanQueueTimeCell = ({
 
 	return (
 		<span>
-			{t("dateFormats.time.medium", { time: new Date(row.meanQueueTime) })}
+			{t("dateFormats.time.medium", { time: renderValidDate(row.meanQueueTime) })}
 		</span>
 	);
 };

--- a/app/src/utils/dateUtils.ts
+++ b/app/src/utils/dateUtils.ts
@@ -5,6 +5,11 @@ import { makeTwoDigits } from "./utils";
  * This File contains methods concerning dates
  */
 
+// check if date can be parsed
+export const renderValidDate = (date: string) => {
+  return !isNaN(Date.parse(date)) ? new Date(date) : ""
+}
+
 // transform relative date to an absolute date
 export const relativeToAbsoluteDate = (relative: any, type: any, from: any) => {
 	let localMoment = moment();


### PR DESCRIPTION
The constructor for javascript `Date`s will return "invalid date" for
invalid date strings. This does not look very nice in our tables,
so this changes it to render an empty string instead. Arguably this
is fine because it is not the responsibility of the view to make sure
the dates it gets are correct.

Resolves #237.