### PR TITLE
Fix MUI error when selecting a date as for StartDate filter

### DIFF
--- a/src/components/shared/TableFilters.tsx
+++ b/src/components/shared/TableFilters.tsx
@@ -469,7 +469,7 @@ const FilterSwitch = ({
 						autoFocus={true}
 						inputRef={startDateRef}
 						className="small-search start-date"
-						value={startDate}
+						value={startDate ?? null}
 						format="dd/MM/yyyy"
 						onChange={(date) => handleDate(date as Date | null, true)}
 						// FixMe: onAccept does not trigger if the already set value is the same as the selected value
@@ -492,7 +492,7 @@ const FilterSwitch = ({
 					<DatePicker
 						inputRef={endDateRef}
 						className="small-search end-date"
-						value={endDate}
+						value={endDate ?? null}
 						format="dd/MM/yyyy"
 						onChange={(date) => handleDate(date as Date | null)}
 						// FixMe: See above


### PR DESCRIPTION
This PR fixes #636,

Upon selecting the StartDate filter and adding selecting a date, an error occurs in MUI level, which can be seen in the devtool console!

It is solved simply by making the endDate and startDate value so called "uncontrolled?" by making it optional as to force passing null!
