### PR TITLE
extend dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,26 @@
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: monthly
-    time: "04:00"
-  open-pull-requests-limit: 15
-  labels:
-    - dependencies
+
+  # GHA
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+
+  # Javascript
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: monthly
+      time: "04:00"
+    open-pull-requests-limit: 15
+    labels:
+      - dependencies
+  - package-ecosystem: npm
+    directory: "/app"
+    schedule:
+      interval: montly
+      time: "04:00"
+    open-pull-requests-limit: 15
+    labels:
+      - dependencies


### PR DESCRIPTION
Currently, dependabot only informs us about dependency updates in our root package.json. It should also inform us about dependency updates in our app/package.json.

This also updates GitHub Actions.

Fixes #318