### PR TITLE
Prevent sort icon from breaking table headers

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -559,6 +559,14 @@ table.main-tbl {
     display: none !important;
   }
 
+  th {
+    span {
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+    }
+  }
+
   td {
     max-width: 800px;
     word-wrap: anywhere;

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -559,7 +559,6 @@ table.main-tbl {
     display: none !important;
   }
 
-  th,
   td {
     max-width: 800px;
     word-wrap: anywhere;


### PR DESCRIPTION
Applies flexbox to table headers to keep table header contents from line breaking. This is supposed to help with cases where the title would be on one line and the sort icon on the next, wasting space and looking quite bad.

Includes #744, so that should be merged first.

Before:
![Bildschirmfoto vom 2024-06-26 16-02-36](https://github.com/opencast/opencast-admin-interface/assets/14070005/17d4e9c8-92b8-4346-be1d-746a0493a172)

After:
![Bildschirmfoto vom 2024-06-26 16-02-58](https://github.com/opencast/opencast-admin-interface/assets/14070005/fe833c95-7333-46f9-be2c-166a2fe38d3c)
