### PR TITLE
Do not run the test deployment in any forks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build:
+    if: github.repository_owner == 'opencast'
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
@@ -44,6 +45,7 @@ jobs:
           path: ./gh-pages
 
   deploy:
+    if: github.repository_owner == 'opencast'
     needs: build
 
     permissions:


### PR DESCRIPTION
This fails with the following errors in any fork:

```
Creating Pages deployment failed

Error: Failed to create deployment (status: 404) with build version 8326e52345e0c9a44fd1240298c51a285a6a3bdc. Request ID 0889:2BD3DA:49E8F40:7FA0CE9:665601BC Ensure GitHub Pages has been enabled: https://github.com/ziegenberg/opencast-admin-interface/settings/pages


HttpError: Not Found
    at /home/runner/work/_actions/actions/deploy-pages/v4/node_modules/@octokit/request/dist-node/index.js:124:1
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at createPagesDeployment (/home/runner/work/_actions/actions/deploy-pages/v4/src/internal/api-client.js:125:1)
    at Deployment.create (/home/runner/work/_actions/actions/deploy-pages/v4/src/internal/deployment.js:74:1)
    at main (/home/runner/work/_actions/actions/deploy-pages/v4/src/index.js:30:1)

```