### PR TITLE
Show only one flavour separator in create event summary

### DIFF
--- a/src/components/events/partials/wizards/NewEventSummary.tsx
+++ b/src/components/events/partials/wizards/NewEventSummary.tsx
@@ -166,7 +166,7 @@ const NewEventSummary = <T extends RequiredFormProps>({
 															{translateOverrideFallback(asset, t, "SHORT")}
 															<span className="ui-helper-hidden">
                                 {/* eslint-disable-next-line react/jsx-no-comment-textnodes */}
-                                ({asset.type} "{asset.flavorType}//
+                                ({asset.type} "{asset.flavorType}/
 																{asset.flavorSubType}")
 															</span>
 														</td>


### PR DESCRIPTION
In the old version, two separators are displayed in the create event summary.

Closes #545