### PR TITLE
Set initial sort column to "title"

### DIFF
--- a/src/reducers/tableReducers.ts
+++ b/src/reducers/tableReducers.ts
@@ -50,7 +50,7 @@ const initialState = {
 	resource: "",
 	pages: [],
 	columns: [],
-	sortBy: "",
+	sortBy: "title",
 	predicate: "",
 	reverse: "ASC",
 	rows: [],


### PR DESCRIPTION
When initially loading the admin ui, the events table will  reorder itself after a few moments. This avoids the reordering by initializing table sorting parameters with "title" for the "sort by column" parameter.

Fixes #610