### PR TITLE
Get rid of Vite build warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "@types/uuid": "^9.0.8",
         "@vitejs/plugin-react-swc": "^3.7.0",
         "prop-types": "^15.8.1",
+        "rollup-preserve-directives": "^1.1.1",
         "sass": "^1.77.4",
         "typescript": "^5.4.5",
         "uuid": "^9.0.1",
@@ -4304,6 +4305,55 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.18.0.tgz",
+      "integrity": "sha512-QmJz14PX3rzbJCN1SG4Xe/bAAX2a6NpCP8ab2vfu2GiUr8AQcr2nCV/oEO3yneFarB67zk8ShlIyWb2LGTb3Sg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.5"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.18.0",
+        "@rollup/rollup-android-arm64": "4.18.0",
+        "@rollup/rollup-darwin-arm64": "4.18.0",
+        "@rollup/rollup-darwin-x64": "4.18.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.18.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.18.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.18.0",
+        "@rollup/rollup-linux-arm64-musl": "4.18.0",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.18.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.18.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.18.0",
+        "@rollup/rollup-linux-x64-gnu": "4.18.0",
+        "@rollup/rollup-linux-x64-musl": "4.18.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.18.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.18.0",
+        "@rollup/rollup-win32-x64-msvc": "4.18.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup-preserve-directives": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/rollup-preserve-directives/-/rollup-preserve-directives-1.1.1.tgz",
+      "integrity": "sha512-+eQafbuEfDPfxQ9hQPlwaROfin4yiVRxap8hnrvvvcSGoukv1tTiYpAW9mvm3uR8J+fe4xd8FdVd5rz9q7jZ+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.5"
+      },
+      "peerDependencies": {
+        "rollup": "^2.0.0 || ^3.0.0 || ^4.0.0"
+      }
+    },
     "node_modules/sass": {
       "version": "1.77.4",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.4.tgz",
@@ -4870,41 +4920,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite/node_modules/rollup": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.18.0.tgz",
-      "integrity": "sha512-QmJz14PX3rzbJCN1SG4Xe/bAAX2a6NpCP8ab2vfu2GiUr8AQcr2nCV/oEO3yneFarB67zk8ShlIyWb2LGTb3Sg==",
-      "dev": true,
-      "dependencies": {
-        "@types/estree": "1.0.5"
-      },
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
-      },
-      "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.18.0",
-        "@rollup/rollup-android-arm64": "4.18.0",
-        "@rollup/rollup-darwin-arm64": "4.18.0",
-        "@rollup/rollup-darwin-x64": "4.18.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.18.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.18.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.18.0",
-        "@rollup/rollup-linux-arm64-musl": "4.18.0",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.18.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.18.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.18.0",
-        "@rollup/rollup-linux-x64-gnu": "4.18.0",
-        "@rollup/rollup-linux-x64-musl": "4.18.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.18.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.18.0",
-        "@rollup/rollup-win32-x64-msvc": "4.18.0",
-        "fsevents": "~2.3.2"
       }
     },
     "node_modules/vitest": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@types/uuid": "^9.0.8",
     "@vitejs/plugin-react-swc": "^3.7.0",
     "prop-types": "^15.8.1",
+    "rollup-preserve-directives": "^1.1.1",
     "sass": "^1.77.4",
     "typescript": "^5.4.5",
     "uuid": "^9.0.1",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,10 +2,11 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import svgr from "vite-plugin-svgr";
 import viteTsconfigPaths from "vite-tsconfig-paths";
+import preserveDirectives from "rollup-preserve-directives";
 
 export default defineConfig({
     base: process.env.PUBLIC_URL || "",
-    plugins: [react(), svgr(), viteTsconfigPaths()],
+    plugins: [react(), svgr(), viteTsconfigPaths(), preserveDirectives()],
     build: {
         outDir: "build",
         sourcemap: true,


### PR DESCRIPTION
There are quite a few errors like the following in the output of `npm run build`:

    Error when using sourcemap for reporting an error: Can't resolve original location of error.

They all relate to the `@mui` package(-s). This seems to be related to https://github.com/vitejs/vite/issues/15012.
I don't fully understand it, but apparently Rollup, which is used by Vite internally somehow,
doesn't preserve enough information to generate source maps properly.

This patch adds a plugin to do exactly that. We should probably remove it in the long run,
if the upstream issue(-s) ever get fixed. I created #708 to track that.

/cc https://github.com/opencast/opencast-admin-interface/pull/685
