### PR TITLE
Fix Date Display in Add Event

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsSchedulingTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsSchedulingTab.tsx
@@ -290,7 +290,7 @@ const EventDetailsSchedulingTab = ({
 																	// tabIndex={1}
 																	value={new Date(formik.values.scheduleStartDate)}
 																	onChange={(value: Date | null) =>
-																		changeStartDate(
+																		value && changeStartDate(
 																			value,
 																			formik.values,
 																			formik.setFieldValue,

--- a/src/components/events/partials/ModalTabsAndPages/NewSourcePage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewSourcePage.tsx
@@ -171,7 +171,7 @@ const NewSourcePage = <T extends RequiredFormProps>({
 														className="source-toggle"
 														onClick={() =>
 															changeStartDate(
-																formik.values.scheduleStartDate,
+																new Date(formik.values.scheduleStartDate),
 																formik.values,
 																formik.setFieldValue
 															)
@@ -438,7 +438,7 @@ const Schedule = <T extends {
 												formik.setFieldValue
 											);
 										} else {
-											changeStartDate(
+											value && changeStartDate(
 												value,
 												formik.values,
 												formik.setFieldValue

--- a/src/components/events/partials/wizards/NewEventSummary.tsx
+++ b/src/components/events/partials/wizards/NewEventSummary.tsx
@@ -93,6 +93,8 @@ const NewEventSummary = <T extends RequiredFormProps>({
 		(workflow) => workflow.id === formik.values.processingWorkflow
 	);
 
+	const endsOnSameDay = formik.values.scheduleStartDate === formik.values.scheduleEndDate;
+
 	return (
 		<>
 			<div className="modal-content">
@@ -181,8 +183,8 @@ const NewEventSummary = <T extends RequiredFormProps>({
 													{t("EVENTS.EVENTS.NEW.SOURCE.DATE_TIME.START_DATE")}
 												</td>
 												<td>
-													{t("dateFormats.date.short", {
-														date: renderValidDate(formik.values.startDate),
+													{t("dateFormats.dateTime.short", {
+														dateTime: renderValidDate(formik.values.startDate),
 													})}
 												</td>
 											</tr>
@@ -214,7 +216,7 @@ const NewEventSummary = <T extends RequiredFormProps>({
 													{formik.values.scheduleStartMinute}
 												</td>
 											</tr>
-											{formik.values.sourceMode === "SCHEDULE_MULTIPLE" && (
+											{(!endsOnSameDay || formik.values.sourceMode === "SCHEDULE_MULTIPLE") && (
 												<tr>
 													<td>
 														{t("EVENTS.EVENTS.NEW.SOURCE.DATE_TIME.END_DATE")}

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -7,9 +7,7 @@ import { makeTwoDigits } from "./utils";
 
 // Get the ISO date string based on local time
 const getISODateString = (date: Date) => {
-	const offsetHours = Math.trunc(date.getTimezoneOffset() / 60)
-	const offsetMinutes = date.getTimezoneOffset() % 60
-	return new Date(date.setHours(-offsetHours, -offsetMinutes, 0)).toISOString().substring(0, 10);
+	return moment(date).format('YYYY-MM-DD');
 }
 
 // check if date can be parsed

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -5,9 +5,16 @@ import { makeTwoDigits } from "./utils";
  * This File contains methods concerning dates
  */
 
+// Get the ISO date string based on local time
+const getISODateString = (date: Date) => {
+	const offsetHours = Math.trunc(date.getTimezoneOffset() / 60)
+	const offsetMinutes = date.getTimezoneOffset() % 60
+	return new Date(date.setHours(-offsetHours, -offsetMinutes, 0)).toISOString().substring(0, 10);
+}
+
 // check if date can be parsed
 export const renderValidDate = (date: string) => {
-  return !isNaN(Date.parse(date)) ? new Date(date) : ""
+	return !isNaN(Date.parse(date)) ? new Date(date) : ""
 }
 
 // transform relative date to an absolute date
@@ -107,14 +114,8 @@ const changeStart = (
 	}
 
 	setDuration(startDate, endDate, setFieldValue);
-	setFieldValue(
-		"scheduleEndDate",
-		new Date(endDate.setHours(0, 0, 0)).toISOString()
-	);
-	setFieldValue(
-		"scheduleStartDate",
-		new Date(startDate.setHours(0, 0, 0)).toISOString()
-	);
+	setFieldValue("scheduleEndDate", getISODateString(endDate));
+	setFieldValue("scheduleStartDate", getISODateString(startDate));
 
 	if (!!checkConflicts) {
 		checkConflicts(
@@ -127,8 +128,7 @@ const changeStart = (
 };
 
 export const changeStartDate = (
-// @ts-expect-error TS(7006): Parameter 'value' implicitly has an 'any' type.
-	value,
+	value: Date,
 // @ts-expect-error TS(7006): Parameter 'formikValues' implicitly has an 'any' t... Remove this comment to see the full error message
 	formikValues,
 // @ts-expect-error TS(7006): Parameter 'setFieldValue' implicitly has an 'any' ... Remove this comment to see the full error message
@@ -227,10 +227,7 @@ const changeEnd = (
 	}
 
 	setDuration(startDate, endDate, setFieldValue);
-	setFieldValue(
-		"scheduleEndDate",
-		new Date(endDate.setHours(0, 0, 0)).toISOString()
-	);
+	setFieldValue("scheduleEndDate", getISODateString(endDate));
 
 	if (!!checkConflicts) {
 		checkConflicts(
@@ -314,10 +311,7 @@ const changeDuration = (
 
 	setFieldValue("scheduleEndHour", makeTwoDigits(endDate.getHours()));
 	setFieldValue("scheduleEndMinute", makeTwoDigits(endDate.getMinutes()));
-	setFieldValue(
-		"scheduleEndDate",
-		new Date(endDate.setHours(0, 0, 0)).toISOString()
-	);
+	setFieldValue("scheduleEndDate", getISODateString(endDate));
 
 	if (!!checkConflicts) {
 		checkConflicts(
@@ -412,18 +406,8 @@ const changeStartMultiple = (
 		endDate.setDate(startDate.getDate() + 1);
 	}
 
-	setFieldValue(
-		"scheduleEndDate",
-		new Date(endDate.setHours(0, 0, 0)).toISOString()
-	);
-	setFieldValue(
-		"scheduleStartDate",
-		new Date(startDate.setHours(0, 0, 0)).toISOString()
-	);
-
-	if (isEndBeforeStart(startDate, endDate)) {
-		endDate.setDate(startDate.getDate() + 1);
-	}
+	setFieldValue("scheduleEndDate", getISODateString(endDate));
+	setFieldValue("scheduleStartDate", getISODateString(startDate));
 
 	if (!!checkConflicts) {
 		checkConflicts(
@@ -537,14 +521,8 @@ export const changeEndDateMultiple = async (
 		}
 	}
 
-	setFieldValue(
-		"scheduleEndDate",
-		new Date(endDate.setHours(0, 0, 0)).toISOString()
-	);
-	setFieldValue(
-		"scheduleStartDate",
-		new Date(startDate.setHours(0, 0, 0)).toISOString()
-	);
+	setFieldValue("scheduleEndDate", getISODateString(endDate));
+	setFieldValue("scheduleStartDate", getISODateString(startDate));
 
 	if (!!checkConflicts) {
 		checkConflicts(
@@ -585,10 +563,7 @@ const changeEndMultiple = (
 
 	if (isEndBeforeStart(startDate, endDate)) {
 		endDate.setDate(startDate.getDate() + 1);
-		setFieldValue(
-			"scheduleEndDate",
-			new Date(endDate.setHours(0, 0, 0)).toISOString()
-		);
+	  setFieldValue("scheduleEndDate", getISODateString(endDate));
 	}
 
 	if (!!checkConflicts) {
@@ -677,10 +652,7 @@ const changeDurationMultiple = (
 
 	setFieldValue("scheduleEndHour", makeTwoDigits(endDate.getHours()));
 	setFieldValue("scheduleEndMinute", makeTwoDigits(endDate.getMinutes()));
-	setFieldValue(
-		"scheduleEndDate",
-		new Date(endDate.setHours(0, 0, 0)).toISOString()
-	);
+	setFieldValue("scheduleEndDate", getISODateString(endDate));
 
 	if (!!checkConflicts) {
 		checkConflicts(


### PR DESCRIPTION
This patch fixes a bunch of errors related to display of date and time in the add event wizard:

- If you select a start date and time for an uploaded event, the summary would only show a date, not the time.
- If you schedule an event, the summary would show a date-time string as start date which is off by one day for everyone operating in a UTC+x timezone.
- If you schedule an event which ends on a day other than the startt date, the summary wouldn't reflect that.

All this should now be fixed.

This fixes #662