### PR TITLE
Fix dialog button sizes and margin

### DIFF
--- a/src/styles/components/modals/_footer.scss
+++ b/src/styles/components/modals/_footer.scss
@@ -38,7 +38,8 @@
             @include btn(red);
         }
 
-        margin: 13px 15px 0;
+        min-width: 100px;
+        margin: 10px 3% 0 15px;
         display: inline-block;
         border-radius: $main-border-radius;
 

--- a/src/styles/components/modals/_wizard.scss
+++ b/src/styles/components/modals/_wizard.scss
@@ -24,7 +24,7 @@
 
     .cancel {
         float: left;
-        margin-left: 20px;
+        margin-left: 3%;
     }
 
     .inactive {


### PR DESCRIPTION
Fixes https://github.com/opencast/opencast-admin-interface/issues/486

Sets the buttons min-width to 100px and adjusts the spacing to the edges, so they line up with the elements above.