### PR TITLE
Don't word wrap on table headers

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -559,7 +559,6 @@ table.main-tbl {
     display: none !important;
   }
 
-  th,
   td {
     max-width: 800px;
     word-wrap: anywhere;


### PR DESCRIPTION
We're currently applying arbitrary word-wrapping to our table cells to keep very long strings from overflowing. This can cause some columns to get very little width in certain cases. This removes word-wrapping from table headers to rectify that issue. Table header contents are controlled by us and should not be terribly long either way, so in my opinion this is fine.

I checked for a couple different languages and they looked fine to me, but if someone thinks that this is not feasible for a certain language please do speak up.

Before:
![Bildschirmfoto vom 2024-06-26 15-18-33](https://github.com/opencast/opencast-admin-interface/assets/14070005/b915a039-3c5d-4c57-9662-1ea9ea666486)

After:
![Bildschirmfoto vom 2024-06-26 15-19-07](https://github.com/opencast/opencast-admin-interface/assets/14070005/23b6c760-af86-4342-a4aa-22d39d2779f9)
