### PR TITLE
Add esc hotkey to close modals

### DIFF
--- a/src/components/events/partials/modals/DeleteEventsModal.tsx
+++ b/src/components/events/partials/modals/DeleteEventsModal.tsx
@@ -5,6 +5,8 @@ import { getSelectedRows } from "../../../../selectors/tableSelectors";
 import { connect } from "react-redux";
 import { useAppDispatch } from "../../../../store";
 import { deleteMultipleEvent } from "../../../../slices/eventSlice";
+import { useHotkeys } from "react-hotkeys-hook";
+import { availableHotkeys } from "../../../../configs/hotkeysConfig";
 
 /**
  * This component manages the delete bulk action
@@ -18,6 +20,13 @@ const DeleteEventsModal = ({
 
 	const [allChecked, setAllChecked] = useState(true);
 	const [selectedEvents, setSelectedEvents] = useState(selectedRows);
+
+	useHotkeys(
+		availableHotkeys.general.CLOSE_MODAL.sequence,
+		() => close(),
+		{ description: t(availableHotkeys.general.CLOSE_MODAL.description) ?? undefined },
+		[close],
+  	);
 
 	const deleteSelectedEvents = () => {
 		dispatch(deleteMultipleEvent(selectedEvents));
@@ -64,6 +73,7 @@ const DeleteEventsModal = ({
 			setAllChecked(true);
 		}
 	};
+
 	return (
 		<>
 			<div className="modal-animation modal-overlay" />

--- a/src/components/events/partials/modals/DeleteSeriesModal.tsx
+++ b/src/components/events/partials/modals/DeleteSeriesModal.tsx
@@ -9,6 +9,8 @@ import {
 	getSeriesConfig,
 	hasEvents,
 } from "../../../../slices/seriesSlice";
+import { useHotkeys } from "react-hotkeys-hook";
+import { availableHotkeys } from "../../../../configs/hotkeysConfig";
 
 /**
  * This component manges the delete series bulk action
@@ -21,6 +23,13 @@ const DeleteSeriesModal = ({ close, selectedRows }) => {
 	const [allChecked, setAllChecked] = useState(true);
 	const [selectedSeries, setSelectedSeries] = useState(selectedRows);
 	const [deleteWithSeriesAllowed, setDeleteWithSeriesAllowed] = useState(false);
+
+	useHotkeys(
+		availableHotkeys.general.CLOSE_MODAL.sequence,
+		() => close(),
+		{ description: t(availableHotkeys.general.CLOSE_MODAL.description) ?? undefined },
+		[close],
+  	);
 
 	useEffect(() => {
 		async function fetchData() {

--- a/src/components/events/partials/modals/EditMetadataEventsModal.tsx
+++ b/src/components/events/partials/modals/EditMetadataEventsModal.tsx
@@ -17,6 +17,8 @@ import {
 	updateBulkMetadata,
 } from "../../../../slices/eventSlice";
 import { unwrapResult } from "@reduxjs/toolkit";
+import { useHotkeys } from "react-hotkeys-hook";
+import { availableHotkeys } from "../../../../configs/hotkeysConfig";
 
 /**
  * This component manges the edit metadata bulk action
@@ -45,6 +47,13 @@ const EditMetadataEventsModal = ({
 	const [fetchedValues, setFetchedValues] = useState(null);
 
 	const user = useAppSelector(state => getUserInformation(state));
+
+	useHotkeys(
+		availableHotkeys.general.CLOSE_MODAL.sequence,
+		() => close(),
+		{ description: t(availableHotkeys.general.CLOSE_MODAL.description) ?? undefined },
+		[close],
+  	);
 
 	useEffect(() => {
 		async function fetchData() {

--- a/src/components/events/partials/modals/EditScheduledEventsModal.tsx
+++ b/src/components/events/partials/modals/EditScheduledEventsModal.tsx
@@ -20,6 +20,8 @@ import {
 	updateScheduledEventsBulk,
 } from "../../../../slices/eventSlice";
 import { fetchRecordings } from "../../../../slices/recordingSlice";
+import { useHotkeys } from "react-hotkeys-hook";
+import { availableHotkeys } from "../../../../configs/hotkeysConfig";
 
 /**
  * This component manages the pages of the edit scheduled bulk action
@@ -53,6 +55,13 @@ const EditScheduledEventsModal = ({
 	const [conflicts, setConflicts] = useState([]);
 
 	const user = useAppSelector(state => getUserInformation(state));
+
+	useHotkeys(
+		availableHotkeys.general.CLOSE_MODAL.sequence,
+		() => close(),
+		{ description: t(availableHotkeys.general.CLOSE_MODAL.description) ?? undefined },
+		[close],
+  	);
 
 	useEffect(() => {
 		// Load recordings that can be used for input

--- a/src/components/events/partials/modals/EmbeddingCodeModal.tsx
+++ b/src/components/events/partials/modals/EmbeddingCodeModal.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { getSourceURL } from "../../../../utils/embeddedCodeUtils";
+import { useHotkeys } from "react-hotkeys-hook";
+import { availableHotkeys } from "../../../../configs/hotkeysConfig";
 
 /**
  * This component renders the embedding code modal
@@ -15,6 +17,13 @@ const EmbeddingCodeModal = ({
 	const [sourceURL, setSourceURL] = useState("");
 	const [currentSize, setCurrentSize] = useState("0x0");
 	const [showCopySuccess, setCopySuccess] = useState(false);
+
+	useHotkeys(
+		availableHotkeys.general.CLOSE_MODAL.sequence,
+		() => close(),
+		{ description: t(availableHotkeys.general.CLOSE_MODAL.description) ?? undefined },
+		[close],
+  	);
 
 	useEffect(() => {
 		const fetchData = async () => {

--- a/src/components/events/partials/modals/EventDetailsModal.tsx
+++ b/src/components/events/partials/modals/EventDetailsModal.tsx
@@ -3,6 +3,8 @@ import { useTranslation } from "react-i18next";
 import EventDetails from "./EventDetails";
 import { useAppDispatch } from "../../../../store";
 import { removeNotificationWizardForm } from "../../../../slices/notificationSlice";
+import { useHotkeys } from "react-hotkeys-hook";
+import { availableHotkeys } from "../../../../configs/hotkeysConfig";
 
 /**
  * This component renders the modal for displaying event details
@@ -36,6 +38,13 @@ const EventDetailsModal = ({
 			handleClose();
 		}
 	};
+
+	useHotkeys(
+		availableHotkeys.general.CLOSE_MODAL.sequence,
+		() => close(),
+		{ description: t(availableHotkeys.general.CLOSE_MODAL.description) ?? undefined },
+		[close],
+  	);
 
 	return (
 		// todo: add hotkeys

--- a/src/components/events/partials/modals/SeriesDetailsModal.tsx
+++ b/src/components/events/partials/modals/SeriesDetailsModal.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import SeriesDetails from "./SeriesDetails";
+import { useHotkeys } from "react-hotkeys-hook";
+import { availableHotkeys } from "../../../../configs/hotkeysConfig";
 
 /**
  * This component renders the modal for displaying series details
@@ -25,6 +27,13 @@ const SeriesDetailsModal = ({
 			handleClose();
 		}
 	};
+
+	useHotkeys(
+		availableHotkeys.general.CLOSE_MODAL.sequence,
+		() => close(),
+		{ description: t(availableHotkeys.general.CLOSE_MODAL.description) ?? undefined },
+		[close],
+  	);
 
 	// todo: add hotkeys
 	return (

--- a/src/components/events/partials/modals/StartTaskModal.tsx
+++ b/src/components/events/partials/modals/StartTaskModal.tsx
@@ -10,6 +10,8 @@ import StartTaskSummaryPage from "../ModalTabsAndPages/StartTaskSummaryPage";
 import { postTasks } from "../../../../thunks/taskThunks";
 import { usePageFunctions } from "../../../../hooks/wizardHooks";
 import { checkValidityStartTaskEventSelection } from "../../../../utils/bulkActionUtils";
+import { useHotkeys } from "react-hotkeys-hook";
+import { availableHotkeys } from "../../../../configs/hotkeysConfig";
 
 /**
  * This component manages the pages of the task start bulk action
@@ -31,6 +33,13 @@ const StartTaskModal = ({
 		pageCompleted,
 		setPageCompleted,
 	} = usePageFunctions(0, initialValues);
+
+	useHotkeys(
+		availableHotkeys.general.CLOSE_MODAL.sequence,
+		() => close(),
+		{ description: t(availableHotkeys.general.CLOSE_MODAL.description) ?? undefined },
+		[close],
+  	);
 
 	const steps = [
 		{

--- a/src/components/recordings/partials/modal/RecordingDetailsModal.tsx
+++ b/src/components/recordings/partials/modal/RecordingDetailsModal.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import RecordingsDetails from "./RecordingsDetails";
+import { availableHotkeys } from "../../../../configs/hotkeysConfig";
+import { useHotkeys } from "react-hotkeys-hook";
 
 /**
  * This component renders the modal for displaying recording details
@@ -10,6 +12,13 @@ const RecordingDetailsModal = ({
     recordingId
 }: any) => {
 	const { t } = useTranslation();
+
+	useHotkeys(
+		availableHotkeys.general.CLOSE_MODAL.sequence,
+		() => close(),
+		{ description: t(availableHotkeys.general.CLOSE_MODAL.description) ?? undefined },
+		[close],
+  	);
 
 	const handleClose = () => {
 		close();

--- a/src/components/shared/ConfirmModal.tsx
+++ b/src/components/shared/ConfirmModal.tsx
@@ -1,5 +1,7 @@
 import React from "react";
+import { useHotkeys } from "react-hotkeys-hook";
 import { useTranslation } from "react-i18next";
+import { availableHotkeys } from "../../configs/hotkeysConfig";
 
 const ConfirmModal = ({
 // @ts-expect-error TS(7031): Binding element 'close' implicitly has an 'any' ty... Remove this comment to see the full error message
@@ -18,6 +20,13 @@ const ConfirmModal = ({
 	deleteWithCautionMessage = "",
 }) => {
 	const { t } = useTranslation();
+
+	useHotkeys(
+		availableHotkeys.general.CLOSE_MODAL.sequence,
+		() => close(),
+		{ description: t(availableHotkeys.general.CLOSE_MODAL.description) ?? undefined },
+		[close],
+  	);
 
 	const handleClose = () => {
 		close();

--- a/src/components/shared/EditTableViewModal.tsx
+++ b/src/components/shared/EditTableViewModal.tsx
@@ -9,6 +9,8 @@ import {
 	getResourceType,
 } from "../../selectors/tableSelectors";
 import { DragDropContext, Droppable, OnDragEndResponder, Draggable as Draggablee } from "@hello-pangea/dnd";
+import { availableHotkeys } from "../../configs/hotkeysConfig";
+import { useHotkeys } from "react-hotkeys-hook";
 
 /**
  * This component renders the modal for editing which columns are shown in the table
@@ -45,6 +47,13 @@ const EditTableViewModal = ({
 			}
 		}
 	}, [activeColumns, deactivatedColumns, isColsLoaded]);
+
+	useHotkeys(
+		availableHotkeys.general.CLOSE_MODAL.sequence,
+		() => handleClose(),
+		{ description: t(availableHotkeys.general.CLOSE_MODAL.description) ?? undefined },
+		[handleClose],
+  	);
 
 	// closes this modal
 	const close = () => {

--- a/src/components/shared/HotKeyCheatSheet.tsx
+++ b/src/components/shared/HotKeyCheatSheet.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { availableHotkeys } from "../../configs/hotkeysConfig";
-import { useHotkeysContext } from "react-hotkeys-hook";
+import { useHotkeys, useHotkeysContext } from "react-hotkeys-hook";
 import { Hotkey } from "react-hotkeys-hook/dist/types";
 
 /**
@@ -13,6 +13,13 @@ const HotKeyCheatSheet: React.FC<{
 	close
 }) => {
 	const { t } = useTranslation();
+
+	useHotkeys(
+		availableHotkeys.general.CLOSE_MODAL.sequence,
+		() => close(),
+		{ description: t(availableHotkeys.general.CLOSE_MODAL.description) ?? undefined },
+		[close],
+  	);
 
 	const handleClose = () => {
 		close();

--- a/src/components/shared/NewResourceModal.tsx
+++ b/src/components/shared/NewResourceModal.tsx
@@ -6,6 +6,8 @@ import NewThemeWizard from "../configuration/partials/wizard/NewThemeWizard";
 import NewAclWizard from "../users/partials/wizard/NewAclWizard";
 import NewGroupWizard from "../users/partials/wizard/NewGroupWizard";
 import NewUserWizard from "../users/partials/wizard/NewUserWizard";
+import { useHotkeys } from "react-hotkeys-hook";
+import { availableHotkeys } from "../../configs/hotkeysConfig";
 
 /**
  * This component renders the modal for adding new resources
@@ -16,6 +18,13 @@ const NewResourceModal = ({
     resource
 }: any) => {
 	const { t } = useTranslation();
+
+	useHotkeys(
+		availableHotkeys.general.CLOSE_MODAL.sequence,
+		() => handleClose(),
+		{ description: t(availableHotkeys.general.CLOSE_MODAL.description) ?? undefined },
+		[handleClose],
+  	);
 
 	const close = () => {
 		handleClose();

--- a/src/components/shared/RegistrationModal.tsx
+++ b/src/components/shared/RegistrationModal.tsx
@@ -10,6 +10,8 @@ import {
 	fetchAdopterRegistration,
 	postRegistration,
 } from "../../utils/adopterRegistrationUtils";
+import { useHotkeys } from "react-hotkeys-hook";
+import { availableHotkeys } from "../../configs/hotkeysConfig";
 
 /**
  * This component renders the adopter registration modal. This modal has various states.
@@ -22,6 +24,13 @@ const RegistrationModal = ({ close }) => {
 	const [state, setState] = useState("form");
 	// initial values for Formik
 	const [initialValues, setInitialValues] = useState({});
+
+	useHotkeys(
+		availableHotkeys.general.CLOSE_MODAL.sequence,
+		() => close(),
+		{ description: t(availableHotkeys.general.CLOSE_MODAL.description) ?? undefined },
+		[close],
+  	);
 
 	const handleClose = () => {
 		close();

--- a/src/components/shared/TableFilterProfiles.tsx
+++ b/src/components/shared/TableFilterProfiles.tsx
@@ -10,6 +10,8 @@ import {
 import { getFilters } from "../../selectors/tableFilterSelectors";
 import { loadFilterProfile } from "../../slices/tableFilterSlice";
 import { useAppDispatch, useAppSelector } from "../../store";
+import { useHotkeys } from "react-hotkeys-hook";
+import { availableHotkeys } from "../../configs/hotkeysConfig";
 
 /**
  * This component renders the table filter profiles in the upper right corner when clicked on settings icon of the
@@ -42,6 +44,13 @@ const TableFiltersProfiles = ({
 	const [validName, setValidName] = useState(false);
 
 	const { t } = useTranslation();
+
+	useHotkeys(
+		availableHotkeys.general.CLOSE_MODAL.sequence,
+		() => setFilterSettings(false),
+		{ description: t(availableHotkeys.general.CLOSE_MODAL.description) ?? undefined },
+		[setFilterSettings],
+  	);
 
 	const currentProfiles = profiles.filter(
 		(profile) => profile.resource === resource

--- a/src/components/users/partials/modal/AclDetailsModal.tsx
+++ b/src/components/users/partials/modal/AclDetailsModal.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import AclDetails from "./AclDetails";
+import { useHotkeys } from "react-hotkeys-hook";
+import { availableHotkeys } from "../../../../configs/hotkeysConfig";
 
 /**
  * This component renders the modal for displaying acl details
@@ -10,6 +12,13 @@ const AclDetailsModal = ({
     aclName
 }: any) => {
 	const { t } = useTranslation();
+
+	useHotkeys(
+		availableHotkeys.general.CLOSE_MODAL.sequence,
+		() => close(),
+		{ description: t(availableHotkeys.general.CLOSE_MODAL.description) ?? undefined },
+		[close],
+  	);
 
 	const handleClose = () => {
 		close();

--- a/src/components/users/partials/modal/GroupDetailsModal.tsx
+++ b/src/components/users/partials/modal/GroupDetailsModal.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import GroupDetails from "./GroupDetails";
+import { useHotkeys } from "react-hotkeys-hook";
+import { availableHotkeys } from "../../../../configs/hotkeysConfig";
 
 /**
  * This component renders the modal for displaying group details
@@ -10,6 +12,13 @@ const GroupDetailsModal = ({
     groupName
 }: any) => {
 	const { t } = useTranslation();
+
+	useHotkeys(
+		availableHotkeys.general.CLOSE_MODAL.sequence,
+		() => close(),
+		{ description: t(availableHotkeys.general.CLOSE_MODAL.description) ?? undefined },
+		[close],
+  	);
 
 	const handleClose = () => {
 		close();

--- a/src/components/users/partials/modal/UserDetailsModal.tsx
+++ b/src/components/users/partials/modal/UserDetailsModal.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import UserDetails from "./UserDetails";
+import { useHotkeys } from "react-hotkeys-hook";
+import { availableHotkeys } from "../../../../configs/hotkeysConfig";
 
 /**
  * This component renders the modal for displaying user details
@@ -10,6 +12,13 @@ const UserDetailsModal = ({
     username
 }: any) => {
 	const { t } = useTranslation();
+
+	useHotkeys(
+		availableHotkeys.general.CLOSE_MODAL.sequence,
+		() => close(),
+		{ description: t(availableHotkeys.general.CLOSE_MODAL.description) ?? undefined },
+		[close],
+  	);
 
 	const handleClose = () => {
 		close();

--- a/src/configs/hotkeysConfig.ts
+++ b/src/configs/hotkeysConfig.ts
@@ -62,5 +62,10 @@ export const availableHotkeys: HotkeyMapType = {
 			description: "HOTKEYS.DESCRIPTIONS.GENERAL.REMOVE_FILTERS",
 			sequence: ["r"],
 		},
+		CLOSE_MODAL: {
+			name: "close_modal",
+			description: "HOTKEYS.DESCRIPTIONS.GENERAL.CLOSE_MODAL",
+			sequence: ["Esc"],
+		}
 	},
 };

--- a/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
@@ -2083,7 +2083,8 @@
 				"SERIES_VIEW": "Series",
 				"NEW_EVENT": "Add event",
 				"NEW_SERIES": "Add series",
-				"CHEAT_SHEET": "Keyboard shortcuts"
+				"CHEAT_SHEET": "Keyboard shortcuts",
+				"CLOSE_MODAL": "Close dialog"
 			}
 		}
 	},


### PR DESCRIPTION
This adds `esc` to the hotkeys config, and uses it to close all modals.
At least I think I got all modals, but I wouldn't be completely surprised if I missed a few anyway.
This is a lot of repeated code and it would be nice to have one or two modal components that can be reused, but that is a larger refactoring task for another time.

Closes https://github.com/opencast/opencast-admin-interface/issues/428