### PR TITLE
Simplify admin check

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,7 +3,6 @@ import {
 	getOrgProperties,
 	getUserInformation,
 } from "../selectors/userInfoSelectors";
-import { hasAccess } from "../utils/utils";
 import { useAppSelector } from "../store";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
@@ -37,7 +36,7 @@ const Footer: React.FC = () => {
 						<li>
 							{"Opencast "}
 							<Tooltip title={t('BUILD.VERSION')}><span>{version}</span></Tooltip>
-							{hasAccess("ROLE_ADMIN", user) && (
+							{user.isAdmin && (
 								<span>
 								{user.ocVersion.buildNumber && (
 									<>{" – "} <Tooltip title={t('BUILD.COMMIT')}><span>{user.ocVersion.buildNumber}</span></Tooltip></>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -198,7 +198,7 @@ const Header = () => {
 					)}
 
 					{/* System warnings and notifications */}
-					{hasAccess("ROLE_ADMIN", user) && (
+					{user.isAdmin && (
 						<div
 							className="nav-dd info-dd"
 							id="info-dd"
@@ -389,8 +389,7 @@ const MenuHelp = ({
 					</li>
 				)}
 				{/* Show only if restUrl is set */}
-				{!!orgProperties["org.opencastproject.admin.help.restdocs.url"] &&
-					hasAccess("ROLE_ADMIN", user) && (
+				{!!orgProperties["org.opencastproject.admin.help.restdocs.url"] && user.isAdmin && (
 						<li>
 							<a
 								target="_blank" rel="noreferrer"
@@ -408,7 +407,7 @@ const MenuHelp = ({
 					</button>
 				</li>
 				{/* Adoter registration Modal */}
-				{hasAccess("ROLE_ADMIN", user) && (
+				{user.isAdmin && (
 					<li>
 						<button className="button-like-anchor" onClick={() => showAdoptersRegistrationModal()}>
 							<span>{t("HELP.ADOPTER_REGISTRATION")}</span>

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowDetails.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowDetails.tsx
@@ -7,7 +7,6 @@ import {
 } from "../../../../selectors/eventDetailsSelectors";
 import { formatDuration } from "../../../../utils/eventDetailsUtils";
 import EventDetailsTabHierarchyNavigation from "./EventDetailsTabHierarchyNavigation";
-import { hasAccess } from "../../../../utils/utils";
 import { getUserInformation } from "../../../../selectors/userInfoSelectors";
 import { useAppDispatch, useAppSelector } from "../../../../store";
 import {
@@ -146,7 +145,7 @@ const EventDetailsWorkflowDetails = ({
 													<td>{formatDuration(workflowData.executionTime)}</td>
 												</tr>
 											)}
-											{hasAccess("ROLE_ADMIN", user) && (
+											{user.isAdmin && (
 												<>
 													<tr>
 														<td>
@@ -172,7 +171,7 @@ const EventDetailsWorkflowDetails = ({
 							</div>
 
 							{/* 'Workflow configuration' table */}
-							{hasAccess("ROLE_ADMIN", user) && (
+							{user.isAdmin && (
 								<div className="obj tbl-details">
 									<header>
 										{
@@ -278,7 +277,7 @@ const EventDetailsWorkflowDetails = ({
 							</div>
 
 							{/* 'Workflow configuration' table */}
-							{hasAccess("ROLE_ADMIN", user) && (
+							{user.isAdmin && (
 								<div className="obj tbl-details">
 									<header>
 										{


### PR DESCRIPTION
We have a `user.isAdmin`, so let's use it and not the more complicated `hasAccess(…)` which uses `user.isAdmin` internally anyway.