### PR TITLE
Make selected table filter smaller

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -405,7 +405,7 @@ div.table-filter {
     }
 
     .ng-multi-value {
-      padding: 5px;
+      align-self: center;
     }
 
     .MuiInputBase-root {


### PR DESCRIPTION
After selecting a filter, the displayed filter would increase the size of the surrounding box, causing the row of buttons to be misaligned. This fixes that be removing some unnecessary padding.

Fixes #449.

Before
![Bildschirmfoto vom 2024-06-18 17-00-47](https://github.com/opencast/opencast-admin-interface/assets/14070005/4c8b6280-70d5-458d-8fb2-b8162b26d38e)

After
![Bildschirmfoto vom 2024-06-18 17-00-36](https://github.com/opencast/opencast-admin-interface/assets/14070005/c72aad99-934d-4755-ad95-5690ebc89a0c)
