### PR TITLE
changing the hamburger menu icon color to have a better contrast ratio

### DIFF
--- a/src/styles/components/_header.scss
+++ b/src/styles/components/_header.scss
@@ -289,8 +289,8 @@
         top: 36px;
         left: $side-margin;
 
-        @include fa-icon($fa-var-bars, 'before', inline-block, 10px 0 0 30px, 0, #3F5E78, 22px);
-        @include fa-icon($fa-var-bars, 'hover:before', inline-block, 10px 0 0 30px, 0, #5B7B96, 22px);
+        @include fa-icon($fa-var-bars, 'before', inline-block, 10px 0 0 30px, 0, #9badbb, 22px);
+        @include fa-icon($fa-var-bars, 'hover:before', inline-block, 10px 0 0 30px, 0, #b9c6d0, 22px);
     }
 
     // Subpage Navigation


### PR DESCRIPTION
changing the hamburger menu icon color to have a better contrast ratio

fix #630 