### PR TITLE
Use "presentation" instead of "slides" for upload

### DIFF
--- a/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
@@ -483,8 +483,8 @@
 						"RECORDING_ELEMENTS": "Recording elements",
 						"RECORDING_METADATA": "Recording metadata",
 						"SEGMENTABLE": {
-							"SHORT": "Slides",
-							"DETAIL": "The file contains a recording of a slide presentation (Keynote, Powerpoint, etc)."
+							"SHORT": "Presentation",
+							"DETAIL": "The file contains a recording of a what is shown to an audience (Keynote, Powerpoint, etc)."
 						},
 						"NON_SEGMENTABLE": {
 							"SHORT": "Presenter",
@@ -705,8 +705,8 @@
 						"CAPTION": "Upload",
 						"RECORDING_ELEMENTS": "Recording elements",
 						"SEGMENTABLE": {
-							"SHORT": "Slides",
-							"DETAIL": "The file contains a recording of a slide presentation (Keynote, Powerpoint, etc)."
+							"SHORT": "Presentation",
+							"DETAIL": "The file contains a recording of a what is shown to an audience (Keynote, Powerpoint, etc)."
 						},
 						"NON_SEGMENTABLE": {
 							"SHORT": "Presenter",


### PR DESCRIPTION
Changes the wording for the source upload in the create event dialog to use the word "presentation" instead of "slides".

Fixes #354.