### PR TITLE
Add module declarations for svg and png ressources

### DIFF
--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -1,0 +1,2 @@
+declare module "*.svg";
+declare module "*.png";

--- a/src/i18n/languages.ts
+++ b/src/i18n/languages.ts
@@ -43,8 +43,7 @@ import { zhCN } from "date-fns/locale/zh-CN";
  * dateLocale: is needed for translation in datepicker
  *
  * !!! If a translation file of a new language was added, please insert these language here, too !!!
- *
- * */
+ */
 const languages = [
 	{
 		code: "en-US",


### PR DESCRIPTION
Removes a bunch of `ts-expect-error`:

```
// @ts-expect-error TS(2307): Cannot find module '../img/*.svg' or
// @ts-expect-error TS(2307): Cannot find module '../../img/*.png' or
```