### PR TITLE
Update start date for uploads when opening the add events dialog

### DIFF
--- a/src/components/events/partials/wizards/NewEventWizard.tsx
+++ b/src/components/events/partials/wizards/NewEventWizard.tsx
@@ -227,6 +227,11 @@ const getInitialValues = (
 		extendedMetadata
 	)};
 
+	// Update start date for uploads
+	if (sourceMetadata?.UPLOAD?.metadata?.[0]) {
+		sourceMetadata.UPLOAD.metadata[0].value = new Date().toISOString();
+	}
+
 	// Transform additional metadata for source (provided by constant in newEventConfig)
 	if (!!sourceMetadata.UPLOAD) {
 		sourceMetadata.UPLOAD.metadata.forEach((field) => {


### PR DESCRIPTION
Users expect the start time in the upload section of the add event dialog to be the time when they open the dialog. Before this patch, it was always the time the admin interface was accessed and was never updated.

This fixes #478