### PR TITLE
Add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+test
+node_modules


### PR DESCRIPTION
This patch adds a `.dockerignore` file to exclude unnecessary files like the git history from the container images.