### PR TITLE
Aligning the rendering of the "Edit Table View" with other modal footers

### DIFF
--- a/src/components/shared/EditTableViewModal.tsx
+++ b/src/components/shared/EditTableViewModal.tsx
@@ -225,16 +225,13 @@ const EditTableViewModal = ({
 						</div>
 
 						<footer>
-							<div className="pull-left">
+							{/* Render buttons for updating table data */}
 								<button onClick={() => clearData()} className="cancel active">
 									{t("CANCEL") /*Cancel*/}
 								</button>
-							</div>
-							<div className="pull-right">
 								<button onClick={() => save()} className="submit active">
 									{t("SAVE") /* Save As Default */}
 								</button>
-							</div>
 						</footer>
 					</section>
 				</>

--- a/src/styles/extensions/views/modals/_edit-table-view.scss
+++ b/src/styles/extensions/views/modals/_edit-table-view.scss
@@ -55,28 +55,4 @@
             width: 48.72%;
         }
     }
-
-    footer {
-
-        a {
-            margin: 15px 5px 15px;
-
-            &:first-child {
-                margin-left: 15px;
-            }
-
-            &:last-child {
-                margin-right: 15px;
-            }
-        }
-
-        .pull-right {
-            float: right;
-        }
-
-        a:first-child {
-            float: none;
-        }
-    }
-
 }


### PR DESCRIPTION
This way, we also profit from the change in #554.

We can also get rid of some SCSS 🥳 
