### PR TITLE
Fix type error for missing organization property

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -22,7 +22,7 @@ const Footer: React.FC = () => {
 	const lastModified = user?.ocVersion?.['last-modified']
 		? new Date(user.ocVersion['last-modified']).toISOString().substring(0, 10)
 		: 'unknown';
-	const aboutEnabled = orgProperties['org.opencastproject.admin.display_about']?.toLowerCase() === 'true';
+	const aboutEnabled = (orgProperties['org.opencastproject.admin.display_about'] || 'false').toLowerCase() === 'true';
 
 	return (
 		<footer id="main-footer">

--- a/src/components/events/partials/modals/SeriesDetails.tsx
+++ b/src/components/events/partials/modals/SeriesDetails.tsx
@@ -62,7 +62,7 @@ const SeriesDetails = ({
 
 	const user = useAppSelector(state => getUserInformation(state));
 	const orgProperties = useAppSelector(state => getOrgProperties(state));
-	const themesEnabled = (orgProperties['admin.themes.enabled']?.toLowerCase() || 'true') === 'true';
+	const themesEnabled = (orgProperties['admin.themes.enabled'] || 'true').toLowerCase() === 'true';
 
 	// information about each tab
 	const tabs = [

--- a/src/components/events/partials/wizards/NewSeriesWizard.tsx
+++ b/src/components/events/partials/wizards/NewSeriesWizard.tsx
@@ -35,7 +35,7 @@ const NewSeriesWizard: React.FC<{
 	const user = useAppSelector(state => getUserInformation(state));
 	const orgProperties = useAppSelector(state => getOrgProperties(state));
 
-	const themesEnabled = (orgProperties['admin.themes.enabled']?.toLowerCase() || 'true') === 'true';
+	const themesEnabled = (orgProperties['admin.themes.enabled'] || 'true').toLowerCase() === 'true';
 
 	const initialValues = getInitialValues(metadataFields, extendedMetadata, user);
 

--- a/src/components/shared/MainNav.tsx
+++ b/src/components/shared/MainNav.tsx
@@ -74,8 +74,8 @@ const MainNav = ({
 	const user = useAppSelector(state => getUserInformation(state));
 	const orgProperties = useAppSelector(state => getOrgProperties(state));
 
-	const statisticsEnabled = orgProperties['admin.statistics.enabled']?.toLowerCase() === 'true';
-	const themesEnabled = (orgProperties['admin.themes.enabled']?.toLowerCase() || 'true') === 'true';
+	const statisticsEnabled = (orgProperties['admin.statistics.enabled'] || 'false').toLowerCase() === 'true';
+	const themesEnabled = (orgProperties['admin.themes.enabled'] || 'true').toLowerCase() === 'true';
 
 	const loadEvents = () => {
 		dispatch(fetchFilters("events"));


### PR DESCRIPTION
If an organization property does not exist, the admin interface completely breaks in some cases. This seems to happen on admin-interface.opencast.org right now:

```
Uncaught TypeError: u.toLowerCase is not a function
    qr Footer.tsx:25
    React 8
    D scheduler.production.min.js:13
    $ scheduler.production.min.js:14
Footer.tsx:25:80
```

What's interesting is that this only seems to happen with the compiled code. Starting the development server, calling `toLowerCase()` just works.

In any case, this patch fixes the issue by providing the default value first, so that `toLowerCase()` is always called on a string.