### PR TITLE
Main menu tooltip position

### DIFF
--- a/src/components/shared/MainNav.tsx
+++ b/src/components/shared/MainNav.tsx
@@ -234,11 +234,11 @@ const MainNav = ({
 	return (
 		<>
 			<div className="menu-top" >
-				<Tooltip title={t("HOTKEYS.DESCRIPTIONS.GENERAL.MAIN_MENU")}>
-					<button className="button-like-anchor" onClick={() => toggleMenu()}>
+				<button className="button-like-anchor" onClick={() => toggleMenu()}>
+					<Tooltip title={t("HOTKEYS.DESCRIPTIONS.GENERAL.MAIN_MENU")} placement={"right"}>
 						<i className="fa fa-bars" />
-					</button>
-				</Tooltip>
+					</Tooltip>
+				</button>
 				{isOpen && (
 					<nav id="roll-up-menu">
 						<div id="nav-container">


### PR DESCRIPTION
This patch adjusts the placement of the main menu tooltip to appear only atop the icon and be placed to the right like with all other main menu tooltips.