### PR TITLE
Document and link translation rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ repository yourself.
 
 Translating the Admin UI
 -------------
-TBA
+You can help translating the editor to your language on [crowdin.com/project/opencast-admin-interface](https://crowdin.com/project/opencast-admin-interface). Simply request to join the project on Crowdin and start translating. If you are interested in translating a language which is not a target language right now, please create [a GitHub issue](https://github.com/opencast/opencast-admin-interface/issues) and we will add the language.
+
+This project follows the general form of [Opencast's Localization Process](https://docs.opencast.org/develop/developer/#participate/localization/), especially regarding what happens when you need to [change an existing translation key](https://docs.opencast.org/develop/developer/#participate/localization/#i-need-to-update-the-wording-of-the-source-translation-what-happens).  Any questions not answered there should be referred to the mailing lists!
 
 
 


### PR DESCRIPTION
https://github.com/opencast/opencast/pull/5769 will soon add a section to the upstream translation docs regarding how to edit keys.  I took the liberty of copying the rest of the translation bits from the editor over here while I was linking things.
