### PR TITLE
Group events in bulk edit scheduled events tab

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/EditScheduledEventsEditPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EditScheduledEventsEditPage.tsx
@@ -111,6 +111,11 @@ const EditScheduledEventsEditPage = <T extends RequiredFormProps>({
 		return result;
 	}
 
+	const findSeriesName = (seriesOptions: { name: string, value: string }[], editedEvents: EditedEvents[]) => {
+		const series = seriesOptions.find((e) => e.value === reduceGroupedEvent(editedEvents).changedSeries)
+		return series ? series.name : ""
+	}
+
 	return (
 		<>
 			<div className="modal-content active">
@@ -161,6 +166,87 @@ const EditScheduledEventsEditPage = <T extends RequiredFormProps>({
 							<FieldArray name="editedEvents">
 								{({ insert, remove, push }) => (
 									<>
+									{hasAccess(
+										"ROLE_UI_EVENTS_DETAILS_METADATA_EDIT",
+										user
+									) && (
+										<div className="obj tbl-details">
+											<header>{t("BULK_ACTIONS.EDIT_EVENTS_METADATA.EDIT.TABLE.FIELDS")}</header>
+											<div className="obj-container">
+												<table className="main-tbl">
+													<tbody>
+														<tr>
+															<td>
+																<span>
+																	{t(
+																		"EVENTS.EVENTS.DETAILS.METADATA.TITLE"
+																	)}
+																</span>
+															</td>
+															<td className="editable ng-isolated-scope">
+															{/*
+																* Per event there are 14 input fields, so with 'key * 14', the right
+																* event is reached. After the '+' comes the number of the input field.
+																* This is the first input field for this event.
+																*/}
+																<input
+																	type={"text"}
+																	onChange={(element) => {
+																		for (const [i, value] of formik.values.editedEvents.entries()) {
+																			formik.setFieldValue(
+																				`editedEvents.${i}.changedTitle`,
+																				element.target.value
+																			)
+																		}
+																	}}
+																	defaultValue={formik.values.editedEvents.length > 0 ? reduceGroupedEvent(formik.values.editedEvents).title : ""}
+																/>
+															</td>
+														</tr>
+														<tr>
+															<td>
+																<span>
+																	{t(
+																		"EVENTS.EVENTS.DETAILS.METADATA.SERIES"
+																	)}
+																</span>
+															</td>
+															<td className="editable ng-isolated-scope">
+																{/*
+																	* Per event there are 14 input fields, so with 'key * 14', the right
+																	* event is reached. After the '+' comes the number of the input field.
+																	* This is the second input field for this event.
+																	*/}
+																<DropDown
+																	value={
+																		formik.values.editedEvents.length > 0 ? reduceGroupedEvent(formik.values.editedEvents).changedSeries : ""
+																	}
+																	text={
+																		formik.values.editedEvents.length > 0 ? findSeriesName(seriesOptions, formik.values.editedEvents) : ""
+																	}
+																	options={seriesOptions}
+																	type={"isPartOf"}
+																	required={false}
+																	handleChange={(element) => {
+																		if (element) {
+																			for (const [i, value] of formik.values.editedEvents.entries()) {
+																				formik.setFieldValue(
+																					`editedEvents.${i}.changedSeries`,
+																					element.value
+																				)
+																			}
+																		}
+																	}}
+																	placeholder={formik.values.editedEvents.length > 0 ? reduceGroupedEvent(formik.values.editedEvents).series : ""}
+																	tabIndex={2 * 14 + 2}
+																/>
+															</td>
+														</tr>
+													</tbody>
+												</table>
+											</div>
+										</div>
+									)}
 										{
 											reduceGroupEvents(Object.values(groupBy(formik.values.editedEvents, i => i.weekday))).map((groupedEvent, key) => (
 												<div className="obj tbl-details">

--- a/src/components/events/partials/ModalTabsAndPages/EditScheduledEventsEditPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EditScheduledEventsEditPage.tsx
@@ -22,6 +22,7 @@ import {
 	fetchScheduling,
 } from "../../../../slices/eventSlice";
 import { Recording } from "../../../../slices/recordingSlice";
+import lodash, { groupBy } from "lodash";
 
 /**
  * This component renders the edit page for scheduled events of the corresponding bulk action
@@ -76,6 +77,40 @@ const EditScheduledEventsEditPage = <T extends RequiredFormProps>({
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [formik.values.events]);
 
+	/**
+	 * For a given matrix of events, return an array of events where the events
+	 * have been grouped by their value
+	 */
+	const reduceGroupEvents = (events: EditedEvents[][] ) => {
+		const reducedEvents: EditedEvents[] = [];
+		for (const [key, value] of Object.entries(events)) {
+			reducedEvents.push(reduceGroupedEvent(value))
+		}
+		return reducedEvents;
+	}
+
+	/**
+	 * For a given array of events, returns an event where each property of the event is empty,
+	 * except if the value of the property was the exact same for all events in the array,
+	 * in which case the property is that value
+	 */
+	const reduceGroupedEvent = (groupedEvents: EditedEvents[]) => {
+		const result = groupedEvents.reduce((prev, curr) => {
+			for (const [key, value] of Object.entries(curr)) {
+				// TODO: This relies on the fact that the EditedEvent type only contains 'string' and 'string[]'. Improve on that.
+				if (typeof value === "string") {
+					// @ts-expect-error TS(7006):
+					prev[key as keyof EditedEvents] = prev[key as keyof EditedEvents] === curr[key as keyof EditedEvents] ? curr[key as keyof EditedEvents] : ""
+				} else {
+					// @ts-expect-error TS(7006):
+					prev[key as keyof EditedEvents] = prev[key as keyof EditedEvents] === curr[key as keyof EditedEvents] ? curr[key as keyof EditedEvents] : []
+				}
+			}
+			return prev;
+		}, lodash.cloneDeep(groupedEvents[0]));
+		return result;
+	}
+
 	return (
 		<>
 			<div className="modal-content active">
@@ -127,75 +162,18 @@ const EditScheduledEventsEditPage = <T extends RequiredFormProps>({
 								{({ insert, remove, push }) => (
 									<>
 										{
-											/*todo: in old UI this was grouped by weekday, which is also stated in the description in the div above
-                                        now there isn't any grouping and there is one div per event -> find out, if that is okay and adapt again if necessary */
-											formik.values.editedEvents.map((event, key) => (
+											reduceGroupEvents(Object.values(groupBy(formik.values.editedEvents, i => i.weekday))).map((groupedEvent, key) => (
 												<div className="obj tbl-details">
-													<header>{event.title}</header>
+													<header>{t("EVENTS.EVENTS.NEW.WEEKDAYSLONG." + groupedEvent.weekday)
+														+ " ("
+														+ t("BULK_ACTIONS.EDIT_EVENTS.EDIT.EVENTS")
+														+ " "
+														+ formik.values.editedEvents.reduce((acc, cur) => cur.weekday === groupedEvent.weekday  ? ++acc : acc, 0)
+														+ ")"}
+													</header>
 													<div className="obj-container">
 														<table className="main-tbl">
 															<tbody>
-																{/* Repeat for all metadata rows*/}
-																{hasAccess(
-																	"ROLE_UI_EVENTS_DETAILS_METADATA_EDIT",
-																	user
-																) && (
-																	<>
-																		<tr>
-																			<td>
-																				<span>
-																					{t(
-																						"EVENTS.EVENTS.DETAILS.METADATA.TITLE"
-																					)}
-																				</span>
-																			</td>
-																			<td className="editable ng-isolated-scope">
-																				{/*
-																				 * Per event there are 14 input fields, so with 'key * 14', the right
-																				 * event is reached. After the '+' comes the number of the input field.
-																				 * This is the first input field for this event.
-																				 */}
-																				<Field
-																					tabIndex={key * 14 + 1}
-																					name={`editedEvents.${key}.changedTitle`}
-																					metadataField={{
-																						type: "text",
-																					}}
-																					component={RenderField}
-																				/>
-																			</td>
-																		</tr>
-																		<tr>
-																			<td>
-																				<span>
-																					{t(
-																						"EVENTS.EVENTS.DETAILS.METADATA.SERIES"
-																					)}
-																				</span>
-																			</td>
-																			<td className="editable ng-isolated-scope">
-																				{/*
-																				 * Per event there are 14 input fields, so with 'key * 14', the right
-																				 * event is reached. After the '+' comes the number of the input field.
-																				 * This is the second input field for this event.
-																				 */}
-																				<Field
-																					tabIndex={key * 14 + 2}
-																					name={`editedEvents.${key}.changedSeries`}
-																					metadataField={{
-																						type: "text",
-																						collection: seriesOptions,
-																						id: "isPartOf",
-																						required:
-																							formik.values.editedEvents[key]
-																								.series !== "",
-																					}}
-																					component={RenderField}
-																				/>
-																			</td>
-																		</tr>
-																	</>
-																)}
 																{hasAccess(
 																	"ROLE_UI_EVENTS_DETAILS_SCHEDULING_EDIT",
 																	user
@@ -224,11 +202,11 @@ const EditScheduledEventsEditPage = <T extends RequiredFormProps>({
 																				 */}
 																				<DropDown
 																					value={
-																						formik.values.editedEvents[key]
+																						groupedEvent
 																							.changedStartTimeHour
 																					}
 																					text={
-																						formik.values.editedEvents[key]
+																						groupedEvent
 																							.changedStartTimeHour
 																					}
 																					options={hours}
@@ -236,10 +214,14 @@ const EditScheduledEventsEditPage = <T extends RequiredFormProps>({
 																					required={true}
 																					handleChange={(element) => {
 																						if (element) {
-																							formik.setFieldValue(
-																								`editedEvents.${key}.changedStartTimeHour`,
-																								element.value
-																							)
+																							for (const [i, value] of formik.values.editedEvents.entries()) {
+																								if (value.weekday == groupedEvent.weekday ) {
+																									formik.setFieldValue(
+																										`editedEvents.${i}.changedStartTimeHour`,
+																										element.value
+																									)
+																								}
+																							}
 																						}
 																					}}
 																					placeholder={t(
@@ -252,15 +234,15 @@ const EditScheduledEventsEditPage = <T extends RequiredFormProps>({
 																				 *
 																				 * Per event there are 14 input fields, so with 'key * 14', the right
 																				 * event is reached. After the '+' comes the number of the input field.
-																				 * This is the fourth input field for this event.
+																				 * This is the third input field for this event.
 																				 */}
 																				<DropDown
 																					value={
-																						formik.values.editedEvents[key]
+																						groupedEvent
 																							.changedStartTimeMinutes
 																					}
 																					text={
-																						formik.values.editedEvents[key]
+																						groupedEvent
 																							.changedStartTimeMinutes
 																					}
 																					options={minutes}
@@ -268,10 +250,14 @@ const EditScheduledEventsEditPage = <T extends RequiredFormProps>({
 																					required={true}
 																					handleChange={(element) => {
 																						if (element) {
-																							formik.setFieldValue(
-																								`editedEvents.${key}.changedStartTimeMinutes`,
-																								element.value
-																							)
+																							for (const [i, value] of formik.values.editedEvents.entries()) {
+																								if (value.weekday == groupedEvent.weekday ) {
+																									formik.setFieldValue(
+																										`editedEvents.${i}.changedStartTimeMinutes`,
+																										element.value
+																									)
+																								}
+																							}
 																						}
 																					}}
 																					placeholder={t(
@@ -292,15 +278,15 @@ const EditScheduledEventsEditPage = <T extends RequiredFormProps>({
 																				 *
 																				 * Per event there are 14 input fields, so with 'key * 14', the right
 																				 * event is reached. After the '+' comes the number of the input field.
-																				 * This is the fifth input field for this event.
+																				 * This is the third input field for this event.
 																				 */}
 																				<DropDown
 																					value={
-																						formik.values.editedEvents[key]
+																						groupedEvent
 																							.changedEndTimeHour
 																					}
 																					text={
-																						formik.values.editedEvents[key]
+																						groupedEvent
 																							.changedEndTimeHour
 																					}
 																					options={hours}
@@ -308,10 +294,14 @@ const EditScheduledEventsEditPage = <T extends RequiredFormProps>({
 																					required={true}
 																					handleChange={(element) => {
 																						if (element) {
-																							formik.setFieldValue(
-																								`editedEvents.${key}.changedEndTimeHour`,
-																								element.value
-																							)
+																							for (const [i, value] of formik.values.editedEvents.entries()) {
+																								if (value.weekday == groupedEvent.weekday ) {
+																									formik.setFieldValue(
+																										`editedEvents.${i}.changedEndTimeHour`,
+																										element.value
+																									)
+																								}
+																							}
 																						}
 																					}}
 																					placeholder={t(
@@ -324,15 +314,15 @@ const EditScheduledEventsEditPage = <T extends RequiredFormProps>({
 																				 *
 																				 * Per event there are 14 input fields, so with 'key * 14', the right
 																				 * event is reached. After the '+' comes the number of the input field.
-																				 * This is the sixth input field for this event.
+																				 * This is the third input field for this event.
 																				 */}
 																				<DropDown
 																					value={
-																						formik.values.editedEvents[key]
+																						groupedEvent
 																							.changedEndTimeMinutes
 																					}
 																					text={
-																						formik.values.editedEvents[key]
+																						groupedEvent
 																							.changedEndTimeMinutes
 																					}
 																					options={minutes}
@@ -340,10 +330,14 @@ const EditScheduledEventsEditPage = <T extends RequiredFormProps>({
 																					required={true}
 																					handleChange={(element) => {
 																						if (element) {
-																							formik.setFieldValue(
-																								`editedEvents.${key}.changedEndTimeMinutes`,
-																								element.value
-																							)
+																							for (const [i, value] of formik.values.editedEvents.entries()) {
+																								if (value.weekday == groupedEvent.weekday ) {
+																									formik.setFieldValue(
+																										`editedEvents.${i}.changedEndTimeMinutes`,
+																										element.value
+																									)
+																								}
+																							}
 																						}
 																					}}
 																					placeholder={t(
@@ -358,7 +352,7 @@ const EditScheduledEventsEditPage = <T extends RequiredFormProps>({
 																		 *
 																		 * Per event there are 14 input fields, so with 'key * 14', the right
 																		 * event is reached. After the '+' comes the number of the input field.
-																		 * This is the seventh input field for this event.
+																		 * This is the third input field for this event.
 																		 */}
 																		<tr>
 																			<td>
@@ -369,11 +363,11 @@ const EditScheduledEventsEditPage = <T extends RequiredFormProps>({
 																			<td className="editable ng-isolated-scope">
 																				<DropDown
 																					value={
-																						formik.values.editedEvents[key]
+																						groupedEvent
 																							.changedLocation
 																					}
 																					text={
-																						formik.values.editedEvents[key]
+																						groupedEvent
 																							.changedLocation
 																					}
 																					options={inputDevices}
@@ -381,14 +375,18 @@ const EditScheduledEventsEditPage = <T extends RequiredFormProps>({
 																					required={true}
 																					handleChange={(element) => {
 																						if (element) {
-																							formik.setFieldValue(
-																								`editedEvents.${key}.changedLocation`,
-																								element.value
-																							);
-																							formik.setFieldValue(
-																								`editedEvents.${key}.changedDeviceInputs`,
-																								[]
-																							);
+																							for (const [i, value] of formik.values.editedEvents.entries()) {
+																								if (value.weekday == groupedEvent.weekday ) {
+																									formik.setFieldValue(
+																										`editedEvents.${i}.changedLocation`,
+																										element.value
+																									)
+																									formik.setFieldValue(
+																										`editedEvents.${i}.changedDeviceInputs`,
+																										element.value
+																									)
+																								}
+																							}
 																						}
 																					}}
 																					placeholder={`-- ${t(
@@ -412,9 +410,6 @@ const EditScheduledEventsEditPage = <T extends RequiredFormProps>({
 
 																		{/* Radio buttons for weekdays
 																		 *
-																		 * Per event there are 14 input fields, so with 'key * 14', the right
-																		 * event is reached. After the '+' comes the number of the input field.
-																		 * These radio buttons are input fields 8 to 14 for this event.
 																		 */}
 																		<tr>
 																			<td>
@@ -423,17 +418,30 @@ const EditScheduledEventsEditPage = <T extends RequiredFormProps>({
 																				)}
 																			</td>
 																			<td className="weekdays">
+																				<fieldset>
 																				{weekdays.map((day, index) => (
 																					<label key={index}>
-																						<Field
+																						<input
 																							tabIndex={key * 14 + 8 + index}
 																							type="radio"
-																							name={`editedEvents.${key}.changedWeekday`}
+																							name={groupedEvent.weekday}
+																							onChange={(element) => {
+																								for (const [i, value] of formik.values.editedEvents.entries()) {
+																									if (value.weekday == groupedEvent.weekday ) {
+																										formik.setFieldValue(
+																											`editedEvents.${i}.changedWeekday`,
+																											element.target.value
+																										)
+																									}
+																								}
+																							}}
+																							defaultChecked={groupedEvent.weekday === day.name}
 																							value={day.name}
 																						/>
 																						{t(day.label)}
 																					</label>
 																				))}
+																				</fieldset>
 																			</td>
 																		</tr>
 																	</>


### PR DESCRIPTION
Aims at fixing #533.

You can bulk edit scheduled events in the admin ui. However, they were not grouped by weekday anymore, but each event was listed individually, which is not really bulk editing at all. This groups the events by weekday again.

Known issues:
- ~The old ui also allow bulk editing of capture agent inputs. This was and still is missing from the new ui. Want to bring this back, but will have to investigate (might need backend changes).~
   - Seems the old admin ui did not fully support inputs either? Would leave that for a separate PR in that case.
- ~The old ui would also allow bulk editing for metadata title and series, regardless of weekday. This is still missing. Planning on bringing that back.~
  - Should be fixed now.

Currently looks like:
![Bildschirmfoto vom 2024-06-14 15-37-19](https://github.com/opencast/opencast-admin-interface/assets/14070005/87f3f999-21c4-4ee4-bf96-a9d8592d3ac3)
