### PR TITLE
Scheduling information in event details for non-scheduled event

### DIFF
--- a/src/components/events/partials/modals/EventDetails.tsx
+++ b/src/components/events/partials/modals/EventDetails.tsx
@@ -129,7 +129,7 @@ const EventDetails : React.FC<{
 			accessRole: "ROLE_UI_EVENTS_DETAILS_SCHEDULING_VIEW",
 			name: "scheduling",
 			hidden:
-				!hasSchedulingProperties && hasAnyDeviceAccess(user, captureAgents),
+				!hasSchedulingProperties || !hasAnyDeviceAccess(user, captureAgents),
 		},
 		{
 			tabNameTranslation: "EVENTS.EVENTS.DETAILS.TABS.WORKFLOWS",

--- a/src/slices/eventDetailsSlice.ts
+++ b/src/slices/eventDetailsSlice.ts
@@ -2114,6 +2114,7 @@ const eventDetailsSlice = createSlice({
 				state.scheduling.hasProperties = true;
 			})
 			.addCase(fetchSchedulingInfo.rejected, (state, action) => {
+				// This usually means we have a non-scheduled event
 				state.statusScheduling = 'failed';
 				const emptySchedulingSource = {
 					start: {
@@ -2142,7 +2143,7 @@ const eventDetailsSlice = createSlice({
 				state.schedulingSource = emptySchedulingSource;
 				state.scheduling.hasProperties = false;
 				state.errorScheduling = action.error;
-				console.error(action.error);
+				console.debug(action.error);
 			})
 			// saveSchedulingInfo
 			.addCase(saveSchedulingInfo.pending, (state) => {


### PR DESCRIPTION
This patch fixes the problems that

- the scheduling tab is shown for non-scheduled event in event details
- a stack trace is logged as error when no scheduling information could be retrieved

This fixes #413