### PR TITLE
Fix wizard stepper that drifts out of window

### DIFF
--- a/src/styles/components/_steps.scss
+++ b/src/styles/components/_steps.scss
@@ -110,4 +110,15 @@
             background: radial-gradient(ellipse at center,  rgba(238,239,240,1) 35%,rgba(146,160,171,1) 40%);
         }
     }
+
+    &.MuiStepper-horizontal {
+      .MuiStep-horizontal {
+        word-break: break-word;
+        padding: 0;
+        flex: 1 1 min-content;
+      }
+      .MuiStepButton-horizontal {
+        padding: 24px 0;
+      }
+    }
 }

--- a/src/styles/components/_steps.scss
+++ b/src/styles/components/_steps.scss
@@ -112,13 +112,13 @@
     }
 
     &.MuiStepper-horizontal {
-      .MuiStep-horizontal {
-        word-break: break-word;
-        padding: 0;
-        flex: 1 1 min-content;
-      }
-      .MuiStepButton-horizontal {
-        padding: 24px 0;
-      }
+        .MuiStep-horizontal {
+            word-break: break-word;
+            padding: 0;
+            flex: 1 1 min-content;
+        }
+        .MuiStepButton-horizontal {
+            padding: 24px 0;
+        }
     }
 }


### PR DESCRIPTION
Fixes the wizard steps that are going out of the window in #612.

The text of the wizard steps include word breaking in non blank spaces now. I don't know if this is a good solution, what do you think?