### PR TITLE
Further simplify the static file server

### DIFF
--- a/staticServer.js
+++ b/staticServer.js
@@ -2,24 +2,26 @@ const path = require("path");
 const express = require("express");
 
 const app = express();
-const port = process.env.PORT || 5000;
 
-app.get("/*", express.static(path.join(__dirname, "test/app/GET")));
+for (const method of ["post", "put", "delete"]) {
+    app[method]("/*", (req, res, next) => {
+        setTimeout(next, 1000);
+    });
+}
 
 app.post("/*", (req, res, next) => {
     res.status(201);
     next();
 });
 
-const serveStatic = (req, res) => {
-    const filePath = path.join(__dirname, "test/app", req.method.toUpperCase(), req.url);
-    setTimeout(() => {
-        res.sendFile(filePath);
-    }, 1000);
-};
+app.use("/", [
+    (req, res, next) => {
+        req.url = `/${req.method}${req.url}`;
+        req.method = "GET";
+        next();
+    },
+    express.static(path.join(__dirname, "test/app"))
+]);
 
-for (const method of ["put", "post", "delete"]) {
-    app[method]("/*", serveStatic);
-}
-
+const port = process.env.PORT || 5000;
 app.listen(port, () => console.log(`Listing on port ${port}`));


### PR DESCRIPTION
This avoids having to poorly reimplement `express.static` using some internal request rewriting logic.