### PR TITLE
Update Deployment Comment

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -98,6 +98,7 @@ jobs:
       - name: add comment with deployment location
         uses: thollander/actions-comment-pull-request@v2
         with:
+          comment_tag: static-test-deployment
           message: >
             This pull request is deployed at
             [test.admin-interface.opencast.org/${{ steps.build-path.outputs.build }}


### PR DESCRIPTION
Instead of writing a new comment every time the static test site gets deployed, this patch will cause the first comment to be updated similar to the container image deployment.

This means that if you open a pull requests, the first two comments should usually hold all information about the latest deployment.