### PR TITLE
Fix the release script for macOS

### DIFF
--- a/.github/build-release.sh
+++ b/.github/build-release.sh
@@ -6,6 +6,6 @@ rm -rf build/
 export PUBLIC_URL=/admin-ui
 CI=false npm run build
 
-FILENAME="oc-admin-ui-$(date --utc +%F).tar.gz"
+FILENAME="oc-admin-ui-$(date -u +%F).tar.gz"
 cd build
 tar -czf ../$FILENAME *


### PR DESCRIPTION
`date --utc` is not POSIX and macOS doesn't have it. `-u` is the standard equivalent.