### PR TITLE
Remove unused `eslint` config

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,9 +49,6 @@
     "serve": "vite preview",
     "test": "vitest"
   },
-  "eslintConfig": {
-    "extends": "react-app"
-  },
   "browserslist": {
     "production": [
       ">0.2%",


### PR DESCRIPTION
WIth #471 we unfortunately lost ESLint. I plan to add it back, but for now, we don't need this config anymore, and the new one will look different anyway.