### PR TITLE
Remove useAppDispatch from tableThunks.ts

### DIFF
--- a/app/src/thunks/tableThunks.ts
+++ b/app/src/thunks/tableThunks.ts
@@ -49,7 +49,6 @@ import { setGroupColumns } from "../actions/groupActions";
 import { fetchAcls, setAclColumns } from "../slices/aclSlice";
 import { setThemeColumns } from "../actions/themeActions";
 import { setServicesColumns } from "../actions/serviceActions";
-import { useAppDispatch } from "../store";
 
 /**
  * This file contains methods/thunks used to manage the table in the main view and its state changes
@@ -407,7 +406,6 @@ export const loadThemesIntoTable = () => (dispatch, getState) => {
 // Navigate between pages
 // @ts-expect-error TS(7006): Parameter 'pageNumber' implicitly has an 'any' typ... Remove this comment to see the full error message
 export const goToPage = (pageNumber) => async (dispatch, getState) => {
-        const appDispatch = useAppDispatch();
 	dispatch(deselectAll());
 	dispatch(setOffset(pageNumber));
 
@@ -462,7 +460,7 @@ export const goToPage = (pageNumber) => async (dispatch, getState) => {
 			break;
 		}
 		case "acls": {
-			await appDispatch(fetchAcls());
+			await dispatch(fetchAcls());
 			dispatch(loadAclsIntoTable());
 			break;
 		}
@@ -477,7 +475,6 @@ export const goToPage = (pageNumber) => async (dispatch, getState) => {
 // Update pages for example if page size was changed
 // @ts-expect-error TS(7006): Parameter 'dispatch' implicitly has an 'any' type.
 export const updatePages = () => async (dispatch, getState) => {
-        const appDispatch = useAppDispatch();
 	const state = getState();
 
 	const pagination = getTablePagination(state);
@@ -534,7 +531,7 @@ export const updatePages = () => async (dispatch, getState) => {
 			break;
 		}
 		case "acls": {
-			await appDispatch(fetchAcls());
+			await dispatch(fetchAcls());
 			dispatch(loadAclsIntoTable());
 			break;
 		}


### PR DESCRIPTION
Fixes #245, which was caused by #214.

Those thunks are likely passed to a `useReducer` somewhere, so we can't have hooks here. We will still want to use useAppDispatch here eventually, but it can wait until we migrated everything else to redux toolkit and can finally get to the tables.