### PR TITLE
Automatically deploy new Crowdin keys

### DIFF
--- a/.github/workflows/crowdin-deploy-keys.yml
+++ b/.github/workflows/crowdin-deploy-keys.yml
@@ -1,0 +1,28 @@
+name: Deploy Crowdin keys
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: crowdin-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-translation-keys:
+    if: github.repository_owner == 'opencast'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: prepare crowdin client
+      run: |
+        wget --quiet https://artifacts.crowdin.com/repo/deb/crowdin3.deb
+        sudo dpkg -i crowdin3.deb
+
+    - name: upload translation source
+      env:
+        CROWDIN_TOKEN: ${{ secrets.CROWDIN_TOKEN }}
+      run: |
+        crowdin upload sources --config .crowdin.yaml -b main


### PR DESCRIPTION
This patch adds a new GitHub Actions workflow which will automatically update the translation keys on Crowdin in patches gets merged.