### PR TITLE
Fix notification when changing series theme

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/SeriesDetailsThemeTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/SeriesDetailsThemeTab.tsx
@@ -52,8 +52,9 @@ const SeriesDetailsThemeTab = ({
 				<>
 					<div className="modal-content">
 						<div className="modal-body">
-							<Notifications context="not-corner" />
 							<div className="full-col">
+                            {/* Notifications */}
+                            <Notifications context="not_corner" />
 								<div className="obj quick-actions">
 									<header>{t("CONFIGURATION.NAVIGATION.THEMES")}</header>
 									<div className="obj-container padded">

--- a/src/components/events/partials/ModalTabsAndPages/SeriesDetailsThemeTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/SeriesDetailsThemeTab.tsx
@@ -53,8 +53,8 @@ const SeriesDetailsThemeTab = ({
 					<div className="modal-content">
 						<div className="modal-body">
 							<div className="full-col">
-                            {/* Notifications */}
-                            <Notifications context="not_corner" />
+								{/* Notifications */}
+								<Notifications context="not_corner" />
 								<div className="obj quick-actions">
 									<header>{t("CONFIGURATION.NAVIGATION.THEMES")}</header>
 									<div className="obj-container padded">


### PR DESCRIPTION
This PR fixes #384 . Like in the old admin UI, the following notification will be displayed after hitting the save button: 

![image](https://github.com/opencast/opencast-admin-interface/assets/32971521/97d41426-ce18-4e29-8e97-a56a36d2ffb7)
 