### PR TITLE
Remove `wait` option from `react-i18next` initialization

### DIFF
--- a/app/src/i18n/i18n.ts
+++ b/app/src/i18n/i18n.ts
@@ -61,7 +61,6 @@ const resources = {
 };
 
 // Configuration of i18next
-// @ts-expect-error TS(2769): No overload matches this call.
 i18n
 	.use(Backend)
 	.use(LanguageDetector)
@@ -82,7 +81,6 @@ i18n
 			},
 		},
 		react: {
-			wait: true,
 			useSuspense: false,
 		},
 	});


### PR DESCRIPTION
This option never did anything in any version we ever used.