### PR TITLE
Fix required metadata not being required

### DIFF
--- a/src/components/events/partials/wizards/NewEventWizard.tsx
+++ b/src/components/events/partials/wizards/NewEventWizard.tsx
@@ -7,7 +7,7 @@ import NewMetadataPage from "../ModalTabsAndPages/NewMetadataPage";
 import NewAccessPage from "../ModalTabsAndPages/NewAccessPage";
 import NewProcessingPage from "../ModalTabsAndPages/NewProcessingPage";
 import NewSourcePage from "../ModalTabsAndPages/NewSourcePage";
-import { NewEventSchema } from "../../../../utils/validate";
+import { NewEventSchema, MetadataSchema } from "../../../../utils/validate";
 import WizardStepperEvent from "../../../shared/wizard/WizardStepperEvent";
 import { getInitialMetadataFieldValues } from "../../../../utils/resourceUtils";
 import { sourceMetadata } from "../../../../configs/sourceConfig";
@@ -98,7 +98,12 @@ const NewEventWizard: React.FC<{
 	];
 
 	// Validation schema of current page
-	const currentValidationSchema = NewEventSchema[page];
+	let currentValidationSchema;
+	if (page === 0 || page === 1) {
+		currentValidationSchema = MetadataSchema(metadataFields.fields);
+	} else {
+		currentValidationSchema = NewEventSchema[page];
+	}
 
 	const nextPage = (values: typeof initialValues) => {
 		setSnapshot(values);

--- a/src/components/events/partials/wizards/NewSeriesWizard.tsx
+++ b/src/components/events/partials/wizards/NewSeriesWizard.tsx
@@ -11,7 +11,7 @@ import NewMetadataExtendedPage from "../ModalTabsAndPages/NewMetadataExtendedPag
 import NewAccessPage from "../ModalTabsAndPages/NewAccessPage";
 import WizardStepper from "../../../shared/wizard/WizardStepper";
 import { initialFormValuesNewSeries } from "../../../../configs/modalConfig";
-import { NewSeriesSchema } from "../../../../utils/validate";
+import { MetadataSchema, NewSeriesSchema } from "../../../../utils/validate";
 import { getInitialMetadataFieldValues } from "../../../../utils/resourceUtils";
 import { useAppDispatch, useAppSelector } from "../../../../store";
 import { postNewSeries } from "../../../../slices/seriesSlice";
@@ -73,7 +73,12 @@ const NewSeriesWizard: React.FC<{
 	];
 
 	// Validation schema of current page
-	const currentValidationSchema = NewSeriesSchema[page];
+	let currentValidationSchema;
+	if (page === 0 || page === 1) {
+		currentValidationSchema = MetadataSchema(metadataFields.fields);
+	} else {
+		currentValidationSchema = NewSeriesSchema[page];
+	}
 
 	const nextPage = (
 		values: {

--- a/src/utils/validate.ts
+++ b/src/utils/validate.ts
@@ -1,4 +1,5 @@
 import * as Yup from "yup";
+import { MetadataField } from "../slices/eventSlice";
 
 /**
  * This File contains all schemas used for validation with yup in the context of events and series
@@ -7,11 +8,70 @@ import * as Yup from "yup";
 const today = new Date();
 today.setHours(0, 0, 0, 0);
 
+/**
+ * Dynamically create a schema for a required metadata field
+ */
+export function createMetadataSchema(
+	schema: { [key: string]: any; },
+	config: { id: string; required: boolean; type: string; })
+{
+	const { id, required, type } = config;
+	if (!required) return schema;
+
+	let validationType: "string" | "array" | "date" = "string";
+	const validations: {
+		type: string,
+		params: any[],
+	}[] = [
+		{
+			type: "required",
+			params: ["this field is required"]
+		},
+	]
+
+	if (type === "mixed_text") {
+		validationType = "array";
+		validations.push({
+			type: "min",
+			params: [1, "there should be atleast one entry"]
+		})
+	}
+
+	if (type === "date" || type === "start_date") {
+		validationType = "date";
+	}
+
+	if (!Yup[validationType as keyof typeof Yup]) {
+		return schema;
+	}
+	let validator = Yup[validationType as "string"]();
+	validations.forEach(validation => {
+		const { params, type } = validation;
+		// @ts-expect-error
+		if (!validator[type]) {
+			return;
+		}
+		// @ts-expect-error
+		validator = validator[type](...params);
+	});
+	schema[id] = validator;
+	return schema;
+}
+
+/**
+ * Dynamically create a schema for required metadata fields
+ */
+export const MetadataSchema = (fields: MetadataField[]) => {
+	const schema = fields.reduce(createMetadataSchema, {});
+	const validateSchema = Yup.object().shape(schema);
+
+	return validateSchema;
+}
+
+
 // Validation Schema used in new event wizard (each step has its own yup validation object)
 export const NewEventSchema = [
-	Yup.object().shape({
-		title: Yup.string().required("Required"),
-	}),
+	Yup.object().shape({}),
 	Yup.object().shape({}),
 	Yup.object().shape({
 		uploadAssetsTrack: Yup.array().when("sourceMode", {

--- a/src/utils/validate.ts
+++ b/src/utils/validate.ts
@@ -15,20 +15,17 @@ export const NewEventSchema = [
 	Yup.object().shape({}),
 	Yup.object().shape({
 		uploadAssetsTrack: Yup.array().when("sourceMode", {
-// @ts-expect-error TS(7006): Parameter 'value' implicitly has an 'any' type.
-			is: (value) => value === "UPLOAD",
+			is: (value: string) => value === "UPLOAD",
 			then: () => Yup.array().test(
 				"at-least-one-uploaded",
 				"at least one uploaded",
 				(uploadAssetsTrack) => {
-// @ts-expect-error TS(2532): Object is possibly 'undefined'.
-					return uploadAssetsTrack.some((asset) => !!asset.file);
+					return uploadAssetsTrack && uploadAssetsTrack.some((asset) => !!asset.file);
 				}
 			),
 		}),
 		scheduleStartDate: Yup.date().when("sourceMode", {
-// @ts-expect-error TS(7006): Parameter 'value' implicitly has an 'any' type.
-			is: (value) =>
+			is: (value: string) =>
 				value === "SCHEDULE_SINGLE" || value === "SCHEDULE_MULTIPLE",
 			then: () => Yup.date().required("Required"),
 		}),
@@ -41,44 +38,37 @@ export const NewEventSchema = [
 			then: () => Yup.array().min(1).required("Required"),
 		}),
 		scheduleStartHour: Yup.string().when("sourceMode", {
-// @ts-expect-error TS(7006): Parameter 'value' implicitly has an 'any' type.
-			is: (value) =>
+			is: (value: string) =>
 				value === "SCHEDULE_SINGLE" || value === "SCHEDULE_MULTIPLE",
 			then: () => Yup.string().required("Required"),
 		}),
 		scheduleStartMinute: Yup.string().when("sourceMode", {
-// @ts-expect-error TS(7006): Parameter 'value' implicitly has an 'any' type.
-			is: (value) =>
+			is: (value: string) =>
 				value === "SCHEDULE_SINGLE" || value === "SCHEDULE_MULTIPLE",
 			then: () => Yup.string().required("Required"),
 		}),
 		scheduleDurationHours: Yup.string().when("sourceMode", {
-// @ts-expect-error TS(7006): Parameter 'value' implicitly has an 'any' type.
-			is: (value) =>
+			is: (value: string) =>
 				value === "SCHEDULE_SINGLE" || value === "SCHEDULE_MULTIPLE",
 			then: () => Yup.string().required("Required"),
 		}),
 		scheduleDurationMinutes: Yup.string().when("sourceMode", {
-// @ts-expect-error TS(7006): Parameter 'value' implicitly has an 'any' type.
-			is: (value) =>
+			is: (value: string) =>
 				value === "SCHEDULE_SINGLE" || value === "SCHEDULE_MULTIPLE",
 			then: () => Yup.string().required("Required"),
 		}),
 		scheduleEndHour: Yup.string().when("sourceMode", {
-// @ts-expect-error TS(7006): Parameter 'value' implicitly has an 'any' type.
-			is: (value) =>
+			is: (value: string) =>
 				value === "SCHEDULE_SINGLE" || value === "SCHEDULE_MULTIPLE",
 			then: () => Yup.string().required("Required"),
 		}),
 		scheduleEndMinute: Yup.string().when("sourceMode", {
-// @ts-expect-error TS(7006): Parameter 'value' implicitly has an 'any' type.
-			is: (value) =>
+			is: (value: string) =>
 				value === "SCHEDULE_SINGLE" || value === "SCHEDULE_MULTIPLE",
 			then: () => Yup.string().required("Required"),
 		}),
 		location: Yup.string().when("sourceMode", {
-// @ts-expect-error TS(7006): Parameter 'value' implicitly has an 'any' type.
-			is: (value) =>
+			is: (value: string) =>
 				value === "SCHEDULE_SINGLE" || value === "SCHEDULE_MULTIPLE",
 			then: () => Yup.string().required("Required"),
 		}),
@@ -141,8 +131,7 @@ export const NewGroupSchema = [
 ];
 
 // Validation Schema used in new user wizard
-// @ts-expect-error TS(7006): Parameter 'usernames' implicitly has an 'any' type... Remove this comment to see the full error message
-export const NewUserSchema = (usernames) =>
+export const NewUserSchema = (usernames: string[]) =>
 	Yup.object().shape({
 		username: Yup.string()
 			.required("Required")
@@ -151,8 +140,7 @@ export const NewUserSchema = (usernames) =>
 		email: Yup.string().email().required("Required"),
 		password: Yup.string().required("Required"),
 		passwordConfirmation: Yup.string()
-// @ts-expect-error TS(2769): No overload matches this call.
-			.oneOf([Yup.ref("password"), null], "Passwords must match")
+			.oneOf([Yup.ref("password"), undefined], "Passwords must match")
 			.required("Required"),
 	});
 
@@ -161,11 +149,9 @@ export const EditUserSchema = Yup.object().shape({
 	name: Yup.string().required("Required"),
 	email: Yup.string().email().required("Required"),
 	passwordConfirmation: Yup.string().when("password", {
-// @ts-expect-error TS(7006): Parameter 'value' implicitly has an 'any' type.
-		is: (value) => !!value,
+		is: (value: any) => !!value,
 		then: () => Yup.string()
-// @ts-expect-error TS(2769): No overload matches this call.
-			.oneOf([Yup.ref("password"), null], "Passwords must match")
+			.oneOf([Yup.ref("password"), undefined], "Passwords must match")
 			.required("Required"),
 	}),
 });


### PR DESCRIPTION
In the backend, metadata catalogs can be configured as needed. One thing that can be configured for each metadata field is if is considered required. A user should not be able to leave a required field empty (or set it to 

empty). Our validation was ignoring said configuration, merely enforcing the title field.

This fixes the issue by dynamically creating a validation schema based on configuration for the existing metadata fields. Although it really feels like Yup does not want me to do this.

Fixes #317.
Includes #798.

![Bildschirmfoto vom 2024-07-03 16-25-45](https://github.com/opencast/opencast-admin-interface/assets/14070005/7a850088-9cfa-46bc-a7e6-2881b3a1d858)
![Bildschirmfoto vom 2024-07-03 16-25-56](https://github.com/opencast/opencast-admin-interface/assets/14070005/1078cd00-3928-4442-ac2c-a9bb0c7b3980)