### PR TITLE
Fail on warnings when building releases

### DIFF
--- a/.github/build-release.sh
+++ b/.github/build-release.sh
@@ -4,7 +4,7 @@
 cd ../app
 rm -rf build/
 export PUBLIC_URL=/admin-ui
-CI=false npm run build
+npm run build
 
 FILENAME="oc-admin-ui-$(date -u +%F).tar.gz"
 cd build


### PR DESCRIPTION
This patch removes the forced `CI=false` which means that the build process will fail on compiler warnings.