### PR TITLE
Remove asset type + flavor from source upload

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/NewAssetUploadPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewAssetUploadPage.tsx
@@ -69,11 +69,6 @@ const NewAssetUploadPage = <T extends RequiredFormProps>({
 													<td>
 														{" "}
 														{translateOverrideFallback(asset, t)}
-														<span className="ui-helper-hidden">
-                              { // eslint-disable-next-line react/jsx-no-comment-textnodes
-                              } ({asset.type} "{asset.flavorType}//
-															{asset.flavorSubType}")
-														</span>
 													</td>
 													<td>
 														<div className="file-upload">

--- a/src/components/events/partials/ModalTabsAndPages/NewSourcePage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewSourcePage.tsx
@@ -295,10 +295,6 @@ const Upload = ({ formik }) => {
 												<span style={{ fontWeight: "bold" }}>
 													{translateOverrideFallback(asset, t, "SHORT")}
 												</span>
-												<span className="ui-helper-hidden">
-													({asset.type} "{asset.flavorType}/
-													{asset.flavorSubType}")
-												</span>
 												<p>
 													{translateOverrideFallback(asset, t, "DETAIL")}
 												</p>


### PR DESCRIPTION
Removes superfluous information in the source upload and asset upload of the "Create Event" dialog. The information in question concerns the asset type (e.g. track) and flavor.

Reasoning:
- The current formatting of the info obfsucates the dialog, making it hard to parse at a glance.
- The info is not needed. Technical users will either know this by heart or can easily look it up in the rare case they need it, and for less technical users the title and description for each asset should be more than sufficient. (And in case they are not, title and description should be improved).

Looks like:
![Bildschirmfoto vom 2024-05-27 09-56-58](https://github.com/opencast/opencast-admin-interface/assets/14070005/e4000472-6879-4966-934d-37d31a6735b8)


Helps with #465.