### PR TITLE
Change color of fa buttons in actions column to have a better contrast ratio

### DIFF
--- a/src/styles/components/_tables.scss
+++ b/src/styles/components/_tables.scss
@@ -285,7 +285,7 @@
 
             &.fa {
                 font-size: 18px;
-                color: #808080;
+                color: $color-darkgray;
             }
 
             &.crosslink {


### PR DESCRIPTION
Change color of fa buttons in actions column to have a better contrast ratio

fix #637 