### PR TITLE
Fix type error when opening statistics page

### DIFF
--- a/src/components/statistics/Statistics.tsx
+++ b/src/components/statistics/Statistics.tsx
@@ -7,6 +7,7 @@ import Header from "../Header";
 import Footer from "../Footer";
 import MainNav from "../shared/MainNav";
 import TimeSeriesStatistics from "../shared/TimeSeriesStatistics";
+import { addNotification } from "../../slices/notificationSlice";
 import {
 	getStatistics,
 	hasStatistics as getHasStatistics,
@@ -46,10 +47,9 @@ const Statistics: React.FC = () => {
 
 	useEffect(() => {
 		// fetch user information for organization id, then fetch statistics
-// @ts-expect-error TS(7006): Parameter 'e' implicitly has an 'any' type.
-		fetchUserInfo().then((e) => {
+		dispatch(fetchUserInfo()).then(() => {
 			dispatch(fetchStatisticsPageStatistics(organizationId)).then();
-		});
+		})
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 

--- a/src/components/statistics/Statistics.tsx
+++ b/src/components/statistics/Statistics.tsx
@@ -7,7 +7,6 @@ import Header from "../Header";
 import Footer from "../Footer";
 import MainNav from "../shared/MainNav";
 import TimeSeriesStatistics from "../shared/TimeSeriesStatistics";
-import { addNotification } from "../../slices/notificationSlice";
 import {
 	getStatistics,
 	hasStatistics as getHasStatistics,


### PR DESCRIPTION
This PR fixes #566
by properly async call (using dispatch!) to fetch the user info before fetching the statistics info!
This PR needs actual statistic data to make sure it works properly, but for the start the error is now gone, and the page should not be interrupted!

![Screenshot 2024-06-04 at 14 08 26](https://github.com/opencast/opencast-admin-interface/assets/53179227/8cb61122-2956-4211-81f0-e7f6d638b4df)
