### PR TITLE
Align content of the main table left

### DIFF
--- a/src/styles/components/_tables.scss
+++ b/src/styles/components/_tables.scss
@@ -290,6 +290,7 @@
 
             &.crosslink {
                 border-bottom: 1px solid transparent;
+                text-align: left;
 
                 &:hover {
                     border-bottom: 1px solid;

--- a/src/styles/extensions/components/_tables.scss
+++ b/src/styles/extensions/components/_tables.scss
@@ -34,6 +34,7 @@
     padding: 0 5px;
     margin-right: 5px;
     display: inline-block;
+    text-align: left;
 }
 
 .action-bar {


### PR DESCRIPTION
Zooming in may have the effect that some elements are suddenly centered in the main table since the elements in the cells are centered by default. This patch fixes the problem so that the content continues to be aligned left.

This fixes #541