### PR TITLE
Change the color of placeholder text input and textarea fields to a darker gray

### DIFF
--- a/src/styles/components/_inputs.scss
+++ b/src/styles/components/_inputs.scss
@@ -43,7 +43,7 @@ textarea {
     color: $medium-prim-color;
 
     &::placeholder {
-        color: $light-prim-color;
+        color: $color-darkgray;
     }
 
     &:hover {


### PR DESCRIPTION
change color of placeholder text to a darker gray to have a better contrast ratio

Fixes #632