### PR TITLE
Fix handling of long strings in modal windows and table

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -141,6 +141,20 @@ div.main-view.stub, div.full-col > div.stub {
   .select-container > p {
     margin-bottom: 10px;
   }
+
+  h2 {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  table {
+    table-layout: fixed;
+  }
+
+  .editable {
+    word-wrap: anywhere;
+  }
 }
 
 .modal-animation {
@@ -533,7 +547,13 @@ table.main-tbl {
     display: none !important;
   }
 
-  td{
+  th,
+  td {
+    max-width: 800px;
+    word-wrap: anywhere;
+  }
+
+  td {
     .fa-check {
       float: right;
       color: $green;


### PR DESCRIPTION
Should fix: https://github.com/opencast/opencast-admin-interface/issues/549

This PR fixes issues with long strings in metadata for example the title. Especially the title creates problems when opening modal windows like the event details or the tables.

For testing: Please add data everywhere where you can: Users, Series, Events, etc, etc. and add long strings. The Modal Windows / Wizards should look fine if you do so. Also, when you save the data, take a look at the tables and search for your entry, the entry should cause no problems in the table. Important: It makes a difference when you put in a string with blanks or not, so maybe you want to test both cases like:

`LONGDATALONGDATALONGDATALONGDATALONGDATALONGDATALONGDATALONGDATALONGDATALONGDATA`
and
`LONGDATA LONGDATA LONGDATA LONGDATA LONGDATA LONGDATA LONGDATA LONGDATA LONGDATA LONGDATA`