### PR TITLE
Add check-label workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    labels:
+      - type:github_actions
 
   # Javascript
   - package-ecosystem: npm
@@ -14,4 +16,4 @@ updates:
       interval: monthly
     open-pull-requests-limit: 15
     labels:
-      - dependencies
+      - type:dependencies

--- a/.github/workflows/check-label.yml
+++ b/.github/workflows/check-label.yml
@@ -1,0 +1,39 @@
+# This workflow runs on any change made to a pull-request and aims to verify
+# that the correct label is present.
+
+name: Check proper lable usage
+
+on:
+  pull_request_target:
+    types: [opened, labeled, unlabeled, synchronize]
+
+jobs:
+  labels:
+    runs-on: ubuntu-latest
+    steps:
+      # Ensure that one of the required labels is present and none of the undesired is absent
+      # See https://github.com/jesusvasquez333/verify-pr-label-action
+      - name: Verify PR label action
+        uses: jesusvasquez333/verify-pr-label-action@v1.4.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          valid-labels: >
+            type:accessibility,
+            type:bug,
+            type:code-enhancement,
+            type:dependencies,
+            type:documentation,
+            type:enhancement,
+            type:github_actions,
+            type:infrastructure,
+            type:security,
+            type:tests,
+            type:typing,
+            type:usability,
+            type:visual-clarity
+          invalid-labels: >
+            status:duplicate,
+            status:conflicts,
+            status:wontfix
+          pull-request-number: "${{ github.event.pull_request.number }}"
+          disable-reviews: true


### PR DESCRIPTION
ℹ️ This is a prerequisite for #491

This workflow runs on any change made to a pull request and aims to verify that the correct label is present. The correct label is required for release configuration in .github/release.yml.

The labels have been aligned with the ones used in the editor.

Helps with fixing #473