### PR TITLE
Add typing to acl details

### DIFF
--- a/src/components/users/partials/modal/AclDetails.tsx
+++ b/src/components/users/partials/modal/AclDetails.tsx
@@ -9,7 +9,7 @@ import { NewAclSchema } from "../../../../utils/validate";
 import ModalNavigation from "../../../shared/modals/ModalNavigation";
 import { checkAcls } from "../../../../slices/aclSlice";
 import { useAppDispatch, useAppSelector } from "../../../../store";
-import { updateAclDetails } from "../../../../slices/aclDetailsSlice";
+import { TransformedAcls, updateAclDetails } from "../../../../slices/aclDetailsSlice";
 
 /**
  * This component manages the pages of the acl details modal
@@ -47,13 +47,16 @@ const AclDetails = ({
 		},
 	];
 
-// @ts-expect-error TS(7006): Parameter 'tabNr' implicitly has an 'any' type.
-	const openTab = (tabNr) => {
+	const openTab = (tabNr: number) => {
 		setPage(tabNr);
 	};
 
-// @ts-expect-error TS(7006): Parameter 'values' implicitly has an 'any' type.
-	const handleSubmit = (values) => {
+	const handleSubmit = (
+		values: {
+			name: string,
+			acls: TransformedAcls,
+		}
+	) => {
 		dispatch(updateAclDetails({values: values, aclId: aclDetails.id}));
 		close();
 	};

--- a/src/components/users/partials/modal/AclDetailsModal.tsx
+++ b/src/components/users/partials/modal/AclDetailsModal.tsx
@@ -8,9 +8,12 @@ import { availableHotkeys } from "../../../../configs/hotkeysConfig";
  * This component renders the modal for displaying acl details
  */
 const AclDetailsModal = ({
-    close,
-    aclName
-}: any) => {
+	close,
+	aclName
+}: {
+	close: () => void,
+	aclName: string,
+}) => {
 	const { t } = useTranslation();
 
 	useHotkeys(

--- a/src/components/users/partials/wizard/AclAccessPage.tsx
+++ b/src/components/users/partials/wizard/AclAccessPage.tsx
@@ -67,8 +67,7 @@ const AclAccessPage = <T extends RequiredFormProps>({
 		fetchData();
 	}, []);
 
-// @ts-expect-error TS(7006): Parameter 'value' implicitly has an 'any' type.
-	const handleTemplateChange = async (value) => {
+	const handleTemplateChange = async (value: string) => {
 		// fetch information about chosen template from backend
 		const template = await fetchAclTemplateById(value);
 

--- a/src/components/users/partials/wizard/NewAclWizard.tsx
+++ b/src/components/users/partials/wizard/NewAclWizard.tsx
@@ -20,7 +20,10 @@ const NewAclWizard = ({
 }) => {
 	const dispatch = useAppDispatch();
 
-	const initialValues = initialFormValuesNewAcl;
+	const initialValues = {
+		...initialFormValuesNewAcl,
+		aclTemplate: "",
+	}
 
 	const {
 		snapshot,
@@ -49,8 +52,7 @@ const NewAclWizard = ({
 
 	const currentValidationSchema = NewAclSchema[page];
 
-// @ts-expect-error TS(7006): Parameter 'values' implicitly has an 'any' type.
-	const handleSubmit = (values) => {
+	const handleSubmit = (values: typeof initialFormValuesNewAcl) => {
 		const response = dispatch(postNewAcl(values));
 		console.info(response);
 		close();
@@ -93,11 +95,8 @@ const NewAclWizard = ({
 								)}
 								{page === 1 && (
 									<AclAccessPage
-									// @ts-expect-error: Type-checking gets confused by redux-connect in the child
 										formik={formik}
-										// @ts-expect-error: Type-checking gets confused by redux-connect in the child
 										nextPage={nextPage}
-										// @ts-expect-error: Type-checking gets confused by redux-connect in the child
 										previousPage={previousPage}
 									/>
 								)}

--- a/src/configs/modalConfig.ts
+++ b/src/configs/modalConfig.ts
@@ -121,7 +121,10 @@ export const initialFormValuesNewThemes = {
 
 // All fields for new acl form that are fix and not depending on response of backend
 // InitialValues of Formik form (others computed dynamically depending on responses from backend)
-export const initialFormValuesNewAcl = {
+export const initialFormValuesNewAcl: {
+	name: string,
+	acls: TransformedAcl[],
+} = {
 	name: "",
 	acls: [],
 };

--- a/src/slices/aclSlice.ts
+++ b/src/slices/aclSlice.ts
@@ -7,6 +7,8 @@ import { NOTIFICATION_CONTEXT_ACCESS } from '../configs/modalConfig';
 import { addNotification, removeNotificationWizardAccess } from './notificationSlice';
 import { AppDispatch } from '../store';
 import { createAppAsyncThunk } from '../createAsyncThunkWithTypes';
+import { initialFormValuesNewAcl } from "../configs/modalConfig";
+import { TransformedAcl } from './aclDetailsSlice';
 
 /**
  * This file contains redux reducer for actions affecting the state of acls
@@ -118,8 +120,7 @@ export const fetchRolesWithTarget = async (target: string) => {
 };
 
 // post new acl to backend
-// @ts-expect-error TS(7006): Parameter 'values' implicitly has an 'any' type.
-export const postNewAcl = (values) => async (dispatch: AppDispatch) => {
+export const postNewAcl = (values: typeof initialFormValuesNewAcl) => async (dispatch: AppDispatch) => {
 	let acls = prepareAccessPolicyRulesForPost(values.acls);
 
 	let data = new URLSearchParams();
@@ -142,8 +143,7 @@ export const postNewAcl = (values) => async (dispatch: AppDispatch) => {
 		});
 };
 // delete acl with provided id
-// @ts-expect-error TS(7006): Parameter 'id' implicitly has an 'any' type.
-export const deleteAcl = (id) => async (dispatch: AppDispatch) => {
+export const deleteAcl = (id: string) => async (dispatch: AppDispatch) => {
 	axios
 		.delete(`/admin-ng/acl/${id}`)
 		.then((res) => {
@@ -158,8 +158,7 @@ export const deleteAcl = (id) => async (dispatch: AppDispatch) => {
 		});
 };
 
-// @ts-expect-error TS(7006):
-export const checkAcls = (acls) => async (dispatch: AppDispatch) => {
+export const checkAcls = (acls: TransformedAcl[]) => async (dispatch: AppDispatch) => {
 	// Remove old notifications of context event-access
 	// Helps to prevent multiple notifications for same problem
 	dispatch(removeNotificationWizardAccess());


### PR DESCRIPTION
Add typescript to acl details and assorted components. Although a lot of typing was present already, this just finishes up on the few missing parts.