### PR TITLE
use darkgray instead of gray to increase contrast ratio

### DIFF
--- a/src/styles/components/modals/_modal-base.scss
+++ b/src/styles/components/modals/_modal-base.scss
@@ -190,7 +190,7 @@
         }
 
         p {
-            color: $color-gray;
+            color: $color-darkgray;
             margin-bottom: 0.3em;
         }
     }


### PR DESCRIPTION
fix #638

Before:
![Screenshot 2024-06-06 095056](https://github.com/opencast/opencast-admin-interface/assets/1741658/b35a9291-9ad5-42d4-b7c1-b4179cb1f1ef)

After:
![Screenshot 2024-06-06 095046](https://github.com/opencast/opencast-admin-interface/assets/1741658/9ba5738c-c4bb-4171-af39-5850207f6197)

