### PR TITLE
Fix checkstyle issues and disable sourcemaps

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -15,7 +15,6 @@ import {
 import { availableHotkeys } from "../configs/hotkeysConfig";
 import { studioURL } from "../configs/generalConfig";
 import { hasAccess } from "../utils/utils";
-import { overflowStyle } from "../utils/componentStyles";
 import RegistrationModal from "./shared/RegistrationModal";
 import HotKeyCheatSheet from "./shared/HotKeyCheatSheet";
 import { useHotkeys } from "react-hotkeys-hook";

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetAttachmentDetails.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetAttachmentDetails.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import EventDetailsTabHierarchyNavigation from "./EventDetailsTabHierarchyNavigation";
 import Notifications from "../../../shared/Notifications";
 import {
 	getAssetAttachmentDetails,
@@ -21,11 +20,6 @@ const EventDetailsAssetAttachmentDetails = ({
 }) => {
 	const attachment = useAppSelector(state => getAssetAttachmentDetails(state));
 	const isFetching = useAppSelector(state => isFetchingAssetAttachmentDetails(state));
-
-// @ts-expect-error TS(7006): Parameter 'subTabName' implicitly has an 'any' typ... Remove this comment to see the full error message
-	const openSubTab = (subTabName) => {
-		setHierarchy(subTabName);
-	};
 
 	return (
 		<div className="modal-content">

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetAttachments.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetAttachments.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import EventDetailsTabHierarchyNavigation from "./EventDetailsTabHierarchyNavigation";
 import Notifications from "../../../shared/Notifications";
 import {
 	getAssetAttachments,

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetCatalogDetails.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetCatalogDetails.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import EventDetailsTabHierarchyNavigation from "./EventDetailsTabHierarchyNavigation";
 import Notifications from "../../../shared/Notifications";
 import {
 	getAssetCatalogDetails,
@@ -21,11 +20,6 @@ const EventDetailsAssetCatalogDetails = ({
 }) => {
 	const catalog = useAppSelector(state => getAssetCatalogDetails(state));
 	const isFetching = useAppSelector(state => isFetchingAssetCatalogDetails(state));
-
-// @ts-expect-error TS(7006): Parameter 'subTabName' implicitly has an 'any' typ... Remove this comment to see the full error message
-	const openSubTab = (subTabName) => {
-		setHierarchy(subTabName);
-	};
 
 	return (
 		<div className="modal-content">

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetCatalogs.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetCatalogs.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import EventDetailsTabHierarchyNavigation from "./EventDetailsTabHierarchyNavigation";
 import Notifications from "../../../shared/Notifications";
 import {
 	getAssetCatalogs,

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetMedia.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetMedia.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import EventDetailsTabHierarchyNavigation from "./EventDetailsTabHierarchyNavigation";
 import Notifications from "../../../shared/Notifications";
 import {
 	getAssetMedia,

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetMediaDetails.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetMediaDetails.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import EventDetailsTabHierarchyNavigation from "./EventDetailsTabHierarchyNavigation";
 import Notifications from "../../../shared/Notifications";
 import {
 	getAssetMediaDetails,
@@ -24,11 +23,6 @@ const EventDetailsAssetMediaDetails = ({
 }) => {
 	const media = useAppSelector(state => getAssetMediaDetails(state));
 	const isFetching = useAppSelector(state => isFetchingAssetMediaDetails(state));
-
-// @ts-expect-error TS(7006): Parameter 'subTabName' implicitly has an 'any' typ... Remove this comment to see the full error message
-	const openSubTab = (subTabName) => {
-		setHierarchy(subTabName);
-	};
 
 	return (
 		<div className="modal-content">

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetPublicationDetails.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetPublicationDetails.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import EventDetailsTabHierarchyNavigation from "./EventDetailsTabHierarchyNavigation";
 import Notifications from "../../../shared/Notifications";
 import {
 	getAssetPublicationDetails,
@@ -21,11 +20,6 @@ const EventDetailsAssetPublicationDetails = ({
 }) => {
 	const publication = useAppSelector(state => getAssetPublicationDetails(state));
 	const isFetching = useAppSelector(state => isFetchingAssetPublicationDetails(state));
-
-// @ts-expect-error TS(7006): Parameter 'subTabName' implicitly has an 'any' typ... Remove this comment to see the full error message
-	const openSubTab = (subTabName) => {
-		setHierarchy(subTabName);
-	};
 
 	return (
 		<div className="modal-content">

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetPublications.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetPublications.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import EventDetailsTabHierarchyNavigation from "./EventDetailsTabHierarchyNavigation";
 import Notifications from "../../../shared/Notifications";
 import {
 	getAssetPublications,

--- a/src/components/events/partials/modals/EventDetails.tsx
+++ b/src/components/events/partials/modals/EventDetails.tsx
@@ -12,15 +12,6 @@ import EventDetailsWorkflowOperationDetails from "../ModalTabsAndPages/EventDeta
 import EventDetailsWorkflowErrors from "../ModalTabsAndPages/EventDetailsWorkflowErrors";
 import EventDetailsWorkflowErrorDetails from "../ModalTabsAndPages/EventDetailsWorkflowErrorDetails";
 import EventDetailsAssetsTab from "../ModalTabsAndPages/EventDetailsAssetsTab";
-import EventDetailsAssetAttachments from "../ModalTabsAndPages/EventDetailsAssetAttachments";
-import EventDetailsAssetCatalogs from "../ModalTabsAndPages/EventDetailsAssetCatalogs";
-import EventDetailsAssetMedia from "../ModalTabsAndPages/EventDetailsAssetMedia";
-import EventDetailsAssetPublications from "../ModalTabsAndPages/EventDetailsAssetPublications";
-import EventDetailsAssetAttachmentDetails from "../ModalTabsAndPages/EventDetailsAssetAttachmentDetails";
-import EventDetailsAssetCatalogDetails from "../ModalTabsAndPages/EventDetailsAssetCatalogDetails";
-import EventDetailsAssetMediaDetails from "../ModalTabsAndPages/EventDetailsAssetMediaDetails";
-import EventDetailsAssetPublicationDetails from "../ModalTabsAndPages/EventDetailsAssetPublicationDetails";
-import EventDetailsAssetsAddAsset from "../ModalTabsAndPages/EventDetailsAssetsAddAsset";
 import EventDetailsSchedulingTab from "../ModalTabsAndPages/EventDetailsSchedulingTab";
 import DetailsExtendedMetadataTab from "../ModalTabsAndPages/DetailsExtendedMetadataTab";
 import DetailsMetadataTab from "../ModalTabsAndPages/DetailsMetadataTab";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     plugins: [react(), svgr(), viteTsconfigPaths(), preserveDirectives()],
     build: {
         outDir: "build",
-        sourcemap: false,
+        sourcemap: true,
     },
     server: {
         open: true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     plugins: [react(), svgr(), viteTsconfigPaths(), preserveDirectives()],
     build: {
         outDir: "build",
-        sourcemap: true,
+        sourcemap: false,
     },
     server: {
         open: true,


### PR DESCRIPTION
ESLint is back, yay. But while it was gone, other PRs introduced checkstyle issues, oh no. This fixes those issues, so that builds may stop failing.

Secondly, this also disables sourcemaps. I was unable to build the project due to out-of-memory errors, and disabling sourcemaps proved a workaround. We can probably enable them again once we get rid of all the old dependencies that come with our current ESLint config.