### PR TITLE
add typing and fix build

### DIFF
--- a/app/src/components/shared/Table.tsx
+++ b/app/src/components/shared/Table.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-// @ts-expect-error TS(7016): Could not find a declaration file for module 'styl... Remove this comment to see the full error message
 import styled from "styled-components";
 import {
 	getPageOffset,
@@ -46,7 +45,7 @@ const SortIcon = styled.i`
 	background-image: url(${sortIcon});
 `;
 
-const SortActiveIcon = styled.i`
+const SortActiveIcon = styled.i<{order: string}>`
     float: right;
     margin: 12px 0 0 5px;
     top: auto;


### PR DESCRIPTION
Currently, the build fails with:

```
TS2578: Unused '@ts-expect-error' directive.
    1 | import React, { useEffect, useState } from "react";
    2 | import { useTranslation } from "react-i18next";
  > 3 | // @ts-expect-error TS(7016): Could not find a declaration file for module 'styl... Remove this comment to see the full error message
      | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    4 | import styled from "styled-components";
    5 | import {
    6 | 	getPageOffset,

```

And running the admin-ui fails with:

```
ERROR in src/components/shared/Table.tsx:236:28
TS2769: No overload matches this call.
  Overload 1 of 2, '(props: PolymorphicComponentProps<"web", FastOmit<DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>, never>, void, void, {}, {}>): Element', gave the following error.
    Type '{ order: any; }' is not assignable to type 'IntrinsicAttributes & FastOmit<Substitute<FastOmit<DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>, never>, FastOmit<...>>, keyof ExecutionProps> & FastOmit<...> & { ...; }'.
      Property 'order' does not exist on type 'IntrinsicAttributes & FastOmit<Substitute<FastOmit<DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>, never>, FastOmit<...>>, keyof ExecutionProps> & FastOmit<...> & { ...; }'.
  Overload 2 of 2, '(props: FastOmit<DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>, never>): ReactElement<any, string | JSXElementConstructor<...>> | null', gave the following error.
    Type '{ order: any; }' is not assignable to type 'IntrinsicAttributes & FastOmit<DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>, never>'.
      Property 'order' does not exist on type 'IntrinsicAttributes & FastOmit<DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>, never>'.
    234 | 										<span>{t(column.label)}</span>
    235 | 										{!!sortBy && column.name === sortBy ? (
  > 236 | 											<SortActiveIcon order={reverse} />
        | 											                ^^^^^
    237 | 										) : (
    238 | 											<SortIcon />
    239 | 										)}

```