### PR TITLE
Fix tabbing in event details metadata

### DIFF
--- a/src/components/shared/wizard/RenderField.tsx
+++ b/src/components/shared/wizard/RenderField.tsx
@@ -33,9 +33,9 @@ const RenderField = ({
 	const handleKeyDown = (event, type) => {
 		const { key } = event;
 		// keys pressable for leaving edit mode
-		const keys = ["Escape", "Tab", "Enter"];
+		const keys = ["Escape", "Enter"];
 
-		if (type !== "textarea" && keys.indexOf(key) > -1) {
+		if ((type !== "textarea" || type !== "select") && keys.indexOf(key) > -1) {
 			setEditMode(false);
 		}
 	};
@@ -209,7 +209,7 @@ const EditableDateValue = ({
 			/>
 		</div>
 	) : (
-		<div onClick={() => setEditMode(true)} className="show-edit">
+		<div onFocus={() => setEditMode(true)} className="show-edit" tabIndex={0}>
 			<span className="editable preserve-newlines">
 				<RenderDate date={text} />
 			</span>
@@ -269,7 +269,7 @@ const EditableSingleSelect = ({
 			/>
 		</div>
 	) : (
-		<div onClick={() => setEditMode(true)} className="show-edit">
+		<div onFocus={() => setEditMode(true)} className="show-edit" tabIndex={0}>
 			<span className="editable preserve-newlines">
 				{text || t("SELECT_NO_OPTION_SELECTED")}
 			</span>
@@ -317,7 +317,7 @@ const EditableSingleValueTextArea = ({
 			/>
 		</div>
 	) : (
-		<div onClick={() => setEditMode(true)} className="show-edit">
+		<div onFocus={() => setEditMode(true)} className="show-edit" tabIndex={0}>
 			<span className="editable preserve-newlines">{text || ""}</span>
 			<div>
 				<i className="edit fa fa-pencil-square" />
@@ -359,7 +359,7 @@ const EditableSingleValue = ({
 			<input {...field} autoFocus={true} type="text" />
 		</div>
 	) : (
-		<div onClick={() => setEditMode(true)} className="show-edit">
+		<div onFocus={() => setEditMode(true)} className="show-edit" tabIndex={0}>
 			<span className="editable preserve-newlines">{text || ""}</span>
 			<div>
 				<i className="edit fa fa-pencil-square" />
@@ -417,7 +417,7 @@ const EditableSingleValueTime = ({
 			/>
 		</div>
 	) : (
-		<div onClick={() => setEditMode(true)} className="show-edit">
+		<div onFocus={() => setEditMode(true)} className="show-edit" tabIndex={0}>
 			<span className="editable preserve-newlines">
 				{t("dateFormats.dateTime.short", { dateTime: new Date(text) }) || ""}
 			</span>

--- a/src/components/shared/wizard/RenderMultiField.tsx
+++ b/src/components/shared/wizard/RenderMultiField.tsx
@@ -91,6 +91,7 @@ const RenderMultiField = ({
 						collection={fieldInfo.collection}
 						field={field}
 						fieldValue={fieldValue}
+						setEditMode={setEditMode}
 						inputValue={inputValue}
 						removeItem={removeItem}
 						handleChange={handleChange}
@@ -124,6 +125,8 @@ const RenderMultiField = ({
 
 // Renders multi select
 const EditMultiSelect = ({
+// @ts-expect-error TS(7031): Binding element 'setEditMode' implicitly has an 'a... Remove this comment to see the full error message
+	setEditMode,
 // @ts-expect-error TS(7031): Binding element 'collection' implicitly has an 'an... Remove this comment to see the full error message
 	collection,
 // @ts-expect-error TS(7031): Binding element 'handleKeyDown' implicitly has an ... Remove this comment to see the full error message
@@ -156,7 +159,7 @@ const EditMultiSelect = ({
 
 	return (
 		<>
-			<div ref={childRef}>
+			<div onBlur={() => setEditMode(false)} ref={childRef}>
 				<div>
 					<input
 						type="text"
@@ -252,7 +255,7 @@ const ShowValue : React.FC<{
 	fieldValue,
 }) => {
 	return (
-		<div onClick={() => setEditMode(true)} className="show-edit">
+		<div onFocus={() => setEditMode(true)} className="show-edit" tabIndex={0}>
 			{field.value instanceof Array && field.value.length !== 0 ? (
 				<ul>
 {/* @ts-expect-error TS(7006): Parameter 'item' implicitly has an 'any' type. */}


### PR DESCRIPTION
Reopening of #288 which was merged and then reverted due to errors.

This is currently breaking the metadata page in the event details as described in #288, so I'm putting it as a draft for now.

