### PR TITLE
Select correct workflows for Start Task

### DIFF
--- a/app/src/components/events/partials/ModalTabsAndPages/StartTaskWorkflowPage.tsx
+++ b/app/src/components/events/partials/ModalTabsAndPages/StartTaskWorkflowPage.tsx
@@ -34,7 +34,7 @@ const StartTaskWorkflowPage = <T extends RequiredFormProps>({
 
 	useEffect(() => {
 		// Load workflow definitions for selecting
-		dispatch(fetchWorkflowDef("default"));
+		dispatch(fetchWorkflowDef("tasks"));
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 


### PR DESCRIPTION
Currently we show workflows for the tags `schedule` and `upload` in the Start Task modal, when we want to show those with `archive`.