### PR TITLE
Replace logout request with redirect

### DIFF
--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -41,15 +41,7 @@ function changeLanguage(code) {
 }
 
 function logout() {
-	axios
-		.get("/j_spring_security_logout")
-		.then((response) => {
-			console.info(response);
-			window.location.reload();
-		})
-		.catch((response) => {
-			console.error(response);
-		});
+	window.location.href = "/j_spring_security_logout";
 }
 
 /**


### PR DESCRIPTION
Restore the old logout procedure by redirecting to `/j_spring_security_logout`, which is required for SAML2 logout.

https://github.com/opencast/opencast/issues/5612