### PR TITLE
Switch to node:20-alpine container base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20
+FROM node:20-alpine
 EXPOSE 3000
 
 COPY . /admin-interface


### PR DESCRIPTION
This patch switches to the node alpine container which is significantly smaller than the Debian based container we use now:

```
docker.io/library/node                      20-alpine    91247b4bc29d  3 days ago     135 MB
docker.io/library/node                      20-bookworm  4c466ea4074f  9 days ago     1.12 GB
docker.io/library/node                      20           4c466ea4074f  9 days ago     1.12 GB
```

This results in significantly smaller test containers:

```
opencast-admin-interface          node-20-alpine  c9b84375017f  13 seconds ago      700 MB
opencast-admin-interface          node-20         2decf3414d30  About a minute ago  1.68 GB
```