### PR TITLE
"Unsaved changes" popup showing up but changes are saved

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/SeriesDetailsAccessTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/SeriesDetailsAccessTab.tsx
@@ -32,7 +32,7 @@ const SeriesDetailsAccessTab = ({
 		dispatch(fetchSeriesDetailsAcls(id));
 	}
 	const updateSeriesAccessWrapper = (id: any, policies: any) => {
-		dispatch(updateSeriesAccess({id, policies}));
+		return dispatch(updateSeriesAccess({id, policies}));
 	}
 
 	useEffect(() => {


### PR DESCRIPTION
Fix an issue where a browser popup informing the user about unsaved changes would show up when trying to close the series details modal after editing acls, no matter if they actually saved their changes or not.

Fixes #382 (The missing translation string was already fixed elsewhere).