### PR TITLE
Enhance the color contrast in the events and series details modal.

### DIFF
--- a/src/styles/base/_variables.scss
+++ b/src/styles/base/_variables.scss
@@ -80,7 +80,7 @@ $light-black-alpha:            rgba($black, 0.04);
 // ----------------------------------------
 
 $body-background:               $off-white;
-$header-link-color:             #5d7589;
+$header-link-color:             #596C82;
 $color-link:                    $medium-prim-color;
 $color-link-hover:              $dark-prim-color;
 
@@ -138,12 +138,18 @@ $modal-full-col-width:          100%;
 $modal-heading-color:           #4d4d4d;
 
 // Nav Colors
+// ----------------------------------------
 $modal-nav-bg-color:            #eeeff0;
 $modal-nav-border-color:        #d6d6d6;
-$modal-nav-link-color:          #92a0ab;
+$modal-nav-link-color:          #646E75;
 $modal-nav-link-active-color:   $header-link-color;
+$subpage-navigation-link-color: lighten($header-link-color, 25%);
+$subpage-navigation-link-hover-color: lighten($header-link-color, 35%);
 
-
+// Stats
+// ----------------------------------------
+$stats-color: $subpage-navigation-link-color;
+$stats-hover-color: $subpage-navigation-link-hover-color;
 
 // Layout
 // ----------------------------------------

--- a/src/styles/components/_header.scss
+++ b/src/styles/components/_header.scss
@@ -301,13 +301,13 @@
 
         a {
             display: inline-block;
-            color: lighten($header-link-color, 22%);
+            color: $subpage-navigation-link-color;
             text-align: center;
             position: relative;
             padding: 0 20px;
 
             &:hover {
-                color: lighten($header-link-color, 32%);
+                color: $subpage-navigation-link-hover-color;
             }
 
             &.active {

--- a/src/styles/components/_stats.scss
+++ b/src/styles/components/_stats.scss
@@ -25,7 +25,6 @@
 
   .col {
     $num-cols: 8;
-    $stat-color: lighten($header-link-color, 22%);
 
     box-sizing: border-box;
     display: inline-block;
@@ -43,10 +42,10 @@
       text-align: center;
       cursor: pointer;
       overflow: hidden;
-      color: $stat-color;
+      color: $stats-color;
 
       &:hover {
-        color: lighten($stat-color, 32%);
+        color: $stats-hover-color;
       }
 
       h1 {
@@ -54,7 +53,7 @@
         font-size: 24px;
         margin: 0 0 5px 0;
         padding: 2px 0;
-        border-bottom: $thin-border-stroke $stat-color;
+        border-bottom: $thin-border-stroke $stats-color;
       }
 
       span {


### PR DESCRIPTION
Fixes #597.

The new enhanced color contrast:

![image](https://github.com/opencast/opencast-admin-interface/assets/2993/c86ba253-a77b-4582-ba14-f0575d7fbc4a)

The color contrast ratio is now increased to 4.5:1 which satifies WCAG AA for large text.