### PR TITLE
Solve problems with accessibility in tables

### DIFF
--- a/src/components/configuration/partials/ThemesActionsCell.tsx
+++ b/src/components/configuration/partials/ThemesActionsCell.tsx
@@ -53,6 +53,7 @@ const ThemesActionsCell = ({
 					onClick={() => showThemeDetails()}
 					className="button-like-anchor more"
 					title={t("CONFIGURATION.THEMES.TABLE.TOOLTIP.DETAILS")}
+					aria-label={t("CONFIGURATION.THEMES.TABLE.TOOLTIP.DETAILS")}
 				/>
 			)}
 
@@ -70,6 +71,7 @@ const ThemesActionsCell = ({
 					onClick={() => setDeleteConfirmation(true)}
 					className="button-like-anchor remove ng-scope ng-isolate-scope"
 					title={t("CONFIGURATION.THEMES.TABLE.TOOLTIP.DELETE")}
+					aria-label={t("CONFIGURATION.THEMES.TABLE.TOOLTIP.DELETE")}
 				/>
 			)}
 

--- a/src/components/events/partials/EventActionCell.tsx
+++ b/src/components/events/partials/EventActionCell.tsx
@@ -123,6 +123,7 @@ const EventActionCell = ({
 					onClick={() => onClickEventDetails()}
 					className="button-like-anchor more"
 					title={t("EVENTS.EVENTS.TABLE.TOOLTIP.DETAILS")}
+					aria-label={t("EVENTS.EVENTS.TABLE.TOOLTIP.DETAILS")}
 				/>
 			)}
 
@@ -132,6 +133,7 @@ const EventActionCell = ({
 					onClick={() => onClickSeriesDetails()}
 					className="button-like-anchor more-series"
 					title={t("EVENTS.SERIES.TABLE.TOOLTIP.DETAILS")}
+					aria-label={t("EVENTS.SERIES.TABLE.TOOLTIP.DETAILS")}
 				/>
 			)}
 
@@ -142,6 +144,7 @@ const EventActionCell = ({
 					onClick={() => setDeleteConfirmation(true)}
 					className="button-like-anchor remove"
 					title={t("EVENTS.EVENTS.TABLE.TOOLTIP.DELETE")}
+					aria-label={t("EVENTS.EVENTS.TABLE.TOOLTIP.DELETE")}
 				/>
 			)}
 
