### PR TITLE
Hide type and flavor of add asset items

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetsAddAsset.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetsAddAsset.tsx
@@ -89,11 +89,6 @@ const EventDetailsAssetsAddAsset = ({
 															<td>
 																{" "}
 																{translateOverrideFallback(asset, t)}
-																<span className="ui-helper-hidden">
-                                  {/* eslint-disable-next-line react/jsx-no-comment-textnodes */}
-                                  ({asset.type} "{asset.flavorType}//
-																	{asset.flavorSubType}")
-																</span>
 															</td>
 															<td>
 																<div className="file-upload">

--- a/src/components/events/partials/wizards/NewEventSummary.tsx
+++ b/src/components/events/partials/wizards/NewEventSummary.tsx
@@ -66,9 +66,6 @@ const NewEventSummary = <T extends RequiredFormProps>({
 	let uploadAssetsNonTrack: {
 		name: string,
 		translate?: string,
-		type: string,
-		flavorType: string,
-		flavorSubType: string,
 		value: any,
 	}[] = [];
 	for (let i = 0; uploadAssetsOptionsNonTrack.length > i; i++) {
@@ -80,9 +77,6 @@ const NewEventSummary = <T extends RequiredFormProps>({
 				translate: !!displayOverride
 					? t(displayOverride)
 					: translateOverrideFallback(uploadAssetsOptionsNonTrack[i], t),
-				type: uploadAssetsOptionsNonTrack[i].type,
-				flavorType: uploadAssetsOptionsNonTrack[i].flavorType,
-				flavorSubType: uploadAssetsOptionsNonTrack[i].flavorSubType,
 				value: fieldValue,
 			});
 		}
@@ -135,11 +129,6 @@ const NewEventSummary = <T extends RequiredFormProps>({
 												<tr key={key}>
 													<td>
 														{asset.translate}
-														<span className="ui-helper-hidden">
-                              {/* eslint-disable-next-line react/jsx-no-comment-textnodes */}
-                              ({asset.type} "{asset.flavorType}//
-															{asset.flavorSubType}")
-														</span>
 													</td>
 													<td>{asset.value.name}</td>
 												</tr>
@@ -167,11 +156,6 @@ const NewEventSummary = <T extends RequiredFormProps>({
 													<tr key={key}>
 														<td>
 															{translateOverrideFallback(asset, t, "SHORT")}
-															<span className="ui-helper-hidden">
-                                {/* eslint-disable-next-line react/jsx-no-comment-textnodes */}
-                                ({asset.type} "{asset.flavorType}/
-																{asset.flavorSubType}")
-															</span>
 														</td>
 														<td>{asset.file[0].name}</td>
 													</tr>


### PR DESCRIPTION
To be consistent, the Add-Asset dialog shouldn't show the type and flavor of the items, same as Add-event dialog.

Before:
![image](https://github.com/opencast/opencast-admin-interface/assets/26736/d684a864-1313-439d-a820-a42f8b46b79d)


After:
![image](https://github.com/opencast/opencast-admin-interface/assets/26736/2a1b6721-4324-48df-adf0-3211e51662bc)


The new event summary page should also hide the asset type and flavor.

Before:
![new-event-summary-before](https://github.com/opencast/opencast-admin-interface/assets/26736/8b9828f0-2201-41ea-9d68-70cb83c52dce)

After:
![image](https://github.com/opencast/opencast-admin-interface/assets/26736/78a7ee9a-bce7-4b25-9354-c0eee254bfc2)
