### PR TITLE
remove tabindex from drop downs

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/EditScheduledEventsEditPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EditScheduledEventsEditPage.tsx
@@ -245,7 +245,6 @@ const EditScheduledEventsEditPage = <T extends RequiredFormProps>({
 																					placeholder={t(
 																						"EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.HOUR"
 																					)}
-																					tabIndex={key * 14 + 3}
 																				/>
 
 																				{/* drop-down for minute
@@ -277,7 +276,6 @@ const EditScheduledEventsEditPage = <T extends RequiredFormProps>({
 																					placeholder={t(
 																						"EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.MINUTE"
 																					)}
-																					tabIndex={key * 14 + 4}
 																				/>
 																			</td>
 																		</tr>
@@ -317,7 +315,6 @@ const EditScheduledEventsEditPage = <T extends RequiredFormProps>({
 																					placeholder={t(
 																						"EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.HOUR"
 																					)}
-																					tabIndex={key * 14 + 5}
 																				/>
 
 																				{/* drop-down for minute
@@ -349,7 +346,6 @@ const EditScheduledEventsEditPage = <T extends RequiredFormProps>({
 																					placeholder={t(
 																						"EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.MINUTE"
 																					)}
-																					tabIndex={key * 14 + 6}
 																				/>
 																			</td>
 																		</tr>
@@ -394,7 +390,6 @@ const EditScheduledEventsEditPage = <T extends RequiredFormProps>({
 																					placeholder={`-- ${t(
 																						"SELECT_NO_OPTION_SELECTED"
 																					)} --`}
-																					tabIndex={key * 14 + 7}
 																				/>
 																			</td>
 																		</tr>
@@ -474,7 +469,6 @@ const EditScheduledEventsEditPage = <T extends RequiredFormProps>({
 							nextPage(formik.values);
 						}
 					}}
-					tabIndex={100}
 				>
 					{t("WIZARD.NEXT_STEP")}
 				</button>
@@ -488,7 +482,6 @@ const EditScheduledEventsEditPage = <T extends RequiredFormProps>({
 							setPageCompleted([]);
 						}
 					}}
-					tabIndex={101}
 				>
 					{t("WIZARD.BACK")}
 				</button>

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsCommentsTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsCommentsTab.tsx
@@ -260,7 +260,6 @@ const EventDetailsCommentsTab = ({
 												placeholder={t(
 													"EVENTS.EVENTS.DETAILS.COMMENTS.SELECTPLACEHOLDER"
 												)}
-												tabIndex={5}
 											/>
 										</div>
 

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsSchedulingTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsSchedulingTab.tsx
@@ -343,7 +343,6 @@ const EventDetailsSchedulingTab = ({
 																	placeholder={t(
 																		"EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.HOUR"
 																	)}
-																	tabIndex={2}
 																	disabled={
 																		!accessAllowed(formik.values.captureAgent)
 																	}
@@ -373,7 +372,6 @@ const EventDetailsSchedulingTab = ({
 																	placeholder={t(
 																		"EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.MINUTE"
 																	)}
-																	tabIndex={3}
 																	disabled={
 																		!accessAllowed(formik.values.captureAgent)
 																	}
@@ -419,7 +417,6 @@ const EventDetailsSchedulingTab = ({
 																		}
 																	}}
 																	placeholder={t("WIZARD.DURATION.HOURS")}
-																	tabIndex={4}
 																	disabled={
 																		!accessAllowed(formik.values.captureAgent)
 																	}
@@ -449,7 +446,6 @@ const EventDetailsSchedulingTab = ({
 																		}
 																	}}
 																	placeholder={t("WIZARD.DURATION.MINUTES")}
-																	tabIndex={5}
 																	disabled={
 																		!accessAllowed(formik.values.captureAgent)
 																	}
@@ -497,7 +493,6 @@ const EventDetailsSchedulingTab = ({
 																	placeholder={t(
 																		"EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.HOUR"
 																	)}
-																	tabIndex={6}
 																	disabled={
 																		!accessAllowed(formik.values.captureAgent)
 																	}
@@ -527,7 +522,6 @@ const EventDetailsSchedulingTab = ({
 																	placeholder={t(
 																		"EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.MINUTE"
 																	)}
-																	tabIndex={7}
 																	disabled={
 																		!accessAllowed(formik.values.captureAgent)
 																	}
@@ -599,7 +593,6 @@ const EventDetailsSchedulingTab = ({
 																	placeholder={t(
 																		"EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.LOCATION"
 																	)}
-																	tabIndex={8}
 																	disabled={
 																		!accessAllowed(formik.values.captureAgent)
 																	}

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowTab.tsx
@@ -379,7 +379,6 @@ const EventDetailsWorkflowTab = ({
 																									"EVENTS.EVENTS.NEW.PROCESSING.SELECT_WORKFLOW_EMPTY"
 																							  )
 																					}
-																					tabIndex={5}
 																					disabled={
 																						!hasCurrentAgentAccess() ||
 																						!isRoleWorkflowEdit

--- a/src/components/events/partials/ModalTabsAndPages/NewAccessPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewAccessPage.tsx
@@ -151,7 +151,6 @@ const NewAccessPage = ({
 																			placeholder={t(
 																				"EVENTS.SERIES.NEW.ACCESS.ACCESS_POLICY.LABEL"
 																			)}
-																			tabIndex={1}
 																			autoFocus={true}
 																		/>
 																	</div>
@@ -246,7 +245,6 @@ const NewAccessPage = ({
 																								placeholder={t(
 																									"EVENTS.SERIES.NEW.ACCESS.ROLES.LABEL"
 																								)}
-																								tabIndex={index + 1}
 																								disabled={
 																									!hasAccess(
 																										editAccessRole,

--- a/src/components/events/partials/ModalTabsAndPages/NewProcessingPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewProcessingPage.tsx
@@ -89,7 +89,6 @@ const NewProcessingPage = <T extends RequiredFormProps>({
 											placeholder={t(
 												"EVENTS.EVENTS.NEW.PROCESSING.SELECT_WORKFLOW"
 											)}
-											tabIndex={99}
 										/>
 									</div>
 								) : (

--- a/src/components/events/partials/ModalTabsAndPages/NewSourcePage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewSourcePage.tsx
@@ -532,7 +532,6 @@ const Schedule = <T extends {
 										}
 									}}
 									placeholder={t("EVENTS.EVENTS.NEW.SOURCE.PLACEHOLDER.HOUR")}
-									tabIndex={13}
 								/>
 
 								{/* drop-down for minute
@@ -563,7 +562,6 @@ const Schedule = <T extends {
 										}
 									}}
 									placeholder={t("EVENTS.EVENTS.NEW.SOURCE.PLACEHOLDER.MINUTE")}
-									tabIndex={14}
 								/>
 							</td>
 						</tr>
@@ -601,7 +599,6 @@ const Schedule = <T extends {
 										}
 									}}
 									placeholder={t("EVENTS.EVENTS.NEW.SOURCE.PLACEHOLDER.HOUR")}
-									tabIndex={15}
 								/>
 
 								{/* drop-down for minute
@@ -632,7 +629,6 @@ const Schedule = <T extends {
 										}
 									}}
 									placeholder={t("EVENTS.EVENTS.NEW.SOURCE.PLACEHOLDER.MINUTE")}
-									tabIndex={16}
 								/>
 							</td>
 						</tr>
@@ -670,7 +666,6 @@ const Schedule = <T extends {
 										}
 									}}
 									placeholder={t("EVENTS.EVENTS.NEW.SOURCE.PLACEHOLDER.HOUR")}
-									tabIndex={17}
 								/>
 
 								{/* drop-down for minute
@@ -701,7 +696,6 @@ const Schedule = <T extends {
 										}
 									}}
 									placeholder={t("EVENTS.EVENTS.NEW.SOURCE.PLACEHOLDER.MINUTE")}
-									tabIndex={18}
 								/>
 
 								{/* display end date if on different day to start date, only if this is current source mode */}
@@ -741,7 +735,6 @@ const Schedule = <T extends {
 									placeholder={t(
 										"EVENTS.EVENTS.NEW.SOURCE.PLACEHOLDER.LOCATION"
 									)}
-									tabIndex={19}
 								/>
 							</td>
 						</tr>

--- a/src/components/events/partials/ModalTabsAndPages/NewThemePage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewThemePage.tsx
@@ -69,7 +69,6 @@ const NewThemePage = <T extends RequiredFormProps>({
 																}
 															}}
 															placeholder={t("EVENTS.SERIES.NEW.THEME.LABEL")}
-															tabIndex={1}
 														/>
 													</div>
 												</p>

--- a/src/components/events/partials/ModalTabsAndPages/SeriesDetailsThemeTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/SeriesDetailsThemeTab.tsx
@@ -76,7 +76,6 @@ const SeriesDetailsThemeTab = ({
 																}
 															}}
 															placeholder={t("EVENTS.SERIES.NEW.THEME.LABEL")}
-															tabIndex={8}
 															disabled={
 																!hasAccess(
 																	"ROLE_UI_SERIES_DETAILS_THEMES_EDIT",

--- a/src/components/shared/DropDown.tsx
+++ b/src/components/shared/DropDown.tsx
@@ -43,7 +43,7 @@ const DropDown = <T,>({
 	required,
 	handleChange,
 	placeholder,
-	tabIndex,
+	tabIndex = 0,
 	autoFocus = false,
 	defaultOpen = false,
 	disabled = false,
@@ -55,7 +55,7 @@ const DropDown = <T,>({
 	required: boolean,
 	handleChange: (option: {value: T, label: string} | null) => void
 	placeholder: string
-	tabIndex: number,
+	tabIndex?: number,
 	autoFocus?: boolean,
 	defaultOpen?: boolean,
 	disabled?: boolean,

--- a/src/components/shared/modals/ResourceDetailsAccessPolicyTab.tsx
+++ b/src/components/shared/modals/ResourceDetailsAccessPolicyTab.tsx
@@ -345,7 +345,6 @@ const ResourceDetailsAccessPolicyTab : React.FC <{
 																								"EVENTS.EVENTS.DETAILS.ACCESS.ACCESS_POLICY.EMPTY"
 																						  )
 																				}
-																				tabIndex={1}
 																			/>
 																		) : (
 																			baseAclId
@@ -459,7 +458,6 @@ const ResourceDetailsAccessPolicyTab : React.FC <{
 																														"EVENTS.EVENTS.DETAILS.ACCESS.ROLES.EMPTY"
 																												  )
 																										}
-																										tabIndex={index + 1}
 																										disabled={
 																											!hasAccess(
 																												editAccessRole,

--- a/src/components/shared/wizard/RenderField.tsx
+++ b/src/components/shared/wizard/RenderField.tsx
@@ -262,7 +262,6 @@ const EditableSingleSelect = ({
 				required={metadataField.required}
 				handleChange={(element) => element && setFieldValue(field.name, element.value)}
 				placeholder={`-- ${t("SELECT_NO_OPTION_SELECTED")} --`}
-				tabIndex={10}
 				autoFocus={true}
 				defaultOpen={true}
 			/>

--- a/src/components/users/partials/wizard/AclAccessPage.tsx
+++ b/src/components/users/partials/wizard/AclAccessPage.tsx
@@ -133,7 +133,6 @@ const AclAccessPage = <T extends RequiredFormProps>({
 																				placeholder={t(
 																					"USERS.ACLS.NEW.ACCESS.ACCESS_POLICY.LABEL"
 																				)}
-																				tabIndex={1}
 																				autoFocus={true}
 																			/>
 																		</div>
@@ -228,7 +227,6 @@ const AclAccessPage = <T extends RequiredFormProps>({
 																								placeholder={t(
 																									"USERS.ACLS.NEW.ACCESS.ROLES.LABEL"
 																								)}
-																								tabIndex={index + 1}
 																								disabled={!isAccess}
 																							/>
 																						</td>
@@ -354,14 +352,12 @@ const AclAccessPage = <T extends RequiredFormProps>({
 									nextPage(formik.values);
 								}
 							}}
-							tabIndex={100}
 						>
 							{t("WIZARD.NEXT_STEP")}
 						</button>
 						<button
 							className="cancel"
 							onClick={() => previousPage(formik.values)}
-							tabIndex={101}
 						>
 							{t("WIZARD.BACK")}
 						</button>


### PR DESCRIPTION
If elements other than button and anchor should be accessible with the keyboard, set the tabindex. However, this only works reliably if it is set to 0. A sequence with values greater than zero is only possible if the element can be accessed via tab anyway. In most cases, a changed order is difficult to understand for users and difficult to maintain for developers anyway, so I advise against using tabindex. 
Elements should be natively accessible via tab, then you don't need to set the tabindex to 0. 

As a fix I have removed all tabIndex entries for DropDown and made the attribute optional with default 0.
This means that the dropdown is always accessible. If necessary, you should consider removing the attribute completely and setting the tabindex to 0.

fixes #598