### PR TITLE
Automatically publish conatiner image

### DIFF
--- a/.github/workflows/deploy-container-image.yaml
+++ b/.github/workflows/deploy-container-image.yaml
@@ -1,0 +1,65 @@
+name: Publish container image
+
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+
+jobs:
+  container-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: echo "github.actor = ${{ github.actor }}"
+
+      - name: Log in to the container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+
+      - name: Build and push images
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Add comment
+        if: github.event_name == 'pull_request_target'
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          comment_tag: container-image
+          message: |
+            Use `docker` or `podman` to test this pull request locally.
+
+            Local test with mock data
+            ```
+            podman run --rm -it -p 127.0.0.1:3000:3000 ${{ steps.meta.outputs.tags }}
+            ```
+
+            Proxy data from develop.opencast.org
+            ```
+            podman run --rm -it -p 127.0.0.1:3000:3000 -e PROXY_TARGET=https://develop.opencast.org ${{ steps.meta.outputs.tags }}
+            ```
+
+            It may take a few seconds for the interface to spin up.
+            It will then be available at http://127.0.0.1:3000.
+            For more options you can pass on to the proxy, take a look at the `README.md`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:20
+EXPOSE 3000
+
+COPY . /admin-interface
+WORKDIR /admin-interface
+
+RUN npm ci
+
+ENV CI true
+CMD [ "npm", "start" ]


### PR DESCRIPTION
This patch adds a `Dockerfile` and a GitHub Actions workflow to automatically build and publish container images for every branch and pull request.

If the source is a pull request, the workflow will also add a comment to explain how this can be used to easily test this pull request:

> Use `docker` or `podman` to test this pull request locally.
>
> Local test with mock data
> ```
> podman run --rm -it -p 127.0.0.1:3000:3000 ghcr.io/lkiesow/opencast-admin-interface:pr-5
> ```
>
> Proxy data from develop.opencast.org
> ```
> podman run --rm -it -p 127.0.0.1:3000:3000 -e PROXY_TARGET=https://develop.opencast.org ghcr.io/lkiesow/opencast-admin-interface:pr-5
> ```
>
> It may take a few seconds for the interface to spin up.
> It will then be available at https://127.0.0.1:3000.


Right now, this will run on all pull requests [instead of just running on pull requests for members of the team Developer like we have for the Opencast Editor](https://github.com/opencast/opencast-editor/blob/baeb482490525ae06f3f942c060dec6d2f32664e/.github/workflows/update-test.yml#L11). We have to authorize unknown contributors anyway before GitHub runs workflows at all and we also only use the package repository for testing.