### PR TITLE
Persist table pagination settings

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -37,6 +37,7 @@ import autoMergeLevel2 from "redux-persist/lib/stateReconciler/autoMergeLevel2";
 // Configuration for persisting states in store
 const eventsPersistConfig = { key: "events", storage, whitelist: ["columns"] }
 const seriesPersistConfig = { key: "series", storage, whitelist: ["columns"] }
+const tablePersistConfig = { key: "table", storage, whitelist: ["pagination"] }
 const recordingsPersistConfig = { key: "recordings", storage, whitelist: ["columns"] }
 const jobsPersistConfig = { key: "jobs", storage, whitelist: ["columns"] }
 const serversPersistConfig = { key: "servers", storage, whitelist: ["columns"] }
@@ -52,7 +53,7 @@ const reducers = combineReducers({
 	tableFilterProfiles,
 	events: persistReducer(eventsPersistConfig, events),
 	series: persistReducer(seriesPersistConfig, series),
-	table,
+	table: persistReducer(tablePersistConfig, table),
 	recordings: persistReducer(recordingsPersistConfig, recordings),
 	jobs: persistReducer(jobsPersistConfig, jobs),
 	servers: persistReducer(serversPersistConfig, servers),


### PR DESCRIPTION
Persists changes to table pagination information, most notably the setting for how many items per page are displayed.

Since this information is stored and applied to ALL tables, setting the limit from 10 to 20 for the events table will also set it to 20 for the series table and all other tables. If we say that is no good, and we want the settings to be per table instead, I'll have to create a different, more extensive PR.

Fixes #544, #447.