### PR TITLE
Fix unique key issue in WizzardStepper

### DIFF
--- a/src/components/shared/wizard/WizardStepper.tsx
+++ b/src/components/shared/wizard/WizardStepper.tsx
@@ -69,8 +69,7 @@ const WizardStepper = ({
 			connector={false}
 			className={cn("step-by-step", classes.root)}
 		>
-			{steps.map((label, key) =>
-				!label.hidden ? (
+			{steps.filter(step => !step.hidden).map((label, key) => (
 					<Step key={label.translation} completed={completed[key]}>
 						<StepButton onClick={() => handleOnClick(key)} disabled={disabled}>
 							<StepLabel StepIconComponent={CustomStepIcon}>
@@ -78,8 +77,7 @@ const WizardStepper = ({
 							</StepLabel>
 						</StepButton>
 					</Step>
-				) : <></>
-			)}
+			))}
 		</Stepper>
 	);
 };

--- a/src/components/shared/wizard/WizardStepperEvent.tsx
+++ b/src/components/shared/wizard/WizardStepperEvent.tsx
@@ -62,8 +62,7 @@ const WizardStepperEvent = ({
 			connector={false}
 			className={cn("step-by-step", classes.root)}
 		>
-			{steps.map((label, key) =>
-				!label.hidden ? (
+			{steps.filter(step => !step.hidden).map((label, key) => (
 					<Step key={label.translation} completed={completed[key]}>
 						<StepButton onClick={() => handleOnClick(key)}>
 							<StepLabel StepIconComponent={CustomStepIcon}>
@@ -71,8 +70,7 @@ const WizardStepperEvent = ({
 							</StepLabel>
 						</StepButton>
 					</Step>
-				) : <></>
-			)}
+			))}
 		</Stepper>
 	);
 };


### PR DESCRIPTION
Fixes a web console complaint about missing unique keys in the WizzardSteppers. I deem using .filter() a nicer solution than a ternary operator that checks if the hidden property of the current label object is false and rendering an empty fragment. This is probably also what made the console unhappy.