### PR TITLE
Fix Set Filter Profile dialog behavior and styles

### DIFF
--- a/src/components/shared/TableFilterProfiles.tsx
+++ b/src/components/shared/TableFilterProfiles.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import cn from "classnames";
 import { getFilterProfiles } from "../../selectors/tableFilterProfilesSelectors";
 import {
-	cancelEditFilterProfile,
+	FilterProfile,
 	createFilterProfile,
 	removeFilterProfile,
 } from "../../slices/tableFilterProfilesSlice";
@@ -40,7 +40,7 @@ const TableFiltersProfiles = ({
 	// State for helping saving and editing profiles
 	const [profileName, setProfileName] = useState("");
 	const [profileDescription, setProfileDescription] = useState("");
-	const [, setCurrentlyEditing] = useState("");
+	const [currentlyEditing, setCurrentlyEditing] = useState<FilterProfile | null>(null);
 	const [validName, setValidName] = useState(false);
 
 	const { t } = useTranslation();
@@ -82,20 +82,18 @@ const TableFiltersProfiles = ({
 	};
 
 	const cancelEditProfile = () => {
-		// What was this achieving?
-		// if (currentlyEditing !== "") {
-		// 	dispatch(createFilterProfile(currentlyEditing));
-		// }
-		dispatch(cancelEditFilterProfile());
-		setSettingsMode(!settingsMode);
-		setFilterSettings(!showFilterSettings);
+		// This holds the value of the profile being edited (in edit mode), and by cancelling the process, the profile won't vanish!
+		if (currentlyEditing) {
+			dispatch(createFilterProfile(currentlyEditing));
+		}
+		setSettingsMode(true);
 		resetStateValues();
 	};
 
 	const resetStateValues = () => {
 		setProfileName("");
 		setProfileDescription("");
-		setCurrentlyEditing("");
+		setCurrentlyEditing(null);
 		setValidName(false);
 	};
 
@@ -185,7 +183,7 @@ const TableFiltersProfiles = ({
 										className="button-like-anchor save"
 										onClick={() => setSettingsMode(!settingsMode)}
 									>
-										{t("TABLE_FILTERS.PROFILES.SAVE_FILTERS").substr(0, 70)}
+										{t("TABLE_FILTERS.PROFILES.ADD").substr(0, 70)}
 									</button>
 								</div>
 							</div>
@@ -204,7 +202,7 @@ const TableFiltersProfiles = ({
 								<h4>{t("TABLE_FILTERS.PROFILES.FILTER_HEADER")}</h4>
 							</header>
 							{/* Input form for save/editing profile*/}
-							<div>
+							<div className="edit-details">
 								<label>
 									{t("TABLE_FILTERS.PROFILES.NAME")}{" "}
 									<i className="required">*</i>

--- a/src/components/shared/TableFilterProfiles.tsx
+++ b/src/components/shared/TableFilterProfiles.tsx
@@ -90,6 +90,13 @@ const TableFiltersProfiles = ({
 		resetStateValues();
 	};
 
+	const closeFilterSetting = () => {
+		if (currentlyEditing) {
+			cancelEditProfile();
+		}
+		setFilterSettings(!showFilterSettings);
+	};
+
 	const resetStateValues = () => {
 		setProfileName("");
 		setProfileDescription("");
@@ -139,7 +146,7 @@ const TableFiltersProfiles = ({
 							<header>
 								<button
 									className="button-like-anchor icon close"
-									onClick={() => setFilterSettings(!showFilterSettings)}
+									onClick={closeFilterSetting}
 								/>
 								<h4>{t("TABLE_FILTERS.PROFILES.FILTERS_HEADER")}</h4>
 							</header>
@@ -194,10 +201,7 @@ const TableFiltersProfiles = ({
 							<header>
 								<button
 									className="button-like-anchor icon close"
-									onClick={() => {
-										setFilterSettings(!showFilterSettings);
-										setSettingsMode(true);
-									}}
+									onClick={closeFilterSetting}
 								/>
 								<h4>{t("TABLE_FILTERS.PROFILES.FILTER_HEADER")}</h4>
 							</header>

--- a/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
@@ -1788,7 +1788,8 @@
 			"NAME": "Name",
 			"NAME_PLACEHOLDER": "Name…",
 			"DESCRIPTION": "Description",
-			"DESCRIPTION_PLACEHOLDER": "Description…"
+			"DESCRIPTION_PLACEHOLDER": "Description…",
+			"ADD": "Add"
 		}
 	},
 	"FILTERS": {

--- a/src/slices/tableFilterProfilesSlice.ts
+++ b/src/slices/tableFilterProfilesSlice.ts
@@ -58,9 +58,6 @@ const tableFilterProfileSlice = createSlice({
 			state.profiles = state.profiles.filter(
 									(filterProfile) => filterProfile.name !== filterProfileToRemove.name
 								)
-		},
-		cancelEditFilterProfile(state) {
-			return
 		}
 	},
 });
@@ -69,7 +66,6 @@ export const {
 	createFilterProfile,
 	editFilterProfile,
 	removeFilterProfile,
-	cancelEditFilterProfile,
 } = tableFilterProfileSlice.actions;
 
 // Export the slice reducer as the default export

--- a/src/styles/components/data-filter/_filter-profiles.scss
+++ b/src/styles/components/data-filter/_filter-profiles.scss
@@ -149,6 +149,28 @@
     .filter-details {
         @include filter-dd-mixin();
 
+        .edit-details {
+            padding: 5px 10px;
+
+            > label {
+                display: block;
+                line-height: 20px;
+            }
+
+            > input, textarea {
+                padding-left: 10px;
+                width: 100%;
+                margin-bottom: 10px;
+                resize: none;
+                font-size: 12px;
+            }
+
+            > input {
+                height: 30px;
+            }
+
+        } // edit-details
+
         .input-container {
 
             //padding: 10px;
@@ -185,8 +207,7 @@
         .btn-container {
             width: 100%;
             float: right;
-            padding: 5px 5px 30px 5px;
-            height: 28px;
+            padding: 5px;
             @include border-bottom-radius($main-border-radius);
             background: darken($body-background, 3%);
             border-top: 1px solid $main-border-color;
@@ -196,14 +217,14 @@
             @include btn(white);
             margin-right: 3px;
             float: left;
-            height: inherit;
+            height: 28px;
         } // cancel
 
         .save {
             @include btn(green);
             text-shadow: none;
             float: right;
-            height: inherit;
+            height: 28px;
         } // save
     } // input-container
 


### PR DESCRIPTION
This PR fixes #618,

As it is stated in issue, this wizard/dialog doesn't behave as it should specially when clicking cancel button (it closes the dialog and in edit mode removes the profile) => that is no go!

This PR fixes this bad behavior by bringing the `currentlyEditing` variable to live once again and set its type as `FilterProfile` or null. So on `cancelEditProfile` we now only check if it was in editing mode and create a record of that instead of letting it be removed for good!

NOTE: A new translation key under "TABLE_FILTERS > PROFILES > ADD" is added. which replace the save text on the button when in adding new profile mode!

Apart from that, the style of the form in add/edit mode gets a proper look now!