### PR TITLE
Add text to icon buttons in the Edit Table dialog.

### DIFF
--- a/src/components/shared/EditTableViewModal.tsx
+++ b/src/components/shared/EditTableViewModal.tsx
@@ -155,7 +155,7 @@ const EditTableViewModal = ({
 																className="button-like-anchor move-item add"
 																onClick={() => changeColumn(column, false)}
 															>
-																<span class="sr-only">{t("PREFERENCES.TABLE.ADD_COLUMN")}</span>
+																<span className="sr-only">{t("PREFERENCES.TABLE.ADD_COLUMN")}</span>
 															</button>
 														</li>
 													) : null
@@ -206,7 +206,7 @@ const EditTableViewModal = ({
 																							className="button-like-anchor move-item remove"
 																							onClick={() => changeColumn(column, true)}
 																						>
-																							<span class="sr-only">{t("PREFERENCES.TABLE.REMOVE_COLUMN")}</span>
+																							<span className="sr-only">{t("PREFERENCES.TABLE.REMOVE_COLUMN")}</span>
 																						</button>
 																					</div>
 																				)}

--- a/src/components/shared/EditTableViewModal.tsx
+++ b/src/components/shared/EditTableViewModal.tsx
@@ -154,7 +154,9 @@ const EditTableViewModal = ({
 															<button
 																className="button-like-anchor move-item add"
 																onClick={() => changeColumn(column, false)}
-															/>
+															>
+																<span class="sr-only">{t("PREFERENCES.TABLE.ADD_COLUMN")}</span>
+															</button>
 														</li>
 													) : null
 												)}
@@ -203,7 +205,9 @@ const EditTableViewModal = ({
 																						<button
 																							className="button-like-anchor move-item remove"
 																							onClick={() => changeColumn(column, true)}
-																						/>
+																						>
+																							<span class="sr-only">{t("PREFERENCES.TABLE.REMOVE_COLUMN")}</span>
+																						</button>
 																					</div>
 																				)}
 																			</Draggablee>

--- a/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
@@ -95,7 +95,9 @@
 			"SUBHEADING": "Select the default data you would like displayed in the {{ tableName }} view",
 			"AVAILABLE_COLUMNS": "Available columns",
 			"SELECTED_COLUMNS": "Selected columns",
-			"FOOTER_TEXT": "The order and selection will be saved automatically. Press \"{{resetTranslation}}\" to restore the default view."
+			"FOOTER_TEXT": "The order and selection will be saved automatically. Press \"{{resetTranslation}}\" to restore the default view.",
+			"ADD_COLUMN": "Add column",
+			"REMOVE_COLUMN": "Remove column"
 		}
 	},
 	"CONFIRMATIONS": {


### PR DESCRIPTION
Fixes #599.

It's all about the green and red buttons in this dialog:

![image](https://github.com/opencast/opencast-admin-interface/assets/2993/fbf1c3c9-3052-4296-9beb-7fbab31f00ef)
