### PR TITLE
Fix add-event dialog console warnings

### DIFF
--- a/src/components/shared/wizard/WizardStepperEvent.tsx
+++ b/src/components/shared/wizard/WizardStepperEvent.tsx
@@ -60,8 +60,7 @@ const WizardStepperEvent = ({
 			activeStep={page}
 			nonLinear
 			alternativeLabel
-// @ts-expect-error TS(2322): Type 'boolean' is not assignable to type 'ReactEle... Remove this comment to see the full error message
-			connector={false}
+			connector={<></>}
 			className={cn("step-by-step", stepperClasses.root)}
 		>
 			{steps.map((label, key) =>

--- a/src/components/shared/wizard/WizardStepperEvent.tsx
+++ b/src/components/shared/wizard/WizardStepperEvent.tsx
@@ -73,7 +73,7 @@ const WizardStepperEvent = ({
 							</StepLabel>
 						</StepButton>
 					</Step>
-				) : <></>
+				) : <React.Fragment key={label.translation} />
 			)}
 		</Stepper>
 	);


### PR DESCRIPTION
Fixes a "missing key prop" and an "invalid prop type" error by adding that key and changing the prop type.
Not sure what to do about the missing `i18next` keys though.

Closes #550 