### PR TITLE
Fix admin interface crashing when rendering filters

### DIFF
--- a/src/components/shared/TableFilters.tsx
+++ b/src/components/shared/TableFilters.tsx
@@ -232,7 +232,7 @@ const TableFilters = ({
 	const renderBlueBox = (filter) => {
 // @ts-expect-error TS(7006): Parameter 'opt' implicitly has an 'any' type.
 		let valueLabel = filter.options.find((opt) => opt.value === filter.value)
-			.label;
+			?.label || filter.value;
 		return (
 			<span>
 				{t(filter.label).substr(0, 40)}:


### PR DESCRIPTION
This fixes the admin interface crashing if there is no preset label for a given filter value. This will be the case, for example, if you filter for usernames.

Note that this is only reproducible with the mock data right now since there seems to be a bug with the production data that prevents rendering the value completely in that case, so you never reach this code 🙈

This fixes #526