### PR TITLE
Remove race condition in table filters

### DIFF
--- a/src/components/configuration/Themes.tsx
+++ b/src/components/configuration/Themes.tsx
@@ -40,8 +40,8 @@ const Themes = ({
 	const themes = useAppSelector(state => getTotalThemes(state));
 
 	// TODO: Get rid of the wrappers when modernizing redux is done
-	const fetchThemesWrapper = () => {
-		dispatch(fetchThemes())
+	const fetchThemesWrapper = async () => {
+		await dispatch(fetchThemes())
 	}
 
 	const loadThemes = async () => {

--- a/src/components/events/Events.tsx
+++ b/src/components/events/Events.tsx
@@ -82,8 +82,8 @@ const Events = ({
 	let location = useLocation();
 
 	// TODO: Get rid of the wrappers when modernizing redux is done
-	const fetchEventsWrapper = () => {
-		dispatch(fetchEvents())
+	const fetchEventsWrapper = async () => {
+		await dispatch(fetchEvents())
 	}
 
 	const loadEvents = async () => {

--- a/src/components/events/Series.tsx
+++ b/src/components/events/Series.tsx
@@ -64,8 +64,8 @@ const Series = ({
 	const showActions = useAppSelector(state => isShowActions(state));
 
 	// TODO: Get rid of the wrappers when modernizing redux is done
-	const fetchSeriesWrapper = () => {
-		dispatch(fetchSeries())
+	const fetchSeriesWrapper = async () => {
+		await dispatch(fetchSeries())
 	}
 
 	const loadEvents = () => {

--- a/src/components/recordings/Recordings.tsx
+++ b/src/components/recordings/Recordings.tsx
@@ -36,8 +36,8 @@ const Recordings = ({
 	const recordings = useAppSelector(state => getTotalRecordings(state));
 
 	// TODO: Get rid of the wrappers when modernizing redux is done
-	const fetchRecordingsWrapper = () => {
-		dispatch(fetchRecordings(undefined))
+	const fetchRecordingsWrapper = async () => {
+		await dispatch(fetchRecordings(undefined))
 	}
 
 	const loadRecordings = async () => {

--- a/src/components/systems/Jobs.tsx
+++ b/src/components/systems/Jobs.tsx
@@ -49,8 +49,8 @@ const Jobs = ({
 	const jobs = useAppSelector(state => getTotalJobs(state));
 
 	// TODO: Get rid of the wrappers when modernizing redux is done
-	const fetchJobsWrapper = () => {
-		dispatch(fetchJobs())
+	const fetchJobsWrapper = async () => {
+		await dispatch(fetchJobs())
 	}
 
 	const loadJobs = async () => {

--- a/src/components/systems/Servers.tsx
+++ b/src/components/systems/Servers.tsx
@@ -49,8 +49,8 @@ const Servers = ({
 	const servers = useAppSelector(state => getTotalServers(state));
 
 	// TODO: Get rid of the wrappers when modernizing redux is done
-	const fetchServersWrapper = () => {
-		dispatch(fetchServers())
+	const fetchServersWrapper = async () => {
+		await dispatch(fetchServers())
 	}
 
 	const loadServers = async () => {

--- a/src/components/systems/Services.tsx
+++ b/src/components/systems/Services.tsx
@@ -49,8 +49,8 @@ const Services = ({
 	const services = useAppSelector(state => getTotalServices(state));
 
 	// TODO: Get rid of the wrappers when modernizing redux is done
-	const fetchServicesWrapper = () => {
-		dispatch(fetchServices())
+	const fetchServicesWrapper = async () => {
+		await dispatch(fetchServices())
 	}
 
 	const loadServices = async () => {

--- a/src/components/users/Groups.tsx
+++ b/src/components/users/Groups.tsx
@@ -51,8 +51,8 @@ const Groups = ({
 	const currentFilterType = useAppSelector(state => getCurrentFilterResource(state));
 
 	// TODO: Get rid of the wrappers when modernizing redux is done
-	const fetchGroupsWrapper = () => {
-		dispatch(fetchGroups())
+	const fetchGroupsWrapper = async () => {
+		await dispatch(fetchGroups())
 	}
 
 	const loadGroups = async () => {

--- a/src/components/users/Users.tsx
+++ b/src/components/users/Users.tsx
@@ -41,8 +41,8 @@ const Users: React.FC = () => {
   const currentFilterType = useAppSelector(state => getCurrentFilterResource(state));
 
 	// TODO: Get rid of the wrappers when modernizing redux is done
-	const fetchUsersWrapper = () => {
-		dispatch(fetchUsers())
+	const fetchUsersWrapper = async () => {
+		await dispatch(fetchUsers())
 	}
 
 	const loadUsers = async () => {


### PR DESCRIPTION
Fixes a race condition that occurs because the resource table was updated before the updated resources were returned.

Closes #517