### PR TITLE
Enable source maps

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     plugins: [react(), svgr(), viteTsconfigPaths()],
     build: {
         outDir: "build",
+        sourcemap: true,
     },
     server: {
         open: true,


### PR DESCRIPTION
Source maps are really valuable when debugging errors. They are disabled by default. This pull request enables them.