### PR TITLE
event source upload: remove filename from blue button when remove file is clicked

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/NewSourcePage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewSourcePage.tsx
@@ -326,11 +326,12 @@ const Upload = ({ formik }) => {
 											<td className="fit">
 												<button
 													className="button-like-anchor remove"
-													onClick={() => {
+													onClick={(e) => {
 														formik.setFieldValue(
 															`uploadAssetsTrack.${key}.file`,
 															null
 														);
+														(document.getElementById(asset.id) as HTMLInputElement).value = '';
 													}}
 												/>
 											</td>


### PR DESCRIPTION
Fixes #476.

It removes the filename text inside the blue file upload button. 

When the remove file button is clicked the value of the element is set to an empty string.