### PR TITLE
Simplify dependencies for the dev servers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,7 @@
         "nodemon": "^3.0.3",
         "react-app-rewired": "2.2.1",
         "react-dev-utils": "^12.0.1",
-        "request-digest": "^1.0.13"
-      },
-      "devDependencies": {
+        "request-digest": "^1.0.13",
         "url-parse": "^1.5.10"
       }
     },

--- a/package.json
+++ b/package.json
@@ -17,9 +17,7 @@
     "nodemon": "^3.0.3",
     "react-app-rewired": "2.2.1",
     "react-dev-utils": "^12.0.1",
-    "request-digest": "^1.0.13"
-  },
-  "devDependencies": {
+    "request-digest": "^1.0.13",
     "url-parse": "^1.5.10"
   }
 }


### PR DESCRIPTION
The distinction between normal and dev dependencies doesn't make sense for this kind of "dev server project."