### PR TITLE
Reset copy success message

### DIFF
--- a/src/components/events/partials/modals/EmbeddingCodeModal.tsx
+++ b/src/components/events/partials/modals/EmbeddingCodeModal.tsx
@@ -75,6 +75,7 @@ const EmbeddingCodeModal = ({
 		// set state with new inputs
 		setTextAreaContent(iFrameString);
 		setCurrentSize(frameSize);
+		setCopySuccess(false);
 	};
 
 	return (


### PR DESCRIPTION
This resets the success message after changing the size of the embed code.

Fixes https://github.com/opencast/opencast-admin-interface/issues/562