### PR TITLE
Fix mock data file path after project restructuring

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: include mock data
         working-directory: ./gh-pages
-        run: cp -rv ../test/app/GET/* .
+        run: cp -rv ../test/GET/* .
 
       - name: include landing page
         run: cp .github/demo-page.html gh-pages/index.html


### PR DESCRIPTION
With the changes introduced by #399 als the mock data was moved.