### PR TITLE
Fix layout of file upload in add event dialog

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -148,10 +148,6 @@ div.main-view.stub, div.full-col > div.stub {
     text-overflow: ellipsis;
   }
 
-  table {
-    table-layout: fixed;
-  }
-
   .editable {
     word-wrap: anywhere;
   }


### PR DESCRIPTION
This patch fixes the table layout of the upload section in the add event dialog which had overlapping elements.

![Screenshot from 2024-06-06 01-05-45](https://github.com/opencast/opencast-admin-interface/assets/1008395/d74d99c1-ddba-4986-9094-9d2870d301f1)

Not the actions again have their own small column.

![Screenshot from 2024-06-06 11-34-11](https://github.com/opencast/opencast-admin-interface/assets/1008395/c956cb7e-1059-49bb-b784-79367738dfea)

The problem was caused by #626