### PR TITLE
Update @mui/material to 5.15.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hello-pangea/dnd": "^16.5.0",
-        "@mui/material": "^5.15.6",
+        "@mui/material": "^5.15.9",
         "@mui/styles": "^5.15.19",
         "@mui/x-date-pickers": "^6.19.0",
         "@reduxjs/toolkit": "^1.9.7",
@@ -1138,14 +1138,14 @@
       "peer": true
     },
     "node_modules/@mui/base": {
-      "version": "5.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.33.tgz",
-      "integrity": "sha512-WcSpoJUw/UYHXpvgtl4HyMar2Ar97illUpqiS/X1gtSBp6sdDW6kB2BJ9OlVQ+Kk/RL2GDp/WHA9sbjAYV35ow==",
+      "version": "5.0.0-beta.40",
+      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.40.tgz",
+      "integrity": "sha512-I/lGHztkCzvwlXpjD2+SNmvNQvB4227xBXhISPjEaJUXGImOQ9f3D2Yj/T3KasSI/h0MLWy74X0J6clhPmsRbQ==",
       "dependencies": {
-        "@babel/runtime": "^7.23.8",
-        "@floating-ui/react-dom": "^2.0.6",
-        "@mui/types": "^7.2.13",
-        "@mui/utils": "^5.15.6",
+        "@babel/runtime": "^7.23.9",
+        "@floating-ui/react-dom": "^2.0.8",
+        "@mui/types": "^7.2.14",
+        "@mui/utils": "^5.15.14",
         "@popperjs/core": "^2.11.8",
         "clsx": "^2.1.0",
         "prop-types": "^15.8.1"
@@ -1169,28 +1169,28 @@
       }
     },
     "node_modules/@mui/core-downloads-tracker": {
-      "version": "5.15.6",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.15.6.tgz",
-      "integrity": "sha512-0aoWS4qvk1uzm9JBs83oQmIMIQeTBUeqqu8u+3uo2tMznrB5fIKqQVCbCgq+4Tm4jG+5F7dIvnjvQ2aV7UKtdw==",
+      "version": "5.15.19",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.15.19.tgz",
+      "integrity": "sha512-tCHSi/Tomez9ERynFhZRvFO6n9ATyrPs+2N80DMDzp6xDVirbBjEwhPcE+x7Lj+nwYw0SqFkOxyvMP0irnm55w==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
       }
     },
     "node_modules/@mui/material": {
-      "version": "5.15.6",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.15.6.tgz",
-      "integrity": "sha512-rw7bDdpi2kzfmcDN78lHp8swArJ5sBCKsn+4G3IpGfu44ycyWAWX0VdlvkjcR9Yrws2KIm7c+8niXpWHUDbWoA==",
+      "version": "5.15.19",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.15.19.tgz",
+      "integrity": "sha512-lp5xQBbcRuxNtjpWU0BWZgIrv2XLUz4RJ0RqFXBdESIsKoGCQZ6P3wwU5ZPuj5TjssNiKv9AlM+vHopRxZhvVQ==",
       "dependencies": {
-        "@babel/runtime": "^7.23.8",
-        "@mui/base": "5.0.0-beta.33",
-        "@mui/core-downloads-tracker": "^5.15.6",
-        "@mui/system": "^5.15.6",
-        "@mui/types": "^7.2.13",
-        "@mui/utils": "^5.15.6",
+        "@babel/runtime": "^7.23.9",
+        "@mui/base": "5.0.0-beta.40",
+        "@mui/core-downloads-tracker": "^5.15.19",
+        "@mui/system": "^5.15.15",
+        "@mui/types": "^7.2.14",
+        "@mui/utils": "^5.15.14",
         "@types/react-transition-group": "^4.4.10",
         "clsx": "^2.1.0",
-        "csstype": "^3.1.2",
+        "csstype": "^3.1.3",
         "prop-types": "^15.8.1",
         "react-is": "^18.2.0",
         "react-transition-group": "^4.4.5"
@@ -1248,13 +1248,13 @@
       }
     },
     "node_modules/@mui/styled-engine": {
-      "version": "5.15.6",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.15.6.tgz",
-      "integrity": "sha512-KAn8P8xP/WigFKMlEYUpU9z2o7jJnv0BG28Qu1dhNQVutsLVIFdRf5Nb+0ijp2qgtcmygQ0FtfRuXv5LYetZTg==",
+      "version": "5.15.14",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.15.14.tgz",
+      "integrity": "sha512-RILkuVD8gY6PvjZjqnWhz8fu68dVkqhM5+jYWfB5yhlSQKg+2rHkmEwm75XIeAqI3qwOndK6zELK5H6Zxn4NHw==",
       "dependencies": {
-        "@babel/runtime": "^7.23.8",
+        "@babel/runtime": "^7.23.9",
         "@emotion/cache": "^11.11.0",
-        "csstype": "^3.1.2",
+        "csstype": "^3.1.3",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -1324,17 +1324,17 @@
       "integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ=="
     },
     "node_modules/@mui/system": {
-      "version": "5.15.6",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.15.6.tgz",
-      "integrity": "sha512-J01D//u8IfXvaEHMBQX5aO2l7Q+P15nt96c4NskX7yp5/+UuZP8XCQJhtBtLuj+M2LLyXHYGmCPeblsmmscP2Q==",
+      "version": "5.15.15",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.15.15.tgz",
+      "integrity": "sha512-aulox6N1dnu5PABsfxVGOZffDVmlxPOVgj56HrUnJE8MCSh8lOvvkd47cebIVQQYAjpwieXQXiDPj5pwM40jTQ==",
       "dependencies": {
-        "@babel/runtime": "^7.23.8",
-        "@mui/private-theming": "^5.15.6",
-        "@mui/styled-engine": "^5.15.6",
-        "@mui/types": "^7.2.13",
-        "@mui/utils": "^5.15.6",
+        "@babel/runtime": "^7.23.9",
+        "@mui/private-theming": "^5.15.14",
+        "@mui/styled-engine": "^5.15.14",
+        "@mui/types": "^7.2.14",
+        "@mui/utils": "^5.15.14",
         "clsx": "^2.1.0",
-        "csstype": "^3.1.2",
+        "csstype": "^3.1.3",
         "prop-types": "^15.8.1"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "/admin-ui",
   "dependencies": {
     "@hello-pangea/dnd": "^16.5.0",
-    "@mui/material": "^5.15.6",
+    "@mui/material": "^5.15.9",
     "@mui/styles": "^5.15.19",
     "@mui/x-date-pickers": "^6.19.0",
     "@reduxjs/toolkit": "^1.9.7",

--- a/src/components/shared/wizard/CustomStepIcon.tsx
+++ b/src/components/shared/wizard/CustomStepIcon.tsx
@@ -2,16 +2,12 @@ import { useStepIconStyles } from "../../../utils/wizardUtils";
 import cn from "classnames";
 import { FaCircle, FaDotCircle } from "react-icons/fa";
 import React from "react";
-
-type customStepIconProps = {
-	active: boolean,
-	completed: boolean,
-}
+import { StepIconProps } from "@mui/material";
 
 /**
  * Component that renders icons of Stepper depending on completeness of steps
  */
-const CustomStepIcon = (props: customStepIconProps) => {
+const CustomStepIcon = (props: StepIconProps) => {
 	const { completed } = props;
 	const classes = useStepIconStyles(props);
 

--- a/src/utils/wizardUtils.ts
+++ b/src/utils/wizardUtils.ts
@@ -1,3 +1,4 @@
+import { StepIconProps } from "@mui/material";
 import  makeStyles  from "@mui/styles/makeStyles";
 
 // Base style for Stepper component
@@ -10,10 +11,6 @@ export const useStepperStyle = makeStyles({
 });
 
 // Style of icons used in Stepper
-type stepIconStyleProps = {
-	active: boolean,
-	completed: boolean,
-}
 export const useStepIconStyles = makeStyles({
 	root: {
 		height: 22,
@@ -23,7 +20,7 @@ export const useStepIconStyles = makeStyles({
 		color: "#92a0ab",
 		width: "20px",
 		height: "20px",
-		transform: (props: stepIconStyleProps) => props.active ? "scale(1.3)" : "scale(1.0)",
+		transform: (props: StepIconProps) => props.active ? "scale(1.3)" : "scale(1.0)",
 	},
 });
 


### PR DESCRIPTION
Updates the dependency  @mui/material, by using provided the provided typing instead of our made up one.

Helps with #510.