### PR TITLE
Hide file remove button if no record file selected

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/NewSourcePage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewSourcePage.tsx
@@ -318,6 +318,7 @@ const Upload = ({ formik }) => {
 											</td>
 											<td className="fit">
 												<button
+													style={{ visibility: asset.file ? "visible" : "hidden" }}
 													className="button-like-anchor remove"
 													onClick={(e) => {
 														formik.setFieldValue(


### PR DESCRIPTION
Simple solution to hide the remove button when no recording file is selected. The visibility is set to hidden to avoid frequent jumping as the element still occupies its space.

Close #609

Screenshots
![image](https://github.com/opencast/opencast-admin-interface/assets/44410838/671b9c28-1e71-4424-a329-3c82a64a019c)
![image](https://github.com/opencast/opencast-admin-interface/assets/44410838/bef47bc0-23b9-4808-b39b-5ab6612340a9)
