### PR TITLE
Disable statistics tab by default

### DIFF
--- a/src/components/shared/MainNav.tsx
+++ b/src/components/shared/MainNav.tsx
@@ -17,7 +17,10 @@ import {
 import { fetchThemes } from "../../slices/themeSlice";
 import { fetchFilters, fetchStats } from "../../slices/tableFilterSlice";
 import { setOffset } from "../../actions/tableActions";
-import { getUserInformation } from "../../selectors/userInfoSelectors";
+import {
+	getOrgProperties,
+	getUserInformation
+} from "../../selectors/userInfoSelectors";
 import { hasAccess } from "../../utils/utils";
 import { fetchServices } from "../../slices/serviceSlice";
 import { fetchGroups } from "../../slices/groupSlice";
@@ -68,6 +71,9 @@ const MainNav = ({
 	let navigate = useNavigate();
 
 	const user = useAppSelector(state => getUserInformation(state));
+	const orgProperties = useAppSelector(state => getOrgProperties(state));
+
+	const statisticsEnabled = orgProperties['admin.statistics.enabled']?.toLowerCase() === 'true';
 
 	const loadEvents = () => {
 		dispatch(fetchFilters("events"));
@@ -295,7 +301,8 @@ const MainNav = ({
 										/>
 									</Link>
 								)}
-							{hasAccess("ROLE_UI_NAV_STATISTICS_VIEW", user) &&
+							{statisticsEnabled &&
+								hasAccess("ROLE_UI_NAV_STATISTICS_VIEW", user) &&
 								hasAccess("ROLE_UI_STATISTICS_ORGANIZATION_VIEW", user) && (
 									<Link to="/statistics/organization">
 										<i


### PR DESCRIPTION
By default the statistics view is broken and you need additional configuration. Therefor, it should be disabled by default in the admin interface.

Unlike the old interface, this patch does not read the actual data from statistics providers, but uses a configuration option to determine if the statistics feature should be an option in the UI.

The configuration and documentation is added in pull request https://github.com/opencast/opencast/pull/5909

This fixes #357