### PR TITLE
Add tabs in event details assets

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetAttachmentDetails.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetAttachmentDetails.tsx
@@ -29,18 +29,6 @@ const EventDetailsAssetAttachmentDetails = ({
 
 	return (
 		<div className="modal-content">
-			{/* Hierarchy navigation */}
-			<EventDetailsTabHierarchyNavigation
-				openSubTab={openSubTab}
-				hierarchyDepth={1}
-				translationKey0={"EVENTS.EVENTS.DETAILS.ASSETS.ATTACHMENTS.TITLE"}
-				subTabArgument0={"asset-attachments"}
-				translationKey1={
-					"EVENTS.EVENTS.DETAILS.ASSETS.ATTACHMENTS.DETAILS.TITLE"
-				}
-				subTabArgument1={"attachment-details"}
-			/>
-
 			<div className="modal-body">
 				{/* Notifications */}
 				<Notifications context="not_corner" />

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetAttachments.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetAttachments.tsx
@@ -34,14 +34,6 @@ const EventDetailsAssetAttachments = ({
 
 	return (
 		<div className="modal-content">
-			{/* Hierarchy navigation */}
-			<EventDetailsTabHierarchyNavigation
-				openSubTab={openSubTab}
-				hierarchyDepth={0}
-				translationKey0={"EVENTS.EVENTS.DETAILS.ASSETS.ATTACHMENTS.TITLE"}
-				subTabArgument0={"asset-attachments"}
-			/>
-
 			<div className="modal-body">
 				{/* Notifications */}
 				<Notifications context="not_corner" />

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetCatalogDetails.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetCatalogDetails.tsx
@@ -29,16 +29,6 @@ const EventDetailsAssetCatalogDetails = ({
 
 	return (
 		<div className="modal-content">
-			{/* Hierarchy navigation */}
-			<EventDetailsTabHierarchyNavigation
-				openSubTab={openSubTab}
-				hierarchyDepth={1}
-				translationKey0={"EVENTS.EVENTS.DETAILS.ASSETS.CATALOGS.TITLE"}
-				subTabArgument0={"asset-catalogs"}
-				translationKey1={"EVENTS.EVENTS.DETAILS.ASSETS.CATALOGS.DETAILS.TITLE"}
-				subTabArgument1={"catalog-details"}
-			/>
-
 			<div className="modal-body">
 				{/* Notifications */}
 				<Notifications context="not_corner" />

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetCatalogs.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetCatalogs.tsx
@@ -34,14 +34,6 @@ const EventDetailsAssetCatalogs = ({
 
 	return (
 		<div className="modal-content">
-			{/* Hierarchy navigation */}
-			<EventDetailsTabHierarchyNavigation
-				openSubTab={openSubTab}
-				hierarchyDepth={0}
-				translationKey0={"EVENTS.EVENTS.DETAILS.ASSETS.CATALOGS.TITLE"}
-				subTabArgument0={"asset-catalogs"}
-			/>
-
 			<div className="modal-body">
 				{/* Notifications */}
 				<Notifications context="not_corner" />

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetMedia.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetMedia.tsx
@@ -34,14 +34,6 @@ const EventDetailsAssetMedia = ({
 
 	return (
 		<div className="modal-content">
-			{/* Hierarchy navigation */}
-			<EventDetailsTabHierarchyNavigation
-				openSubTab={openSubTab}
-				hierarchyDepth={0}
-				translationKey0={"EVENTS.EVENTS.DETAILS.ASSETS.MEDIA.TITLE"}
-				subTabArgument0={"asset-media"}
-			/>
-
 			<div className="modal-body">
 				{/* Notifications */}
 				<Notifications context="not_corner" />

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetMediaDetails.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetMediaDetails.tsx
@@ -32,16 +32,6 @@ const EventDetailsAssetMediaDetails = ({
 
 	return (
 		<div className="modal-content">
-			{/* Hierarchy navigation */}
-			<EventDetailsTabHierarchyNavigation
-				openSubTab={openSubTab}
-				hierarchyDepth={1}
-				translationKey0={"EVENTS.EVENTS.DETAILS.ASSETS.MEDIA.TITLE"}
-				subTabArgument0={"asset-media"}
-				translationKey1={"EVENTS.EVENTS.DETAILS.ASSETS.MEDIA.DETAILS.TITLE"}
-				subTabArgument1={"media-details"}
-			/>
-
 			<div className="modal-body">
 				{/* Notifications */}
 				<Notifications context="not_corner" />

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetPublicationDetails.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetPublicationDetails.tsx
@@ -29,18 +29,6 @@ const EventDetailsAssetPublicationDetails = ({
 
 	return (
 		<div className="modal-content">
-			{/* Hierarchy navigation */}
-			<EventDetailsTabHierarchyNavigation
-				openSubTab={openSubTab}
-				hierarchyDepth={1}
-				translationKey0={"EVENTS.EVENTS.DETAILS.ASSETS.PUBLICATIONS.TITLE"}
-				subTabArgument0={"asset-publications"}
-				translationKey1={
-					"EVENTS.EVENTS.DETAILS.ASSETS.PUBLICATIONS.DETAILS.TITLE"
-				}
-				subTabArgument1={"publication-details"}
-			/>
-
 			<div className="modal-body">
 				{/* Notifications */}
 				<Notifications context="not_corner" />

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetPublications.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetPublications.tsx
@@ -31,14 +31,6 @@ const EventDetailsAssetPublications = ({
 
 	return (
 		<div className="modal-content">
-			{/* Hierarchy navigation */}
-			<EventDetailsTabHierarchyNavigation
-				openSubTab={openSubTab}
-				hierarchyDepth={0}
-				translationKey0={"EVENTS.EVENTS.DETAILS.ASSETS.PUBLICATIONS.TITLE"}
-				subTabArgument0={"asset-publications"}
-			/>
-
 			<div className="modal-body">
 				{/* Notifications */}
 				<Notifications context="not_corner" />

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetsTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetsTab.tsx
@@ -18,6 +18,15 @@ import {
 	fetchAssetPublications,
 	fetchAssets,
 } from "../../../../slices/eventDetailsSlice";
+import EventDetailsAssetsAddAsset from "./EventDetailsAssetsAddAsset";
+import EventDetailsAssetAttachments from "./EventDetailsAssetAttachments";
+import EventDetailsAssetAttachmentDetails from "./EventDetailsAssetAttachmentDetails";
+import EventDetailsAssetCatalogs from "./EventDetailsAssetCatalogs";
+import EventDetailsAssetCatalogDetails from "./EventDetailsAssetCatalogDetails";
+import EventDetailsAssetMedia from "./EventDetailsAssetMedia";
+import EventDetailsAssetMediaDetails from "./EventDetailsAssetMediaDetails";
+import EventDetailsAssetPublications from "./EventDetailsAssetPublications";
+import EventDetailsAssetPublicationDetails from "./EventDetailsAssetPublicationDetails";
 
 /**
  * This component manages the main assets tab of event details modal
@@ -27,8 +36,10 @@ const EventDetailsAssetsTab = ({
 	eventId,
 // @ts-expect-error TS(7031): Binding element 't' implicitly has an 'any' type.
 	t,
-// @ts-expect-error TS(7031): Binding element 'setHierarchy' implicitly has an '... Remove this comment to see the full error message
-	setHierarchy,
+// @ts-expect-error TS(7031): Binding element 'assetsTabHierarchy' implicitly has an '... Remove this comment to see the full error message
+ 	assetsTabHierarchy,
+// @ts-expect-error TS(7031): Binding element 'setAssetsTabHierarchy' implicitly has an '... Remove this comment to see the full error message
+ 	setAssetsTabHierarchy,
 }) => {
 	const dispatch = useAppDispatch();
 
@@ -38,6 +49,48 @@ const EventDetailsAssetsTab = ({
 	const isFetching = useAppSelector(state => isFetchingAssets(state));
 	const transactionsReadOnly = useAppSelector(state => isTransactionReadOnly(state));
 	const isFetchingAssetUploadOptions = useAppSelector(state => getIsFetchingAssetUploadOptions(state));
+
+	const assetsTabs = [
+		{
+			tabNameTranslation: "EVENTS.EVENTS.DETAILS.ASSETS.ATTACHMENTS.TITLE",
+			tabHierarchies: ["asset-attachments", "attachment-details"],
+			open: () => openSubTab("asset-attachments", "attachment"),
+		},
+		{
+			tabNameTranslation: "EVENTS.EVENTS.DETAILS.ASSETS.CATALOGS.TITLE",
+			tabHierarchies: ["asset-catalogs", "catalog-details"],
+			open: () => openSubTab("asset-catalogs", "catalog"),
+		},
+		{
+			tabNameTranslation: "EVENTS.EVENTS.DETAILS.ASSETS.MEDIA.TITLE",
+			tabHierarchies: ["asset-media", "media-details"],
+			open: () => openSubTab("asset-media", "media"),
+		},
+		{
+			tabNameTranslation: "EVENTS.EVENTS.DETAILS.ASSETS.PUBLICATIONS.TITLE",
+			tabHierarchies: ["asset-publications", "publication-details"],
+			open: () => openSubTab("asset-publications", "publication"),
+		},
+	];
+
+	const assetsNavStyle = {
+		borderBottom: "1px solid #d6d6d6",
+		lineHeight: "35px",
+		paddingLeft: "15px",
+	};
+
+	const assetsTabActive = {
+		padding: "14px 5px",
+		fontWeight: "600",
+		minWidth: "100px",
+		color: "#5d7589",
+	};
+
+	const assetsTabInactive = {
+		padding: "14px 5px",
+		minWidth: "100px",
+		color: "#92a0ab",
+	};
 
 	useEffect(() => {
 		dispatch(removeNotificationWizardForm());
@@ -67,173 +120,252 @@ const EventDetailsAssetsTab = ({
 		} else if (subTabName === "asset-publications") {
 			dispatch(fetchAssetPublications(eventId)).then();
 		}
-		setHierarchy(subTabName);
+		setAssetsTabHierarchy(subTabName);
 	};
 
 	return (
-		<div className="modal-content">
-			<div className="modal-body">
-				{/* Notifications */}
-				<Notifications context="not_corner" />
+		<>
+			{/* Assets tabs */}
+			<nav style={assetsNavStyle}>
+				{assetsTabs.map((tab) => (
+					<button
+						className={"button-like-anchor"}
+						style={tab.tabHierarchies.includes(assetsTabHierarchy) ? assetsTabActive: assetsTabInactive}
+						onClick={tab.open}
+					>
+						{t(tab.tabNameTranslation)}
+					</button>
+				))}
+			</nav>
+			{((assetsTabHierarchy === "entry" && (
+				<div className="modal-content">
+					<div className="modal-body">
+						{/* Notifications */}
+						<Notifications context="not_corner" />
 
-				{/* table with types of assets */}
-				<div className="full-col">
-					<div className="obj tbl-container operations-tbl">
-						{" "}
-						{/* Assets */}
-						<header>{t("EVENTS.EVENTS.DETAILS.ASSETS.CAPTION")}</header>
-						<div className="obj-container">
-							{isFetching || (
-								<table cellPadding="0" cellSpacing="0" className="main-tbl">
-									<thead>
-										<tr>
-											<th>
-												{" "}
-												{t("EVENTS.EVENTS.DETAILS.ASSETS.TYPE") /* Type */}
-											</th>
-											<th>
-												{" "}
-												{t("EVENTS.EVENTS.DETAILS.ASSETS.SIZE") /* Size */}
-											</th>
-											<th className="medium">
-												{!isFetchingAssetUploadOptions &&
-													!!uploadAssetOptions &&
-													uploadAssetOptions.filter(
-														(asset) => asset.type !== "track"
-													).length > 0 &&
-													!transactionsReadOnly &&
-													hasAccess(
-														"ROLE_UI_EVENTS_DETAILS_ASSETS_EDIT",
-														user
-													) && (
-														<button
-															className="button-like-anchor details-link"
-															onClick={() =>
-																openSubTab(
-																	"add-asset",
-																	"newassetupload",
-																	false,
-																	true
-																)
-															}
-														>
-															{t("EVENTS.EVENTS.NEW.UPLOAD_ASSET.ADD")}
-														</button>
-													)}
-											</th>
-										</tr>
-									</thead>
-									<tbody>
-										<tr>
-											<td>
-												{
-													t(
-														"EVENTS.EVENTS.DETAILS.ASSETS.ATTACHMENTS.CAPTION"
-													) /* Attachments */
-												}
-											</td>
-											<td>{assets.attachments}</td>
-											<td>
-												{assets.attachments > 0 && (
-													<button
-														className="button-like-anchor details-link"
-														onClick={() =>
-															openSubTab("asset-attachments", "attachment")
-														}
-													>
+						{/* table with types of assets */}
+						<div className="full-col">
+							<div className="obj tbl-container operations-tbl">
+								{" "}
+								{/* Assets */}
+								<header>{t("EVENTS.EVENTS.DETAILS.ASSETS.CAPTION")}</header>
+								<div className="obj-container">
+									{isFetching || (
+										<table cellPadding="0" cellSpacing="0" className="main-tbl">
+											<thead>
+												<tr>
+													<th>
+														{" "}
+														{t("EVENTS.EVENTS.DETAILS.ASSETS.TYPE") /* Type */}
+													</th>
+													<th>
+														{" "}
+														{t("EVENTS.EVENTS.DETAILS.ASSETS.SIZE") /* Size */}
+													</th>
+													<th className="medium">
+														{!isFetchingAssetUploadOptions &&
+															!!uploadAssetOptions &&
+															uploadAssetOptions.filter(
+																(asset) => asset.type !== "track"
+															).length > 0 &&
+															!transactionsReadOnly &&
+															hasAccess(
+																"ROLE_UI_EVENTS_DETAILS_ASSETS_EDIT",
+																user
+															) && (
+																<button
+																	className="button-like-anchor details-link"
+																	onClick={() =>
+																		openSubTab(
+																			"add-asset",
+																			"newassetupload",
+																			false,
+																			true
+																		)
+																	}
+																>
+																	{t("EVENTS.EVENTS.NEW.UPLOAD_ASSET.ADD")}
+																</button>
+															)}
+													</th>
+												</tr>
+											</thead>
+											<tbody>
+												<tr>
+													<td>
 														{
 															t(
-																"EVENTS.EVENTS.DETAILS.ASSETS.DETAILS"
-															) /* Details */
+																"EVENTS.EVENTS.DETAILS.ASSETS.ATTACHMENTS.CAPTION"
+															) /* Attachments */
 														}
-													</button>
-												)}
-											</td>
-										</tr>
-										<tr>
-											<td>
-												{
-													t(
-														"EVENTS.EVENTS.DETAILS.ASSETS.CATALOGS.CAPTION"
-													) /* Catalogs */
-												}
-											</td>
-											<td>{assets.catalogs}</td>
-											<td>
-												{assets.catalogs > 0 && (
-													<button
-														className="button-like-anchor details-link"
-														onClick={() =>
-															openSubTab("asset-catalogs", "catalog")
-														}
-													>
+													</td>
+													<td>{assets.attachments}</td>
+													<td>
+														{assets.attachments > 0 && (
+															<button
+																className="button-like-anchor details-link"
+																onClick={() =>
+																	openSubTab("asset-attachments", "attachment")
+																}
+															>
+																{
+																	t(
+																		"EVENTS.EVENTS.DETAILS.ASSETS.DETAILS"
+																	) /* Details */
+																}
+															</button>
+														)}
+													</td>
+												</tr>
+												<tr>
+													<td>
 														{
 															t(
-																"EVENTS.EVENTS.DETAILS.ASSETS.DETAILS"
-															) /* Details */
+																"EVENTS.EVENTS.DETAILS.ASSETS.CATALOGS.CAPTION"
+															) /* Catalogs */
 														}
-													</button>
-												)}
-											</td>
-										</tr>
-										<tr>
-											<td>
-												{
-													t(
-														"EVENTS.EVENTS.DETAILS.ASSETS.MEDIA.CAPTION"
-													) /* Media */
-												}
-											</td>
-											<td>{assets.media}</td>
-											<td>
-												{assets.media > 0 && (
-													<button
-														className="button-like-anchor details-link"
-														onClick={() => openSubTab("asset-media", "media")}
-													>
+													</td>
+													<td>{assets.catalogs}</td>
+													<td>
+														{assets.catalogs > 0 && (
+															<button
+																className="button-like-anchor details-link"
+																onClick={() =>
+																	openSubTab("asset-catalogs", "catalog")
+																}
+															>
+																{
+																	t(
+																		"EVENTS.EVENTS.DETAILS.ASSETS.DETAILS"
+																	) /* Details */
+																}
+															</button>
+														)}
+													</td>
+												</tr>
+												<tr>
+													<td>
 														{
 															t(
-																"EVENTS.EVENTS.DETAILS.ASSETS.DETAILS"
-															) /* Details */
+																"EVENTS.EVENTS.DETAILS.ASSETS.MEDIA.CAPTION"
+															) /* Media */
 														}
-													</button>
-												)}
-											</td>
-										</tr>
-										<tr>
-											<td>
-												{
-													t(
-														"EVENTS.EVENTS.DETAILS.ASSETS.PUBLICATIONS.CAPTION"
-													) /* Publications */
-												}
-											</td>
-											<td>{assets.publications}</td>
-											<td>
-												{assets.publications > 0 && (
-													<button
-														className="button-like-anchor details-link"
-														onClick={() =>
-															openSubTab("asset-publications", "publication")
-														}
-													>
+													</td>
+													<td>{assets.media}</td>
+													<td>
+														{assets.media > 0 && (
+															<button
+																className="button-like-anchor details-link"
+																onClick={() => openSubTab("asset-media", "media")}
+															>
+																{
+																	t(
+																		"EVENTS.EVENTS.DETAILS.ASSETS.DETAILS"
+																	) /* Details */
+																}
+															</button>
+														)}
+													</td>
+												</tr>
+												<tr>
+													<td>
 														{
 															t(
-																"EVENTS.EVENTS.DETAILS.ASSETS.DETAILS"
-															) /* Details */
+																"EVENTS.EVENTS.DETAILS.ASSETS.PUBLICATIONS.CAPTION"
+															) /* Publications */
 														}
-													</button>
-												)}
-											</td>
-										</tr>
-									</tbody>
-								</table>
-							)}
+													</td>
+													<td>{assets.publications}</td>
+													<td>
+														{assets.publications > 0 && (
+															<button
+																className="button-like-anchor details-link"
+																onClick={() =>
+																	openSubTab("asset-publications", "publication")
+																}
+															>
+																{
+																	t(
+																		"EVENTS.EVENTS.DETAILS.ASSETS.DETAILS"
+																	) /* Details */
+																}
+															</button>
+														)}
+													</td>
+												</tr>
+											</tbody>
+										</table>
+									)}
+								</div>
+							</div>
 						</div>
 					</div>
 				</div>
-			</div>
-		</div>
+			)) ||
+			(assetsTabHierarchy === "add-asset" && (
+				<EventDetailsAssetsAddAsset
+					eventId={eventId}
+					t={t}
+					setHierarchy={setAssetsTabHierarchy}
+				/>
+			)) ||
+			(assetsTabHierarchy === "asset-attachments" && (
+				<EventDetailsAssetAttachments
+					eventId={eventId}
+					t={t}
+					setHierarchy={setAssetsTabHierarchy}
+				/>
+			)) ||
+			(assetsTabHierarchy === "attachment-details" && (
+				<EventDetailsAssetAttachmentDetails
+					eventId={eventId}
+					t={t}
+					setHierarchy={setAssetsTabHierarchy}
+				/>
+			)) ||
+			(assetsTabHierarchy === "asset-catalogs" && (
+				<EventDetailsAssetCatalogs
+					eventId={eventId}
+					t={t}
+					setHierarchy={setAssetsTabHierarchy}
+				/>
+			)) ||
+			(assetsTabHierarchy === "catalog-details" && (
+				<EventDetailsAssetCatalogDetails
+					eventId={eventId}
+					t={t}
+					setHierarchy={setAssetsTabHierarchy}
+				/>
+			)) ||
+			(assetsTabHierarchy === "asset-media" && (
+				<EventDetailsAssetMedia
+					eventId={eventId}
+					t={t}
+					setHierarchy={setAssetsTabHierarchy}
+				/>
+			)) ||
+			(assetsTabHierarchy === "media-details" && (
+				<EventDetailsAssetMediaDetails
+					eventId={eventId}
+					t={t}
+					setHierarchy={setAssetsTabHierarchy}
+				/>
+			)) ||
+			(assetsTabHierarchy === "asset-publications" && (
+				<EventDetailsAssetPublications
+					eventId={eventId}
+					t={t}
+					setHierarchy={setAssetsTabHierarchy}
+				/>
+			)) ||
+			(assetsTabHierarchy === "publication-details" && (
+				<EventDetailsAssetPublicationDetails
+					eventId={eventId}
+					t={t}
+					setHierarchy={setAssetsTabHierarchy}
+				/>
+			)))}
+		</>
 	);
 };
 

--- a/src/components/events/partials/modals/EventDetails.tsx
+++ b/src/components/events/partials/modals/EventDetails.tsx
@@ -235,77 +235,14 @@ const EventDetails : React.FC<{
 					/>
 				)}
 				{page === 2 && <EventDetailsPublicationTab eventId={eventId} />}
-				{page === 3 &&
-					((assetsTabHierarchy === "entry" && (
-						<EventDetailsAssetsTab
-							eventId={eventId}
-							t={t}
-							setHierarchy={setAssetsTabHierarchy}
-						/>
-					)) ||
-						(assetsTabHierarchy === "add-asset" && (
-							<EventDetailsAssetsAddAsset
-								eventId={eventId}
-								t={t}
-								setHierarchy={setAssetsTabHierarchy}
-							/>
-						)) ||
-						(assetsTabHierarchy === "asset-attachments" && (
-							<EventDetailsAssetAttachments
-								eventId={eventId}
-								t={t}
-								setHierarchy={setAssetsTabHierarchy}
-							/>
-						)) ||
-						(assetsTabHierarchy === "attachment-details" && (
-							<EventDetailsAssetAttachmentDetails
-								eventId={eventId}
-								t={t}
-								setHierarchy={setAssetsTabHierarchy}
-							/>
-						)) ||
-						(assetsTabHierarchy === "asset-catalogs" && (
-							<EventDetailsAssetCatalogs
-								eventId={eventId}
-								t={t}
-								setHierarchy={setAssetsTabHierarchy}
-							/>
-						)) ||
-						(assetsTabHierarchy === "catalog-details" && (
-							<EventDetailsAssetCatalogDetails
-								eventId={eventId}
-								t={t}
-								setHierarchy={setAssetsTabHierarchy}
-							/>
-						)) ||
-						(assetsTabHierarchy === "asset-media" && (
-							<EventDetailsAssetMedia
-								eventId={eventId}
-								t={t}
-								setHierarchy={setAssetsTabHierarchy}
-							/>
-						)) ||
-						(assetsTabHierarchy === "media-details" && (
-							<EventDetailsAssetMediaDetails
-								eventId={eventId}
-								t={t}
-								setHierarchy={setAssetsTabHierarchy}
-							/>
-						)) ||
-						(assetsTabHierarchy === "asset-publications" && (
-							<EventDetailsAssetPublications
-								eventId={eventId}
-								t={t}
-								setHierarchy={setAssetsTabHierarchy}
-							/>
-						)) ||
-						(assetsTabHierarchy === "publication-details" && (
-							<EventDetailsAssetPublicationDetails
-								eventId={eventId}
-								t={t}
-								setHierarchy={setAssetsTabHierarchy}
-							/>
-						)))}
+				{page === 3 && (
+					<EventDetailsAssetsTab
+						eventId={eventId}
+						t={t}
+						assetsTabHierarchy={assetsTabHierarchy}
+						setAssetsTabHierarchy={setAssetsTabHierarchy}
+					/>
+				)}
 				{page === 4 && !isLoadingScheduling && (
 					<EventDetailsSchedulingTab eventId={eventId} t={t} />
 				)}


### PR DESCRIPTION
Adds sub navigation with tabs in event details assets as suggested in https://github.com/opencast/opencast-admin-interface/issues/623.

[Screencast from 25.06.2024 13:20:27.webm](https://github.com/opencast/opencast-admin-interface/assets/44410838/abe7e8bd-425d-48df-ada5-972e8731e9d8)

Close #623