### PR TITLE
add i18n for EVENTS.RECORDINGS.TABLE.CAPTION

### DIFF
--- a/app/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/app/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
@@ -1039,6 +1039,11 @@
 				}
 			}
 		},
+		"RECORDINGS": {
+			"TABLE": {
+				"CAPTION": "Locations"
+			}
+		},
 		"SERIES": {
 			"NEW": {
 				"CAPTION": "Create series",


### PR DESCRIPTION
Fixes #414

_Rant: Why does the 'Locations' screen live under 'recordings'?_