### PR TITLE
Fix user not having access to created event

### DIFF
--- a/app/src/components/events/partials/wizards/NewEventWizard.tsx
+++ b/app/src/components/events/partials/wizards/NewEventWizard.tsx
@@ -22,6 +22,7 @@ import {
 } from "../../../../selectors/eventSelectors";
 import { useAppDispatch, useAppSelector } from "../../../../store";
 import { postNewEvent } from "../../../../slices/eventSlice";
+import { getUserInformation } from "../../../../selectors/userInfoSelectors";
 
 // Get info about the current language and its date locale
 const currentLanguage = getCurrentLanguageInformation();
@@ -39,11 +40,13 @@ const NewEventWizard: React.FC<{
 	const uploadAssetOptions = useAppSelector(state => getAssetUploadOptions(state));
 	const metadataFields = useAppSelector(state => getEventMetadata(state));
 	const extendedMetadata = useAppSelector(state => getExtendedEventMetadata(state));
+	const user = useAppSelector(state => getUserInformation(state));
 
 	const initialValues = getInitialValues(
 		metadataFields,
 		extendedMetadata,
-		uploadAssetOptions
+		uploadAssetOptions,
+		user
 	);
 	let workflowPanelRef = React.useRef();
 
@@ -237,7 +240,9 @@ const getInitialValues = (
 // @ts-expect-error TS(7006): Parameter 'extendedMetadata' implicitly has an 'an... Remove this comment to see the full error message
 	extendedMetadata,
 // @ts-expect-error TS(7006): Parameter 'uploadAssetOptions' implicitly has an '... Remove this comment to see the full error message
-	uploadAssetOptions
+	uploadAssetOptions,
+// @ts-expect-error TS(7006): Parameter 'uploadAssetOptions' implicitly has an '... Remove this comment to see the full error message
+	user
 ) => {
 	// Transform metadata fields provided by backend (saved in redux)
 	let initialValues = getInitialMetadataFieldValues(
@@ -310,6 +315,16 @@ const getInitialValues = (
 	initialValues["scheduleEndHour"] = (defaultDate.getHours() + 1).toString();
 // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
 	initialValues["scheduleEndMinute"] = "55";
+
+// @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+	initialValues["acls"] = [
+		{
+			role: user.userRole,
+			read: true,
+			write: true,
+			actions: [],
+		},
+	];
 
 	return initialValues;
 };

--- a/app/src/components/events/partials/wizards/NewSeriesWizard.tsx
+++ b/app/src/components/events/partials/wizards/NewSeriesWizard.tsx
@@ -15,6 +15,7 @@ import { NewSeriesSchema } from "../../../../utils/validate";
 import { getInitialMetadataFieldValues } from "../../../../utils/resourceUtils";
 import { useAppDispatch, useAppSelector } from "../../../../store";
 import { postNewSeries } from "../../../../slices/seriesSlice";
+import { getUserInformation } from "../../../../selectors/userInfoSelectors";
 
 /**
  * This component manages the pages of the new series wizard and the submission of values
@@ -28,8 +29,9 @@ const NewSeriesWizard: React.FC<{
 
 	const metadataFields = useAppSelector(state => getSeriesMetadata(state));
 	const extendedMetadata = useAppSelector(state => getSeriesExtendedMetadata(state));
+	const user = useAppSelector(state => getUserInformation(state));
 
-	const initialValues = getInitialValues(metadataFields, extendedMetadata);
+	const initialValues = getInitialValues(metadataFields, extendedMetadata, user);
 
 	const [page, setPage] = useState(0);
 	const [snapshot, setSnapshot] = useState(initialValues);
@@ -179,7 +181,7 @@ const NewSeriesWizard: React.FC<{
 };
 
 // @ts-expect-error TS(7006): Parameter 'metadataFields' implicitly has an 'any'... Remove this comment to see the full error message
-const getInitialValues = (metadataFields, extendedMetadata) => {
+const getInitialValues = (metadataFields, extendedMetadata, user) => {
 	// Transform metadata fields provided by backend (saved in redux)
 	let initialValues = getInitialMetadataFieldValues(
 		metadataFields,
@@ -191,6 +193,16 @@ const getInitialValues = (metadataFields, extendedMetadata) => {
 // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
 		initialValues[key] = value;
 	}
+
+// @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+	initialValues["acls"] = [
+		{
+			role: user.userRole,
+			read: true,
+			write: true,
+			actions: [],
+		},
+	];
 
 	return initialValues;
 };

--- a/app/src/configs/modalConfig.ts
+++ b/app/src/configs/modalConfig.ts
@@ -24,14 +24,7 @@ export const initialFormValuesNewEvents = {
 	processingWorkflow: "",
 	configuration: {},
 	aclTemplate: "",
-	acls: [
-		{
-			role: "ROLE_USER_ADMIN",
-			read: true,
-			write: true,
-			actions: [],
-		},
-	],
+	acls: [],
 };
 
 // constants for hours and minutes (used in selection for start/end time and duration)
@@ -76,14 +69,7 @@ export const WORKFLOW_UPLOAD_ASSETS_NON_TRACK = "publish-uploaded-assets";
 // All fields for new series form that are fix and not depending on response of backend
 // InitialValues of Formik form (others computed dynamically depending on responses from backend)
 export const initialFormValuesNewSeries = {
-	acls: [
-		{
-			role: "ROLE_USER_ADMIN",
-			read: true,
-			write: true,
-			actions: [],
-		},
-	],
+	acls: [],
 	theme: "",
 };
 


### PR DESCRIPTION
When creating a new event (or series), the access tab will suggest to create it with the role `ROLE_USER_ADMIN`. If you are not an admin, this means you won't be able to access the created event later on.

Instead of always setting `ROLE_USER_ADMIN` as the default, this tries to get the user role from `/info/me.json` instead and suggest that as the default. Should be more in line with how it works in the old admin ui too