### PR TITLE
Only display date in series table created cell

### DIFF
--- a/src/components/events/partials/SeriesDateTimeCell.tsx
+++ b/src/components/events/partials/SeriesDateTimeCell.tsx
@@ -13,8 +13,8 @@ const SeriesDateTimeCell = ({
 	return (
 		// Link template for creation date of series
 		<span>
-			{t("dateFormats.dateTime.short", {
-				dateTime: renderValidDate(row.creation_date),
+			{t("dateFormats.date.short", {
+				date: renderValidDate(row.creation_date),
 			})}
 		</span>
 	);


### PR DESCRIPTION
There's such a thing as too much information, and in the series table only the date is really required for the created field.

Fixes #474