@@ -166,6 +169,11 @@ const EventActionCell = ({
 							? t("EVENTS.EVENTS.TABLE.TOOLTIP.EDITOR_NEEDS_CUTTING")
 							: t("EVENTS.EVENTS.TABLE.TOOLTIP.EDITOR")
 					}
+					aria-label={
+						row.needs_cutting
+							? t("EVENTS.EVENTS.TABLE.TOOLTIP.EDITOR_NEEDS_CUTTING")
+							: t("EVENTS.EVENTS.TABLE.TOOLTIP.EDITOR")
+					}
 					target="_blank" rel="noreferrer"
 				>
 					{row.needs_cutting && <span id="badge" className="badge" />}
@@ -177,6 +185,7 @@ const EventActionCell = ({
 				<button
 					onClick={() => onClickComments()}
 					title={t("EVENTS.EVENTS.TABLE.TOOLTIP.COMMENTS")}
+					aria-label={t("EVENTS.EVENTS.TABLE.TOOLTIP.COMMENTS")}
 					className="button-like-anchor comments"
 				/>
 			)}
@@ -186,6 +195,7 @@ const EventActionCell = ({
 				<button
 					onClick={() => onClickComments()}
 					title={t("EVENTS.EVENTS.TABLE.TOOLTIP.COMMENTS")}
+					aria-label={t("EVENTS.EVENTS.TABLE.TOOLTIP.COMMENTS")}
 					className="button-like-anchor comments-open"
 				/>
 			)}
@@ -196,6 +206,7 @@ const EventActionCell = ({
 				hasAccess("ROLE_UI_EVENTS_DETAILS_WORKFLOWS_EDIT", user) && (
 					<button
 						title={t("EVENTS.EVENTS.TABLE.TOOLTIP.PAUSED_WORKFLOW")}
+						aria-label={t("EVENTS.EVENTS.TABLE.TOOLTIP.PAUSED_WORKFLOW")}
 						onClick={() => onClickWorkflow()}
 						className="button-like-anchor fa fa-warning"
 					/>
@@ -206,6 +217,7 @@ const EventActionCell = ({
 				<button
 					onClick={() => onClickAssets()}
 					title={t("EVENTS.EVENTS.TABLE.TOOLTIP.ASSETS")}
+					aria-label={t("EVENTS.EVENTS.TABLE.TOOLTIP.ASSETS")}
 					className="button-like-anchor fa fa-folder-open"
 				/>
 			)}
@@ -214,6 +226,7 @@ const EventActionCell = ({
 				<button
 					onClick={() => showEmbeddingCodeModal()}
 					title={t("EVENTS.EVENTS.TABLE.TOOLTIP.EMBEDDING_CODE")}
+					aria-label={t("EVENTS.EVENTS.TABLE.TOOLTIP.EMBEDDING_CODE")}
 					className="button-like-anchor fa fa-link"
 				/>
 			)}

--- a/src/components/events/partials/SeriesActionsCell.tsx
+++ b/src/components/events/partials/SeriesActionsCell.tsx
@@ -76,6 +76,7 @@ const SeriesActionsCell = ({
 					onClick={() => showSeriesDetailsModal()}
 					className="button-like-anchor more-series"
 					title={t("EVENTS.SERIES.TABLE.TOOLTIP.DETAILS")}
+					aria-label={t("EVENTS.SERIES.TABLE.TOOLTIP.DETAILS")}
 				/>
 			)}
 
@@ -93,6 +94,7 @@ const SeriesActionsCell = ({
 					onClick={() => showDeleteConfirmation()}
 					className="button-like-anchor remove"
 					title={t("EVENTS.SERIES.TABLE.TOOLTIP.DELETE")}
+					aria-label={t("EVENTS.SERIES.TABLE.TOOLTIP.DELETE")}
 				/>
 			)}
 

--- a/src/components/recordings/partials/RecordingsActionCell.tsx
+++ b/src/components/recordings/partials/RecordingsActionCell.tsx
@@ -50,6 +50,7 @@ const RecordingsActionCell = ({
 				<button
 					className="button-like-anchor more"
 					title={t("RECORDINGS.RECORDINGS.TABLE.TOOLTIP.DETAILS")}
+					aria-label={t("RECORDINGS.RECORDINGS.TABLE.TOOLTIP.DETAILS")}
 					onClick={() => showRecordingDetails()}
 				/>
 			)}
@@ -66,6 +67,7 @@ const RecordingsActionCell = ({
 				<button
 					className="button-like-anchor remove"
 					title={t("RECORDINGS.RECORDINGS.TABLE.TOOLTIP.DELETE")}
+					aria-label={t("RECORDINGS.RECORDINGS.TABLE.TOOLTIP.DELETE")}
 					onClick={() => setDeleteConfirmation(true)}
 				/>
 			)}

--- a/src/components/shared/Table.tsx
+++ b/src/components/shared/Table.tsx
@@ -334,12 +334,13 @@ const Table = ({
 				</div>
 
 				{/* Pagination and navigation trough pages */}
-				<div className="pagination">
+				<div className="pagination" role="group" aria-label={t("TABLE_PAGINATION")}>
 					<button
 						className={"button-like-anchor " + cn("prev", { disabled: !isNavigatePrevious() })}
 						onClick={() => goToPage(pageOffset - 1)}
+						title={t("TABLE_PREVIOUS")}
+						aria-label={t("TABLE_PREVIOUS")}
 					>
-						<span className="sr-only">{t("TABLE_PREVIOUS")}</span>
 					</button>
 					{directAccessible.map((page, key) =>
 						page.active ? (
@@ -356,8 +357,9 @@ const Table = ({
 					<button
 						className={"button-like-anchor " + cn("next", { disabled: !isNavigateNext() })}
 						onClick={() => goToPage(pageOffset + 1)}
+						title={t("TABLE_NEXT")}
+						aria-label={t("TABLE_NEXT")}
 					>
-						<span className="sr-only">{t("TABLE_NEXT")}</span>
 					</button>
 				</div>
 			</div>

--- a/src/components/users/partials/AclsActionsCell.tsx
+++ b/src/components/users/partials/AclsActionsCell.tsx
@@ -49,6 +49,7 @@ const AclsActionsCell = ({
 					onClick={() => showAclDetails()}
 					className="button-like-anchor more"
 					title={t("USERS.ACLS.TABLE.TOOLTIP.DETAILS")}
+					aria-label={t("USERS.ACLS.TABLE.TOOLTIP.DETAILS")}
 				/>
 			)}
 
@@ -62,6 +63,7 @@ const AclsActionsCell = ({
 					onClick={() => setDeleteConfirmation(true)}
 					className="button-like-anchor remove"
 					title={t("USERS.ACLS.TABLE.TOOLTIP.DETAILS")}
+					aria-label={t("USERS.ACLS.TABLE.TOOLTIP.DETAILS")}
 				/>
 			)}
 

--- a/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
@@ -2011,6 +2011,7 @@
 	"TABLE_EDIT": "Edit",
 	"TABLE_NEXT": "Next page",
 	"TABLE_PREVIOUS": "Previous page",
+	"TABLE_PAGINATION": "Pagination",
 	"DASHBOARD": {
 		"RUNNING": "Running",
 		"FINISHED": "Finished",


### PR DESCRIPTION
- add aria-label to table actions
- keep title attr as a tooltip for the unlabeled icon buttons
- add aria-label and group to pagination

Unfortunately, the table filter buttons are sometimes read out more and sometimes less well in different browsers with different screen readers. Adding an aria label may only make things worse.

fix #620 