### PR TITLE
Fix unique key issue in new event summary page

### DIFF
--- a/app/src/components/events/partials/wizards/summaryTables/MetadataExtendedSummaryTable.tsx
+++ b/app/src/components/events/partials/wizards/summaryTables/MetadataExtendedSummaryTable.tsx
@@ -81,7 +81,7 @@ const MetadataExtendedSummaryTable = ({
 			<header className="no-expand">{t(header)}</header>
 			<div className="obj-container">
 				{catalogs.map((catalog, key) => (
-					<table className="main-tbl">
+					<table key={key} className="main-tbl">
 						<tbody>
 							{catalog.map((entry, key) => (
 								<tr key={key}>


### PR DESCRIPTION
Fixes a web console complaint about missing unique keys in the summary page for new events and series, which could have potentially caused bugs if you were jumping between tabs and making changes a lot.