### PR TITLE
Refetch event ACL after saving

### DIFF
--- a/src/slices/eventDetailsSlice.ts
+++ b/src/slices/eventDetailsSlice.ts
@@ -1631,6 +1631,7 @@ export const saveAccessPolicies = createAsyncThunk('eventDetails/saveAccessPolic
 		.post(`/admin-ng/event/${eventId}/access`, data.toString(), headers)
 		.then((response) => {
 			console.info(response);
+			dispatch(fetchAccessPolicies(eventId))
 			dispatch(
 				addNotification({
 					type: "info",


### PR DESCRIPTION
After successfully saving event ACL, refetch event ACL from backend and update our state accordingly. This should fix some niche issues, such as described in #353.