### PR TITLE
Better naming for Crowdin workflows

### DIFF
--- a/.github/workflows/crowdin-download-translations.yml
+++ b/.github/workflows/crowdin-download-translations.yml
@@ -30,14 +30,7 @@ jobs:
 
       - name: add new translations
         run: |
-          git add /src/i18n/org/opencastproject/adminui/languages/
-
-      - name: update language list
-        working-directory: /src/i18n/org/opencastproject/adminui/languages/
-        run: |
-          echo -n '[ "' > locales.json
-          echo -n ??-??.json | sed 's/  */", "/g' >> locales.json
-          echo '" ]' >> locales.json
+          git add src/i18n/org/opencastproject/adminui/languages/
 
       - name: upload translations
         run: |

--- a/.github/workflows/crowdin-download-translations.yml
+++ b/.github/workflows/crowdin-download-translations.yml
@@ -16,24 +16,29 @@ jobs:
         run: |
           git config --global user.email 'crowdin-bot@opencast.org'
           git config --global user.name 'Crowdin Bot'
+
       - name: prepare crowdin client
         run: |
           wget --quiet https://artifacts.crowdin.com/repo/deb/crowdin3.deb -O crowdin.deb
           sudo dpkg -i crowdin.deb
+
       - name: download translations
         env:
           CROWDIN_TOKEN: ${{ secrets.CROWDIN_TOKEN }}
         run: |
-          crowdin download --config .crowdin.yaml -b admin-ui-picard
+          crowdin download --config .crowdin.yaml -b main
+
       - name: add new translations
         run: |
           git add /src/i18n/org/opencastproject/adminui/languages/
+
       - name: update language list
         working-directory: /src/i18n/org/opencastproject/adminui/languages/
         run: |
           echo -n '[ "' > locales.json
           echo -n ??-??.json | sed 's/  */", "/g' >> locales.json
           echo '" ]' >> locales.json
+
       - name: upload translations
         run: |
           if git commit -m "Automatically update translation keys"; then

--- a/.github/workflows/crowdin-download-translations.yml
+++ b/.github/workflows/crowdin-download-translations.yml
@@ -1,4 +1,4 @@
-name: Update translations
+name: Crowdin » Download translations
 
 on:
   schedule:

--- a/.github/workflows/crowdin-upload-keys.yml
+++ b/.github/workflows/crowdin-upload-keys.yml
@@ -1,4 +1,4 @@
-name: Deploy Crowdin keys
+name: Crowdin » Upload keys
 
 on:
   push:


### PR DESCRIPTION
Let all GitHub Actions workflow definitions for Crowdin…

- have a filename starting with `crowdin-…`
- Have a name starting with `Crowdin » `