### PR TITLE
Change color of link and button text in action bar above tables to have a better contrast ratio

### DIFF
--- a/src/styles/extensions/components/_tables.scss
+++ b/src/styles/extensions/components/_tables.scss
@@ -73,7 +73,7 @@
     }
 
     button {
-        $highlight-blue: #3aa5ef;
+        $highlight-blue: #1d5888;
 
         color: $highlight-blue;
         text-shadow: 0 1px 0 rgba($white, 0.75);


### PR DESCRIPTION
Change color of link and button text to have a better contrast ratio.

Fixes #633