### PR TITLE
Update Node.js to current LTS

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -13,10 +13,10 @@ jobs:
       - name: checkout code
         uses: actions/checkout@v3
 
-      - name: use node.js 16.x
+      - name: get node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
 
       - name: download dependencies
         run: npm ci


### PR DESCRIPTION
This patch updates the Node.js version used for creating releases to the current LTS version which is Node.js 20.