### PR TITLE
Use correct source for container image

### DIFF
--- a/.github/workflows/deploy-container-image.yaml
+++ b/.github/workflows/deploy-container-image.yaml
@@ -18,8 +18,9 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
-
-      - run: echo "github.actor = ${{ github.actor }}"
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Log in to the container registry
         uses: docker/login-action@v3


### PR DESCRIPTION
The workflow for building the test container images is triggered by `pull_request_target` which means that we explicitly need to state that we want to check out the pull request source code and not what is already in the repository.