### PR TITLE
Remove redux persist

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -40,7 +40,6 @@
     "react-select": "^5.7.3",
     "redux": "^4.2.1",
     "redux-devtools-extension": "^2.13.9",
-    "redux-persist": "^6.0.0",
     "redux-thunk": "^2.4.2",
     "reselect": "^4.1.8",
     "styled-components": "^5.3.10",

--- a/app/src/index.tsx
+++ b/app/src/index.tsx
@@ -5,8 +5,6 @@ import App from "./App";
 import * as serviceWorker from "./serviceWorker";
 
 // redux imports
-import { persistStore } from "redux-persist";
-import { PersistGate } from "redux-persist/lib/integration/react";
 import { Provider } from "react-redux";
 import store from "./store";
 
@@ -17,15 +15,10 @@ import "./i18n/i18n";
 import "font-awesome/css/font-awesome.min.css";
 import "react-datepicker/dist/react-datepicker.css";
 
-// todo: comment persistent stuff in, only out commented because for debugging purposes
-const persistor = persistStore(store);
-
 ReactDOM.render(
 	<React.StrictMode>
 		<Provider store={store}>
-			<PersistGate loading={<div>loading...</div>} persistor={persistor}>
-				<App />
-			</PersistGate>
+			<App />
 		</Provider>
 	</React.StrictMode>,
 	document.getElementById("root")


### PR DESCRIPTION
Aims to resolve #231

Redux persist in its current form is causing to many problems to keep it around. Therefore this simply
removes it.

The most common problem with redux persist is
that users make changes to configuration, which
are then not taken over into the ui as they are blocked by the existing redux state. This can also happen
when new versions of the ui are released. Resolving this requires a hard page reload which is simply un- userfriendly.

Whatever efficiency benefits redux persist may bring, they are not worth requiring clearing your browser cache every other day.