### PR TITLE
Fix file upload labels 

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/NewSourcePage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewSourcePage.tsx
@@ -314,14 +314,6 @@ const Upload = ({ formik }) => {
 														name={`uploadAssetsTrack.${key}.file`}
 														tabIndex={0}
 													/>
-													{/* Show name of file that is uploaded */}
-													{formik.values.uploadAssetsTrack[key].file && (
-														<span className="ui-helper">
-															{formik.values.uploadAssetsTrack[
-																key
-															].file[0].name.substr(0, 50)}
-														</span>
-													)}
 												</div>
 											</td>
 											<td className="fit">

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -148,10 +148,6 @@ div.main-view.stub, div.full-col > div.stub {
     text-overflow: ellipsis;
   }
 
-  table {
-    table-layout: fixed;
-  }
-
   .editable {
     word-wrap: anywhere;
   }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -489,9 +489,9 @@ input.disabled, select.disabled {
 
 // Use HTML5 input field for file upload
 .file-upload > input[type="file"] {
-  width: inherit !important;
+  width: 300px;
   visibility: visible !important;
-  hidden: false !important;
+  text-align: left;
 }
 
 // Notification alias error to danger

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -489,7 +489,7 @@ input.disabled, select.disabled {
 
 // Use HTML5 input field for file upload
 .file-upload > input[type="file"] {
-  width: 300px;
+  width: 100%;
   visibility: visible !important;
   text-align: left;
 }


### PR DESCRIPTION
The file upload dialog in the add events dialog does not work well with
long filenames and even renders the filename twice. This patch fixes
that.

![Screenshot from 2024-06-06 12-00-49](https://github.com/opencast/opencast-admin-interface/assets/1008395/1b4dc704-b06a-4a79-b934-6b56c863ea1d)

This patch is based on https://github.com/opencast/opencast-admin-interface/pull/666 which fixes the broken table in that dialog.

This fixes #661