### PR TITLE
Make themes optional

### DIFF
--- a/src/components/events/partials/modals/SeriesDetails.tsx
+++ b/src/components/events/partials/modals/SeriesDetails.tsx
@@ -9,7 +9,7 @@ import {
 	getSeriesDetailsThemeNames,
 	hasStatistics as seriesHasStatistics,
 } from "../../../../selectors/seriesDetailsSelectors";
-import { getUserInformation } from "../../../../selectors/userInfoSelectors";
+import { getOrgProperties, getUserInformation } from "../../../../selectors/userInfoSelectors";
 import { hasAccess } from "../../../../utils/utils";
 import SeriesDetailsAccessTab from "../ModalTabsAndPages/SeriesDetailsAccessTab";
 import SeriesDetailsThemeTab from "../ModalTabsAndPages/SeriesDetailsThemeTab";
@@ -61,6 +61,8 @@ const SeriesDetails = ({
 	const [page, setPage] = useState(0);
 
 	const user = useAppSelector(state => getUserInformation(state));
+	const orgProperties = useAppSelector(state => getOrgProperties(state));
+	const themesEnabled = orgProperties['admin.themes.enabled']?.toLowerCase() === 'true';
 
 	// information about each tab
 	const tabs = [
@@ -84,6 +86,7 @@ const SeriesDetails = ({
 			tabNameTranslation: "EVENTS.SERIES.DETAILS.TABS.THEME",
 			accessRole: "ROLE_UI_SERIES_DETAILS_THEMES_VIEW",
 			name: "theme",
+			hidden: !theme && !themesEnabled
 		},
 		{
 			tabNameTranslation: "EVENTS.SERIES.DETAILS.TABS.STATISTICS",
@@ -117,7 +120,7 @@ const SeriesDetails = ({
 						{t(tabs[2].tabNameTranslation)}
 					</button>
 				)}
-				{hasAccess(tabs[3].accessRole, user) && (
+				{!tabs[3].hidden && hasAccess(tabs[3].accessRole, user) && (
 					<button className={"button-like-anchor " + cn({ active: page === 3 })} onClick={() => openTab(3)}>
 						{t(tabs[3].tabNameTranslation)}
 					</button>

--- a/src/components/events/partials/modals/SeriesDetails.tsx
+++ b/src/components/events/partials/modals/SeriesDetails.tsx
@@ -62,7 +62,7 @@ const SeriesDetails = ({
 
 	const user = useAppSelector(state => getUserInformation(state));
 	const orgProperties = useAppSelector(state => getOrgProperties(state));
-	const themesEnabled = orgProperties['admin.themes.enabled']?.toLowerCase() === 'true';
+	const themesEnabled = (orgProperties['admin.themes.enabled']?.toLowerCase() || 'true') === 'true';
 
 	// information about each tab
 	const tabs = [

--- a/src/components/events/partials/wizards/NewSeriesWizard.tsx
+++ b/src/components/events/partials/wizards/NewSeriesWizard.tsx
@@ -35,7 +35,7 @@ const NewSeriesWizard: React.FC<{
 	const user = useAppSelector(state => getUserInformation(state));
 	const orgProperties = useAppSelector(state => getOrgProperties(state));
 
-	const themesEnabled = orgProperties['admin.themes.enabled']?.toLowerCase() === 'true';
+	const themesEnabled = (orgProperties['admin.themes.enabled']?.toLowerCase() || 'true') === 'true';
 
 	const initialValues = getInitialValues(metadataFields, extendedMetadata, user);
 

--- a/src/components/events/partials/wizards/NewSeriesWizard.tsx
+++ b/src/components/events/partials/wizards/NewSeriesWizard.tsx
@@ -15,7 +15,7 @@ import { NewSeriesSchema } from "../../../../utils/validate";
 import { getInitialMetadataFieldValues } from "../../../../utils/resourceUtils";
 import { useAppDispatch, useAppSelector } from "../../../../store";
 import { postNewSeries } from "../../../../slices/seriesSlice";
-import { getUserInformation } from "../../../../selectors/userInfoSelectors";
+import { getOrgProperties, getUserInformation } from "../../../../selectors/userInfoSelectors";
 import { MetadataCatalog } from "../../../../slices/eventSlice";
 import { UserInfoState } from "../../../../slices/userInfoSlice";
 import { TransformedAcl } from "../../../../slices/aclDetailsSlice";
@@ -33,6 +33,9 @@ const NewSeriesWizard: React.FC<{
 	const metadataFields = useAppSelector(state => getSeriesMetadata(state));
 	const extendedMetadata = useAppSelector(state => getSeriesExtendedMetadata(state));
 	const user = useAppSelector(state => getUserInformation(state));
+	const orgProperties = useAppSelector(state => getOrgProperties(state));
+
+	const themesEnabled = orgProperties['admin.themes.enabled']?.toLowerCase() === 'true';
 
 	const initialValues = getInitialValues(metadataFields, extendedMetadata, user);
 
@@ -60,7 +63,7 @@ const NewSeriesWizard: React.FC<{
 		{
 			translation: "EVENTS.SERIES.NEW.THEME.CAPTION",
 			name: "theme",
-			hidden: false,
+			hidden: !themesEnabled,
 		},
 		{
 			translation: "EVENTS.SERIES.NEW.SUMMARY.CAPTION",

--- a/src/components/shared/MainNav.tsx
+++ b/src/components/shared/MainNav.tsx
@@ -75,7 +75,7 @@ const MainNav = ({
 	const orgProperties = useAppSelector(state => getOrgProperties(state));
 
 	const statisticsEnabled = orgProperties['admin.statistics.enabled']?.toLowerCase() === 'true';
-	const themesEnabled = orgProperties['admin.themes.enabled']?.toLowerCase() === 'true';
+	const themesEnabled = (orgProperties['admin.themes.enabled']?.toLowerCase() || 'true') === 'true';
 
 	const loadEvents = () => {
 		dispatch(fetchFilters("events"));

--- a/src/components/shared/MainNav.tsx
+++ b/src/components/shared/MainNav.tsx
@@ -75,6 +75,7 @@ const MainNav = ({
 	const orgProperties = useAppSelector(state => getOrgProperties(state));
 
 	const statisticsEnabled = orgProperties['admin.statistics.enabled']?.toLowerCase() === 'true';
+	const themesEnabled = orgProperties['admin.themes.enabled']?.toLowerCase() === 'true';
 
 	const loadEvents = () => {
 		dispatch(fetchFilters("events"));
@@ -310,7 +311,8 @@ const MainNav = ({
 										</Link>
 									)
 								))}
-							{hasAccess("ROLE_UI_NAV_CONFIGURATION_VIEW", user) &&
+							{themesEnabled &&
+								hasAccess("ROLE_UI_NAV_CONFIGURATION_VIEW", user) &&
 								hasAccess("ROLE_UI_THEMES_VIEW", user) && (
 									<Link to="/configuration/themes" onClick={() => loadThemes()}>
 										<Tooltip title={t("NAV.CONFIGURATION.TITLE")}>


### PR DESCRIPTION
Not all workflows/installations support theming which can be confusing as a user. This patch makes them optional in the admin interface and disable them by default. Admins can easily enable them in Opencast's organization configuration.

This fixes #523