### PR TITLE
Fix video preview displaying wrong video

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetMediaDetails.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetMediaDetails.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import Notifications from "../../../shared/Notifications";
 import {
 	getAssetMediaDetails,
@@ -24,6 +24,14 @@ const EventDetailsAssetMediaDetails = ({
 
 	const media = useAppSelector(state => getAssetMediaDetails(state));
 	const isFetching = useAppSelector(state => isFetchingAssetMediaDetails(state));
+
+	const videoRef = useRef<HTMLVideoElement>(null);
+
+	// Make sure to reload the video player when the url changes, React will not do that for us
+	// This is necessary for proper rerendering when switching between assets
+	useEffect(() => {
+		videoRef.current?.load();
+	}, [media.url]);
 
 	return (
 		<div className="modal-content">
@@ -366,8 +374,8 @@ const EventDetailsAssetMediaDetails = ({
 								{/* video player */}
 								<div className="video-player">
 									<div>
-										<video id="player" controls>
-											<source src={media.url} type="video/mp4" />
+										<video ref={videoRef} id="player" controls>
+											<source src={media.url} />
 										</video>
 									</div>
 								</div>

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetMediaDetails.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetMediaDetails.tsx
@@ -375,7 +375,7 @@ const EventDetailsAssetMediaDetails = ({
 								<div className="video-player">
 									<div>
 										<video ref={videoRef} id="player" controls>
-											<source src={media.url} />
+											<source src={media.url} type={media.mimetype}/>
 										</video>
 									</div>
 								</div>


### PR DESCRIPTION
The video preview player in the event assets details would try to display the media from the assets previously visited, which would lead to the player displaying no or the wrong video. This fixes that by ensuring that the player reloads when the url changes.

Fixes #466.