### PR TITLE
Set CI=true in all workflows

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -22,8 +22,6 @@ jobs:
         run: npm ci
 
       - name: build project
-        env:
-          CI: false
         run: npm run build
 
       - name: create pages directory

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -29,10 +29,9 @@ jobs:
         run: npm ci
 
       - name: build app
-        run: npm run build
         env:
           PUBLIC_URL: /${{ steps.build-path.outputs.build }}
-          CI: false
+        run: npm run build
 
       - name: prepare git
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,4 @@ jobs:
         run: npm ci
 
       - name: build project
-        env:
-          CI: false
         run: npm run build


### PR DESCRIPTION
As all the warnings on the build are now fixed (thx to #430), we no longer need to set `CI=false` to actively suppress warnings to be picked up by our CI tests. This should help with us not introducing new warnings.