### PR TITLE
Remove Tooltip from Stats Filter

### DIFF
--- a/src/components/shared/Stats.tsx
+++ b/src/components/shared/Stats.tsx
@@ -10,7 +10,6 @@ import { connect } from "react-redux";
 import { loadEventsIntoTable } from "../../thunks/tableThunks";
 import { useAppDispatch, useAppSelector } from "../../store";
 import { fetchEvents } from "../../slices/eventSlice";
-import { Tooltip } from "./Tooltip";
 
 /**
  * This component renders the status bar of the event view and filters depending on these
@@ -59,25 +58,20 @@ const Stats = ({
 				{/* Show one counter for each status */}
 				{stats.map((st, key) => (
 					<div className="col" key={key}>
-						<Tooltip title={t(st.description)}>
-							<button
-								className="stat"
-								onClick={() => showStatsFilter(st)}
-							>
-								<h1>{st.count}</h1>
-								{/* Show the description of the status, if defined,
-                        	    else show name of filter and its value*/}
-								{!!st.description ? (
-									<span>{t(st.description)}</span>
-								) : (
-									st.filters.map((filter, key) => (
-										<span key={key}>
-											{t(filter.filter)}: {t(filter.value)}
-										</span>
-									))
-								)}
-							</button>
-						</Tooltip>
+						<button className="stat" onClick={() => showStatsFilter(st)}>
+							<h1>{st.count}</h1>
+							{/* Show the description of the status, if defined,
+								else show name of filter and its value*/}
+							{!!st.description ? (
+								<span>{t(st.description)}</span>
+							) : (
+								st.filters.map((filter, key) => (
+									<span key={key}>
+										{t(filter.filter)}: {t(filter.value)}
+									</span>
+								))
+							)}
+						</button>
 					</div>
 				))}
 			</div>


### PR DESCRIPTION
This patch removes the tooltips from the stats filters since they always just showed exactly what already was displayed on the label without tooltip. Additional visual clutter with no additional information does not make much sense.

![Screenshot from 2024-06-29 01-19-53](https://github.com/opencast/opencast-admin-interface/assets/1008395/9bd2acc8-edf0-41f5-9f43-5e59e0ad285c)
*Example: Tooltip for “Todo” was also just “Todo”. That's not helpful.*