### PR TITLE
Harmonize date rendering between read-only and read/write fields

### DIFF
--- a/app/src/components/events/partials/ModalTabsAndPages/DetailsMetadataTab.tsx
+++ b/app/src/components/events/partials/ModalTabsAndPages/DetailsMetadataTab.tsx
@@ -4,13 +4,13 @@ import { Field, Formik } from "formik";
 import cn from "classnames";
 import _ from "lodash";
 import Notifications from "../../../shared/Notifications";
+import RenderDate from "../../../shared/RenderDate";
 import RenderMultiField from "../../../shared/wizard/RenderMultiField";
 import RenderField from "../../../shared/wizard/RenderField";
 import { getUserInformation } from "../../../../selectors/userInfoSelectors";
 import { getCurrentLanguageInformation, hasAccess, isJson } from "../../../../utils/utils";
 import { getMetadataCollectionFieldName } from "../../../../utils/resourceUtils";
 import { useAppSelector } from "../../../../store";
-import { parseISO } from "date-fns";
 
 /**
  * This component renders metadata details of a certain event or series
@@ -128,7 +128,7 @@ const DetailsMetadataTab: React.FC<{
 																) : (
 																	<td>{
 																		field.type === "time" || field.type === "date"
-																			? parseISO(field.value).toLocaleString(currentLanguage?.dateLocale.code, { timeZone: 'UTC' })
+																			? <RenderDate date={field.value} />
 																			: field.value
 																	}</td>
 																)

--- a/app/src/components/shared/RenderDate.tsx
+++ b/app/src/components/shared/RenderDate.tsx
@@ -1,0 +1,8 @@
+import { useTranslation } from "react-i18next";
+
+const RenderDate: React.FC<{ date: string }> = ({ date }) => {
+    const { t } = useTranslation();
+    return <>{t("dateFormats.dateTime.short", { dateTime: new Date(date) })}</>;
+};
+
+export default RenderDate;

--- a/app/src/components/shared/wizard/RenderField.tsx
+++ b/app/src/components/shared/wizard/RenderField.tsx
@@ -6,6 +6,7 @@ import { useClickOutsideField } from "../../../hooks/wizardHooks";
 import { isJson } from "../../../utils/utils";
 import { getMetadataCollectionFieldName } from "../../../utils/resourceUtils";
 import DropDown from "../DropDown";
+import RenderDate from "../RenderDate";
 import { parseISO } from "date-fns";
 
 const childRef = React.createRef<HTMLDivElement>();
@@ -210,7 +211,7 @@ const EditableDateValue = ({
 	) : (
 		<div onClick={() => setEditMode(true)} className="show-edit">
 			<span className="editable preserve-newlines">
-				{t("dateFormats.dateTime.short", { dateTime: new Date(text) }) || ""}
+				<RenderDate date={text} />
 			</span>
 			<div>
 				<i className="edit fa fa-pencil-square" />


### PR DESCRIPTION
Metadata fields, that is. This expands on f62e5dac7b5bd080b067b0b7cdc9e4bb74950d22 (itself a late addition to #277) and fixes a time drift between the read-only "Created" field and the non-edit-mode variant of the Start field (the values of which are synchronized) caused by the two methods of formatting interpreting the source date in different timezones.