### PR TITLE
Fix the `server` `npm`-script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "staticServer.js",
   "scripts": {
     "client": "cd app && npm start",
-    "server": "nodemon server.js",
+    "server": "nodemon",
     "start": "npm run server & npm run client",
     "proxy-server": "nodemon proxyServer.js $npm_config_host $npm_config_username $npm_config_password"
   },


### PR DESCRIPTION
`server.js` does not exist. (Anymore?)
The command worked anyway because `nodemon` just ignores it and then goes on to run whatever `main` points to, but this is still misleading.