### PR TITLE
Automatically Deploy Demo Page

### DIFF
--- a/.github/demo-page.html
+++ b/.github/demo-page.html
@@ -1,0 +1,10 @@
+﻿<!DOCTYPE html>
+<html lang=en>
+<head>
+<meta http-equiv=content-type content="text/html; charset=utf-8" />
+<meta http-equiv=refresh content="0; url=/admin-ui/index.html">
+</head>
+<body>
+  <a href=/admin-ui/index.html>to admin interface →</a>
+</body>
+</html>

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,65 @@
+name: Publish Test Page
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v4
+
+      - name: get node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: download dependencies
+        working-directory: ./app
+        run: npm ci
+
+      - name: build project
+        working-directory: ./app
+        env:
+          CI: false
+        run: npm run build
+
+      - name: create pages directory
+        working-directory: ./app
+        run: mkdir gh-pages
+
+      - name: include admin intterface
+        working-directory: ./app
+        run: mv build gh-pages/admin-ui
+
+      - name: include mock data
+        working-directory: ./app/gh-pages
+        run: cp -rv ../../test/app/GET/* .
+
+      - name: include landing page
+        run: cp .github/demo-page.html app/gh-pages/index.html
+
+      - name: upload test page artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./app/gh-pages
+
+  deploy:
+    needs: build
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,34 +18,30 @@ jobs:
           node-version: 20
 
       - name: download dependencies
-        working-directory: ./app
         run: npm ci
 
       - name: build project
-        working-directory: ./app
         env:
           CI: false
         run: npm run build
 
       - name: create pages directory
-        working-directory: ./app
         run: mkdir gh-pages
 
-      - name: include admin intterface
-        working-directory: ./app
+      - name: include admin interface
         run: mv build gh-pages/admin-ui
 
       - name: include mock data
-        working-directory: ./app/gh-pages
-        run: cp -rv ../../test/app/GET/* .
+        working-directory: ./gh-pages
+        run: cp -rv ../test/app/GET/* .
 
       - name: include landing page
-        run: cp .github/demo-page.html app/gh-pages/index.html
+        run: cp .github/demo-page.html gh-pages/index.html
 
       - name: upload test page artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./app/gh-pages
+          path: ./gh-pages
 
   deploy:
     needs: build


### PR DESCRIPTION
This patch deploys the latest version of the admin interface to GitHub Pages (admin-interface.opencast.org). The mock data are deployed so that they can be used for `GET` requests.