### PR TITLE
Prevent concurrent main deployments

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     if: github.repository_owner == 'opencast'


### PR DESCRIPTION
Skip unnecessary deployments in progress to lower the CO2 footprint and avoid errors because of concurrency.

Based on example: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow

```
Error: Creating Pages deployment failed
Error: HttpError: Deployment request failed for 98ee67b8c0d72b912a763192679bb61269c2c300 due to in progress deployment. Please cancel d01107971c7d484019a882c5db16e77a46ef05f1 first or wait for it to complete.
    at /home/runner/work/_actions/actions/deploy-pages/v4/node_modules/@octokit/request/dist-node/index.js:124:1
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at createPagesDeployment (/home/runner/work/_actions/actions/deploy-pages/v4/src/internal/api-client.js:125:1)
    at Deployment.create (/home/runner/work/_actions/actions/deploy-pages/v4/src/internal/deployment.js:74:1)
    at main (/home/runner/work/_actions/actions/deploy-pages/v4/src/index.js:30:1)
Error: Error: Failed to create deployment (status: 400) with build version 98ee67b8c0d72b912a763192679bb61269c2c300. Request ID E0C1:AFE82:572582F:998661F:665F7F96 Responded with: Deployment request failed for 98ee67b8c0d72b912a763192679bb61269c2c300 due to in progress deployment. Please cancel d01107971c7d484019a882c5db16e77a46ef05f1 first or wait for it to complete.
```

https://github.com/opencast/opencast-admin-interface/actions/runs/9374093827/job/25809387792