### PR TITLE
Enforce minimum column width

### DIFF
--- a/src/styles/components/_tables.scss
+++ b/src/styles/components/_tables.scss
@@ -52,6 +52,7 @@
 
     th {
         &.sortable {
+            min-width: 80px;
             cursor: pointer;
             &:hover {
                 background: linear-gradient(to bottom, $off-white, darken(#f1f3f5, 3%));

--- a/src/styles/components/_tables.scss
+++ b/src/styles/components/_tables.scss
@@ -52,7 +52,7 @@
 
     th {
         &.sortable {
-            min-width: 80px;
+            min-width: 150px;
             cursor: pointer;
             &:hover {
                 background: linear-gradient(to bottom, $off-white, darken(#f1f3f5, 3%));


### PR DESCRIPTION
This PR enforces a minimum column width to prevent the sorting arrow from dropping down a line.

Fixes #450
