### PR TITLE
Submitter undefined

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowDetails.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowDetails.tsx
@@ -104,12 +104,7 @@ const EventDetailsWorkflowDetails = ({
 													}
 												</td>
 												<td>
-													{workflowData.creator.name + " "}
-													{workflowData.creator.email && (
-														<span>
-															{"<" + workflowData.creator.email + ">"}
-														</span>
-													)}
+													{ workflowData.creator }
 												</td>
 											</tr>
 											<tr>


### PR DESCRIPTION
The submitter of a workflow can never be undefined, but the new interface states exactly that. The reason for that is that the interface tries to access non-existing data. This patch fixes the problem.

This fixes #359