### PR TITLE
Fix processing status translation key

### DIFF
--- a/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
@@ -635,7 +635,7 @@
 				"PROCESSED": "Finished",
 				"RECORDING_FAILURE": "Recording failure",
 				"PROCESSING_FAILURE": "Processing failure",
-				"PROCESSING_CANCELED": "Processing canceled"
+				"PROCESSING_CANCELLED": "Processing canceled"
 			},
 			"STATE_MAPPING": {
 				"RETRACTING": "Retracting",


### PR DESCRIPTION
This patch fixes the translation key for “Processing canceled” so that the status will actually be translated.

<img src=https://github.com/opencast/opencast-admin-interface/assets/1008395/c0ce76f1-8906-4cd2-98ff-2b7507b7ae67 width=400px />
