### PR TITLE
Custom roles in ACL policy

### DIFF
--- a/src/components/shared/DropDown.tsx
+++ b/src/components/shared/DropDown.tsx
@@ -8,7 +8,7 @@ import {
 	filterBySearch,
 	formatDropDownOptions,
 } from "../../utils/dropDownUtils";
-import Select, { Theme } from "react-select";
+import Select, { Props } from "react-select";
 import CreatableSelect from "react-select/creatable";
 
 /**
@@ -56,9 +56,9 @@ const DropDown = <T,>({
 
 	const style = dropDownStyle(type);
 
-	const commonProps = {
+	const commonProps: Props = {
 		tabIndex: tabIndex,
-		theme: (theme: Theme) => (dropDownSpacingTheme(theme)),
+		theme: (theme) => (dropDownSpacingTheme(theme)),
 		styles: style,
 		defaultMenuIsOpen: defaultOpen,
 		autoFocus: autoFocus,
@@ -73,7 +73,7 @@ const DropDown = <T,>({
 		),
 		placeholder: placeholder,
 		onInputChange: (value: string) => setSearch(value),
-		onChange: (element: {value: T, label: string} | null) => handleChange(element),
+		onChange: (element) => handleChange(element as {value: T, label: string}),
 		isDisabled: disabled,
 	};
 

--- a/src/components/shared/DropDown.tsx
+++ b/src/components/shared/DropDown.tsx
@@ -8,7 +8,8 @@ import {
 	filterBySearch,
 	formatDropDownOptions,
 } from "../../utils/dropDownUtils";
-import Select from "react-select";
+import Select, { Theme } from "react-select";
+import CreatableSelect from "react-select/creatable";
 
 /**
  * TODO: Ideally, we would remove "type", and just type the "options" array properly.
@@ -33,6 +34,7 @@ const DropDown = <T,>({
 	tabIndex = 0,
 	autoFocus = false,
 	defaultOpen = false,
+	creatable = false,
 	disabled = false,
 }: {
 	value: T
@@ -45,6 +47,7 @@ const DropDown = <T,>({
 	tabIndex?: number,
 	autoFocus?: boolean,
 	defaultOpen?: boolean,
+	creatable?: boolean,
 	disabled?: boolean,
 }) => {
 	const { t } = useTranslation();
@@ -53,28 +56,40 @@ const DropDown = <T,>({
 
 	const style = dropDownStyle(type);
 
+	const commonProps = {
+		tabIndex: tabIndex,
+		theme: (theme: Theme) => (dropDownSpacingTheme(theme)),
+		styles: style,
+		defaultMenuIsOpen: defaultOpen,
+		autoFocus: autoFocus,
+		isSearchable: true,
+		value: { value: value, label: text === "" ? placeholder : text },
+		inputValue: searchText,
+		options: formatDropDownOptions(
+			filterBySearch(searchText.toLowerCase(), type, options, t),
+			type,
+			required,
+			t
+		),
+		placeholder: placeholder,
+		onInputChange: (value: string) => setSearch(value),
+		onChange: (element: {value: T, label: string} | null) => handleChange(element),
+		isDisabled: disabled,
+	};
+
 	return (
-		<Select
-			tabIndex={tabIndex}
-			theme={(theme) => (dropDownSpacingTheme(theme))}
-			styles={style}
-			defaultMenuIsOpen={defaultOpen}
-			autoFocus={autoFocus}
-			isSearchable
-			value={{ value: value, label: text === "" ? placeholder : text }}
-			inputValue={searchText}
-			options={formatDropDownOptions(
-				filterBySearch(searchText.toLowerCase(), type, options, t),
-				type,
-				required,
-				t
+		<div>
+			{creatable ? (
+				<CreatableSelect
+					{...commonProps}
+					noOptionsMessage={() => "No matching results."}
+				/>
+			) : (
+				<Select
+					{...commonProps}
+				/>
 			)}
-			placeholder={placeholder}
-			noOptionsMessage={() => "No matching results."}
-			onInputChange={(value) => setSearch(value)}
-			onChange={(element) => handleChange(element as {value: T, label: string} )}
-			isDisabled={disabled}
-		/>
+		</div>
 	);
 };
 

--- a/src/components/shared/DropDown.tsx
+++ b/src/components/shared/DropDown.tsx
@@ -82,11 +82,11 @@ const DropDown = <T,>({
 			{creatable ? (
 				<CreatableSelect
 					{...commonProps}
-					noOptionsMessage={() => "No matching results."}
 				/>
 			) : (
 				<Select
 					{...commonProps}
+					noOptionsMessage={() => t("SELECT_NO_MATCHING_RESULTS")}
 				/>
 			)}
 		</div>

--- a/src/components/shared/modals/ResourceDetailsAccessPolicyTab.tsx
+++ b/src/components/shared/modals/ResourceDetailsAccessPolicyTab.tsx
@@ -430,6 +430,7 @@ const ResourceDetailsAccessPolicyTab = ({
 																										}
 																										type={"aclRole"}
 																										required={true}
+																										creatable={policy.allowNewRole}
 																										handleChange={(element) => {
 																											if (element) {
 																												replace(index, {
@@ -439,13 +440,17 @@ const ResourceDetailsAccessPolicyTab = ({
 																											}
 																										}}
 																										placeholder={
-																											roles.length > 0
+																											policy.allowNewRole
+																												? t(
+																														"EVENTS.EVENTS.DETAILS.ACCESS.ROLES.CREATE"
+																													)
+																												: roles.length > 0
 																												? t(
 																														"EVENTS.EVENTS.DETAILS.ACCESS.ROLES.LABEL"
-																												  )
+																													)
 																												: t(
 																														"EVENTS.EVENTS.DETAILS.ACCESS.ROLES.EMPTY"
-																												  )
+																													)
 																										}
 																										disabled={
 																											!hasAccess(
@@ -585,6 +590,17 @@ const ResourceDetailsAccessPolicyTab = ({
 																								+{" "}
 																								{t(
 																									"EVENTS.EVENTS.DETAILS.ACCESS.ACCESS_POLICY.NEW"
+																								)}
+																							</button>
+																							<button
+																								onClick={() =>
+																									push(createPolicy("", true))
+																								}
+                                                className="button-like-anchor"
+																							>
+																								+{" "}
+																								{t(
+																									"EVENTS.EVENTS.DETAILS.ACCESS.ACCESS_POLICY.NEW_ROLE"
 																								)}
 																							</button>
 																						</td>

--- a/src/components/shared/modals/ResourceDetailsAccessPolicyTab.tsx
+++ b/src/components/shared/modals/ResourceDetailsAccessPolicyTab.tsx
@@ -430,7 +430,7 @@ const ResourceDetailsAccessPolicyTab = ({
 																										}
 																										type={"aclRole"}
 																										required={true}
-																										creatable={policy.allowNewRole}
+																										creatable={true}
 																										handleChange={(element) => {
 																											if (element) {
 																												replace(index, {
@@ -440,17 +440,7 @@ const ResourceDetailsAccessPolicyTab = ({
 																											}
 																										}}
 																										placeholder={
-																											policy.allowNewRole
-																												? t(
-																														"EVENTS.EVENTS.DETAILS.ACCESS.ROLES.CREATE"
-																													)
-																												: roles.length > 0
-																												? t(
-																														"EVENTS.EVENTS.DETAILS.ACCESS.ROLES.LABEL"
-																													)
-																												: t(
-																														"EVENTS.EVENTS.DETAILS.ACCESS.ROLES.EMPTY"
-																													)
+																											t("EVENTS.EVENTS.DETAILS.ACCESS.ROLES.LABEL")
 																										}
 																										disabled={
 																											!hasAccess(
@@ -590,17 +580,6 @@ const ResourceDetailsAccessPolicyTab = ({
 																								+{" "}
 																								{t(
 																									"EVENTS.EVENTS.DETAILS.ACCESS.ACCESS_POLICY.NEW"
-																								)}
-																							</button>
-																							<button
-																								onClick={() =>
-																									push(createPolicy("", true))
-																								}
-                                                className="button-like-anchor"
-																							>
-																								+{" "}
-																								{t(
-																									"EVENTS.EVENTS.DETAILS.ACCESS.ACCESS_POLICY.NEW_ROLE"
 																								)}
 																							</button>
 																						</td>

--- a/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
@@ -861,13 +861,10 @@
 						"ADDITIONAL_ACTIONS": "Additional Actions",
 						"ACTION": "Actions",
 						"NEW": "New policy",
-						"NEW_ROLE": "New custom role",
 						"DETAILS": "Details"
 					},
 					"ROLES": {
-						"LABEL": "Select a role",
-						"CREATE": "Enter a new role",
-						"EMPTY": "No role found"
+						"LABEL": "Select or create a role"
 					}
 				},
 				"COMMENTS": {

--- a/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
@@ -861,10 +861,12 @@
 						"ADDITIONAL_ACTIONS": "Additional Actions",
 						"ACTION": "Actions",
 						"NEW": "New policy",
+						"NEW_ROLE": "New custom role",
 						"DETAILS": "Details"
 					},
 					"ROLES": {
 						"LABEL": "Select a role",
+						"CREATE": "Enter a new role",
 						"EMPTY": "No role found"
 					}
 				},

--- a/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
@@ -20,6 +20,7 @@
 	"RESET": "Reset",
 	"SELECT_NO_OPTION_SELECTED": "No option selected",
 	"SELECT_NO_OPTIONS_AVAILABLE": "No options available",
+	"SELECT_NO_MATCHING_RESULTS": "No matching results.",
 	"YES": "Yes",
 	"COPY": "Copy to clipboard",
 	"UPDATE": {

--- a/src/utils/resourceUtils.ts
+++ b/src/utils/resourceUtils.ts
@@ -582,12 +582,11 @@ export const buildThemeBody = (values) => {
 
 // creates an empty policy with the role from the argument
 // @ts-expect-error TS(7006): Parameter 'role' implicitly has an 'any' type.
-export const createPolicy = (role, allowNewRole: boolean = false) => {
+export const createPolicy = (role) => {
 	return {
 		role: role,
 		read: false,
 		write: false,
 		actions: [],
-		allowNewRole: allowNewRole,
 	};
 };

--- a/src/utils/resourceUtils.ts
+++ b/src/utils/resourceUtils.ts
@@ -582,11 +582,12 @@ export const buildThemeBody = (values) => {
 
 // creates an empty policy with the role from the argument
 // @ts-expect-error TS(7006): Parameter 'role' implicitly has an 'any' type.
-export const createPolicy = (role) => {
+export const createPolicy = (role, allowNewRole: boolean = false) => {
 	return {
 		role: role,
 		read: false,
 		write: false,
 		actions: [],
+		allowNewRole: allowNewRole,
 	};
 };


### PR DESCRIPTION
# Changes
- Add create option function to dropdown component
- Add button "new custom role" to create a policy with a new custom role

# Alternative 
We could show only one button "new policy" and enable the creation in the dropdown

# Screenshot
![grafik](https://github.com/opencast/opencast-admin-interface/assets/44410838/9d8b1f08-b44c-4b60-9c3f-681e6090804f)

Close #658