### PR TITLE
Use button tag for stat filter items

### DIFF
--- a/src/components/shared/Stats.tsx
+++ b/src/components/shared/Stats.tsx
@@ -60,7 +60,7 @@ const Stats = ({
 				{stats.map((st, key) => (
 					<div className="col" key={key}>
 						<Tooltip title={t(st.description)}>
-							<div
+							<button
 								className="stat"
 								onClick={() => showStatsFilter(st)}
 							>
@@ -76,7 +76,7 @@ const Stats = ({
 										</span>
 									))
 								)}
-							</div>
+							</button>
 						</Tooltip>
 					</div>
 				))}

--- a/src/styles/components/_stats.scss
+++ b/src/styles/components/_stats.scss
@@ -43,9 +43,19 @@
       cursor: pointer;
       overflow: hidden;
       color: $stats-color;
+      border: none;
+      border-radius: 0;
+      background-color: transparent;
+      height: unset;
+      width: 100%;
+      font-weight: unset;
+      font-size: unset;
 
       &:hover {
         color: $stats-hover-color;
+      }
+      &:focus {
+        outline: $stats-color solid thin;
       }
 
       h1 {


### PR DESCRIPTION
To access the stat filters with the keyboard they need to be a button or have tabIndex={0} and need a key listener.
Better a11y implementaion is always the simple one. So the div is now a button and with some css it looks the same. 


fixes #624