### PR TITLE
External links in new pages

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -183,6 +183,7 @@ const Header = ({
 									href={
 										orgProperties["org.opencastproject.admin.mediamodule.url"]
 									}
+									target="_blank" rel="noreferrer"
 								>
 									<span className="fa fa-play-circle" />
 								</a>
@@ -192,7 +193,7 @@ const Header = ({
 					{/* Opencast Studio */}
 					{hasAccess("ROLE_STUDIO", user) && (
 						<div className="nav-dd" title="Studio">
-							<a href={studioURL}>
+							<a href={studioURL} target="_blank" rel="noreferrer">
 								<span className="fa fa-video-camera" />
 							</a>
 						</div>
@@ -382,6 +383,7 @@ const MenuHelp = ({
 									"org.opencastproject.admin.help.documentation.url"
 								]
 							}
+							target="_blank" rel="noreferrer"
 						>
 							<span>{t("HELP.DOCUMENTATION")}</span>
 						</a>
@@ -392,7 +394,7 @@ const MenuHelp = ({
 					hasAccess("ROLE_ADMIN", user) && (
 						<li>
 							<a
-								target="_self"
+								target="_blank" rel="noreferrer"
 								href={
 									orgProperties["org.opencastproject.admin.help.restdocs.url"]
 								}

--- a/src/components/events/partials/EventActionCell.tsx
+++ b/src/components/events/partials/EventActionCell.tsx
@@ -166,6 +166,7 @@ const EventActionCell = ({
 							? t("EVENTS.EVENTS.TABLE.TOOLTIP.EDITOR_NEEDS_CUTTING")
 							: t("EVENTS.EVENTS.TABLE.TOOLTIP.EDITOR")
 					}
+					target="_blank" rel="noreferrer"
 				>
 					{row.needs_cutting && <span id="badge" className="badge" />}
 				</a>

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetAttachmentDetails.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetAttachmentDetails.tsx
@@ -148,6 +148,7 @@ const EventDetailsAssetAttachmentDetails = ({
 												<a
 													className="fa fa-external-link"
 													href={attachment.url}
+													target="_blank" rel="noreferrer"
 												/>
 											</td>
 										</tr>

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetCatalogDetails.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetCatalogDetails.tsx
@@ -143,7 +143,7 @@ const EventDetailsAssetCatalogDetails = ({
 											</td>
 											<td>
 												{/* eslint-disable-next-line jsx-a11y/anchor-has-content */}
-												<a className="fa fa-external-link" href={catalog.url} />
+												<a className="fa fa-external-link" href={catalog.url} target="_blank" rel="noreferrer"/>
 											</td>
 										</tr>
 									</tbody>

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetMedia.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetMedia.tsx
@@ -80,7 +80,7 @@ const EventDetailsAssetMedia = ({
 										media.map((item, key) => (
 											<tr key={key}>
 												<td>
-													<a href={item.url}>{item.id}</a>
+													<a href={item.url} target="_blank" rel="noreferrer">{item.id}</a>
 												</td>
 												<td>{item.type}</td>
 												<td>{item.mimetype}</td>

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetMediaDetails.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetMediaDetails.tsx
@@ -139,7 +139,7 @@ const EventDetailsAssetMediaDetails = ({
 												}
 											</td>
 											<td>
-												<a href={media.url}>{media.url.split("?")[0]}</a>
+												<a href={media.url} target="_blank" rel="noreferrer">{media.url.split("?")[0]}</a>
 											</td>
 										</tr>
 									</tbody>

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetPublicationDetails.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetPublicationDetails.tsx
@@ -148,6 +148,7 @@ const EventDetailsAssetPublicationDetails = ({
 												<a
 													className="fa fa-external-link"
 													href={publication.url}
+													target="_blank" rel="noreferrer"
 												/>
 											</td>
 										</tr>

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsPublicationTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsPublicationTab.tsx
@@ -70,7 +70,7 @@ const EventDetailsPublicationTab = ({
 
 														{publication.enabled ? (
 															// eslint-disable-next-line jsx-a11y/anchor-has-content
-															<a className="play" href={publication.url} />
+															<a className="play" href={publication.url} target="_blank" rel="noreferrer"/>
 														) : (
 															<span style={styleSpan}>
 																{t(


### PR DESCRIPTION
This PR fixes #525
There are a few other places like feedback and feeds that are not included here, because they were not provided by default settings.
