### PR TITLE
Fix several save-button misplacements in the event and series details

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/DetailsExtendedMetadataTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/DetailsExtendedMetadataTab.tsx
@@ -165,7 +165,7 @@ const DetailsExtendedMetadataTab: React.FC<{
 											{formik.dirty && (
 												<>
 													{/* Render buttons for updating metadata */}
-													<footer style={{ padding: "15px" }}>
+													<footer>
 														<button
 															type="submit"
 															onClick={() => formik.handleSubmit()}

--- a/src/components/events/partials/ModalTabsAndPages/DetailsMetadataTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/DetailsMetadataTab.tsx
@@ -160,7 +160,7 @@ const DetailsMetadataTab: React.FC<{
 									{formik.dirty && (
 										<>
 											{/* Render buttons for updating metadata */}
-											<footer style={{ padding: "15px" }}>
+											<footer>
 												<button
 													type="submit"
 													onClick={() => formik.handleSubmit()}

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsSchedulingTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsSchedulingTab.tsx
@@ -661,7 +661,7 @@ const EventDetailsSchedulingTab = ({
 										{formik.dirty && (
 											<>
 												{/* Render buttons for updating scheduling */}
-												<footer style={{ padding: "15px" }}>
+												<footer>
 													<button
 														type="submit"
 														onClick={() => formik.handleSubmit()}

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowTab.tsx
@@ -453,7 +453,7 @@ const EventDetailsWorkflowTab = ({
 													!!workflowConfiguration &&
 													!!workflowConfiguration.workflowId &&
 													formik.dirty && (
-														<footer style={{ padding: "15px" }}>
+														<footer style={{ padding: "0 15px" }}>
 															<div className="pull-left">
 																<button
 																	type="reset"

--- a/src/components/events/partials/ModalTabsAndPages/SeriesDetailsThemeTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/SeriesDetailsThemeTab.tsx
@@ -90,7 +90,7 @@ const SeriesDetailsThemeTab = ({
 									{formik.dirty && (
 										<>
 											{/* Render buttons for updating theme */}
-											<footer style={{ padding: "15px" }}>
+											<footer>
 												<button
 													type="submit"
 													onClick={() => formik.handleSubmit()}

--- a/src/components/shared/modals/ResourceDetailsAccessPolicyTab.tsx
+++ b/src/components/shared/modals/ResourceDetailsAccessPolicyTab.tsx
@@ -620,7 +620,7 @@ const ResourceDetailsAccessPolicyTab : React.FC <{
 											{!transactions.read_only &&
 												policyChanged &&
 												formik.dirty && (
-													<footer style={{ padding: "15px" }}>
+													<footer style={{ padding: "0 15px" }}>
 														<div className="pull-left">
 															<button
 																type="reset"


### PR DESCRIPTION
This PR fixes several button misplacements when editing data in the event and series details:

- Event Metadata
- Event Extended Metadata
- Event Scheduling
- Event Workflow
- Event ACL
- Series Metadata
- Series Themes
- Series ACL
- maybe more

Fixes (at least): https://github.com/opencast/opencast-admin-interface/issues/531, https://github.com/opencast/opencast-admin-interface/issues/527 and https://github.com/opencast/opencast-admin-interface/issues/570

To test, click through all possible tabs of existing events, series (and maybe something else?) and change data. Then take a look on the save and cancel button if something is misplaced.