### PR TITLE
Show build information

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -19,6 +19,10 @@ const Footer: React.FC = () => {
 	const user = useAppSelector(state => getUserInformation(state));
 	const orgProperties = useAppSelector(state => getOrgProperties(state));
 
+	const lastModified = user?.ocVersion?.['last-modified']
+		? new Date(user.ocVersion['last-modified']).toISOString().substring(0, 10)
+		: 'unknown';
+
 	return (
 		<footer id="main-footer">
 			<div className="default-footer">
@@ -26,9 +30,13 @@ const Footer: React.FC = () => {
 					{/* Only render if a version is set */}
 					{!!user.ocVersion && (
 						<li>
-							Opencast {user.ocVersion.version}
+							{"Opencast "}
+							<span title={t('BUILD.VERSION')}>{user.ocVersion.version}</span>
 							{hasAccess("ROLE_ADMIN", user) && (
-								<span> - {user.ocVersion.buildNumber || "undefined"}</span>
+								<span>
+								{" – "} <span title={t('BUILD.COMMIT')}>{user.ocVersion.buildNumber || "undefined"}</span>
+								{" – "} <span title={t('BUILD.DATE_DESC')}>{t("BUILD.BUILT_ON")} {lastModified}</span>
+								</span>
 							)}
 						</li>
 					)}

--- a/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
@@ -2,6 +2,12 @@
 	"MATTERHORN": "Opencast",
 	"NAV_HOME": "Start",
 	"NAV_ABOUT": "About",
+	"BUILD": {
+		"BUILT_ON": "built on",
+		"DATE_DESC":"Date this system's kernel module was built on.",
+		"COMMIT": "Git commit this version of Opencast was built from.",
+		"VERSION": "Common bundle version of Opencast modules"
+	},
 	"NO": "No",
 	"SUBMIT": "Submit",
 	"UPDATE": "Update",

--- a/src/slices/userInfoSlice.ts
+++ b/src/slices/userInfoSlice.ts
@@ -8,7 +8,7 @@ import { addNotification } from './notificationSlice';
 type OcVersion = {
 	buildNumber: string | undefined,
 	consistent: boolean | undefined,
-	lastModified: number | undefined,
+	'last-modified': number | undefined,
 	version: string | undefined,
 }
 
@@ -67,7 +67,7 @@ const initialState: UserInfoState = {
 	ocVersion: {
 		buildNumber: undefined,
 		consistent: undefined,
-		lastModified: undefined,
+		"last-modified": undefined,
 		version: undefined,
 	},
 };


### PR DESCRIPTION
This patch adds additional build information like the build date to the footer and also adds the explanation we had on the old interface what these values mean to the `title` attributes.

This fixes #332