### PR TITLE
Collapse roles in user table

### DIFF
--- a/src/components/users/partials/UsersRolesCell.tsx
+++ b/src/components/users/partials/UsersRolesCell.tsx
@@ -7,14 +7,34 @@ const UsersRolesCell = ({
     row
 }: any) => {
 	const getRoleString = () => {
-		let roleString = "";
+		let displayRoles = [];
+		let roleCountUI = 0;
+		let roleCountAPI = 0;
+		let roleCountCaptureAgent = 0;
 
-// @ts-expect-error TS(7006): Parameter 'role' implicitly has an 'any' type.
-		row.roles.forEach((role) => {
-			roleString = roleString.concat(role.name + ", ");
-		});
+		for (const role of row.roles) {
+			if (role.name.startsWith('ROLE_UI')) {
+				roleCountUI++;
+			} else if (role.name.startsWith('ROLE_API')) {
+				roleCountAPI++;
+			} else if (role.name.startsWith('ROLE_CAPTURE_AGENT')) {
+				roleCountCaptureAgent++;
+			} else {
+				displayRoles.push(role.name);
+			}
+		}
 
-		return roleString;
+		if (roleCountUI > 0) {
+			displayRoles.push(`${roleCountUI} UI roles`);
+		}
+		if (roleCountAPI > 0) {
+			displayRoles.push(`${roleCountAPI} API roles`);
+		}
+		if (roleCountCaptureAgent > 0) {
+			displayRoles.push(`${roleCountUI} capture agent roles`);
+		}
+
+		return displayRoles.join(', ');
 	};
 
 	return <span>{getRoleString()}</span>;

--- a/src/components/users/partials/UsersRolesCell.tsx
+++ b/src/components/users/partials/UsersRolesCell.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 
 /**
  * This component renders the roles cells of users in the table view
@@ -6,6 +7,8 @@ import React from "react";
 const UsersRolesCell = ({
     row
 }: any) => {
+	const { t } = useTranslation();
+
 	const getRoleString = () => {
 		let displayRoles = [];
 		let roleCountUI = 0;
@@ -25,13 +28,16 @@ const UsersRolesCell = ({
 		}
 
 		if (roleCountUI > 0) {
-			displayRoles.push(`${roleCountUI} UI roles`);
+      const desc = t('USERS.USERS.TABLE.COLLAPSED.UI');
+			displayRoles.push(`${roleCountUI} ${desc}`);
 		}
 		if (roleCountAPI > 0) {
-			displayRoles.push(`${roleCountAPI} API roles`);
+      const desc = t('USERS.USERS.TABLE.COLLAPSED.API');
+			displayRoles.push(`${roleCountAPI} ${desc}`);
 		}
 		if (roleCountCaptureAgent > 0) {
-			displayRoles.push(`${roleCountUI} capture agent roles`);
+      const desc = t('USERS.USERS.TABLE.COLLAPSED.CAPTURE_AGENT');
+			displayRoles.push(`${roleCountCaptureAgent} ${desc}`);
 		}
 
 		return displayRoles.join(', ');

--- a/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
@@ -1243,6 +1243,11 @@
 				"USERNAME": "Username",
 				"EMAIL": "Email",
 				"ROLES": "Roles",
+				"COLLAPSED": {
+					"UI": "user interface roles",
+					"API": "API roles",
+					"CAPTURE_AGENT": "capture agent roles"
+				},
 				"TYPE": "Type",
 				"PROVIDER": "Provider",
 				"ACTION": "Actions",


### PR DESCRIPTION
The roles column in the user table can get extremely long in a production system. This patch collapses UI, API and capture agent roles.

![Screenshot from 2024-06-05 13-54-02](https://github.com/opencast/opencast-admin-interface/assets/1008395/bfb9a9be-0c7a-45f2-9f59-cffa8643bd0d)


This fixes #351