### PR TITLE
Fix render warning

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,15 +10,13 @@
       content="Web site created using create-react-app"
     />
     <link rel="apple-touch-icon" href="/logo192.png" />
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
     <link rel="manifest" href="/manifest.json" />
     <title>Opencast</title>
   </head>
-  <body id="root">
+  <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <script type="module" src="/src/index.tsx"></script>
+    <div id="root">
+    </div>
   </body>
 </html>


### PR DESCRIPTION
This fixes following warning:

```
Warning: render(): Rendering components directly into document.body is discouraged, since its children are often manipulated by third-party scripts and browser extensions. This may lead to subtle reconciliation issues. Try rendering into a container element created for your app.
```