### PR TITLE
Fix unnecessary green ticks in Metadata wizard

### DIFF
--- a/src/components/shared/wizard/RenderMultiField.tsx
+++ b/src/components/shared/wizard/RenderMultiField.tsx
@@ -269,7 +269,7 @@ const ShowValue = ({
 				{showCheck && (
 					<i
 						className={cn("saved fa fa-check", {
-							active: initialValues[field.name] !== field.value,
+							active: JSON.stringify(initialValues[field.name] ?? []) !== JSON.stringify(field.value ?? []),
 						})}
 					/>
 				)}


### PR DESCRIPTION
This PR fixes #629,

The problem comes from comparing arrays like other types, which in this case of `!==` is always true.
The correct way of comparing array is to convert them into json string and then check if they are equal!

With this PR, you will see the green tick only after changing the value of the inputs,  which is the intended behavior!