### PR TITLE
Show workflow operations when clicking on status in events table

### DIFF
--- a/src/components/events/Events.tsx
+++ b/src/components/events/Events.tsx
@@ -41,6 +41,8 @@ import {
 	setShowActions,
 } from "../../slices/eventSlice";
 import { fetchSeries } from "../../slices/seriesSlice";
+import EventDetailsModal from "./partials/modals/EventDetailsModal";
+import { showModal } from "../../selectors/eventDetailsSelectors";
 
 // References for detecting a click outside of the container of the dropdown menu
 const containerAction = React.createRef<HTMLDivElement>();
@@ -53,6 +55,7 @@ const Events = () => {
 	const dispatch = useAppDispatch();
 
 	const currentFilterType = useAppSelector(state => getCurrentFilterResource(state));
+	const displayEventDetailsModal = useAppSelector(state => showModal(state));
 
 	const [displayActionMenu, setActionMenu] = useState(false);
 	const [displayNavigation, setNavigation] = useState(false);
@@ -304,6 +307,12 @@ const Events = () => {
 					<h1>{t("EVENTS.EVENTS.TABLE.CAPTION")}</h1>
 					<h4>{t("TABLE_SUMMARY", { numberOfRows: events })}</h4>
 				</div>
+
+				{/*Include table modal*/}
+				{displayEventDetailsModal &&
+					<EventDetailsModal />
+				}
+
 				{/*Include table component*/}
 				{/* <Table templateMap={eventsTemplateMap} resourceType="events" /> */}
         <Table templateMap={eventsTemplateMap} />

--- a/src/components/events/partials/EventActionCell.tsx
+++ b/src/components/events/partials/EventActionCell.tsx
@@ -1,21 +1,25 @@
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import ConfirmModal from "../../shared/ConfirmModal";
-import EventDetailsModal from "./modals/EventDetailsModal";
 import EmbeddingCodeModal from "./modals/EmbeddingCodeModal";
 import { getUserInformation } from "../../../selectors/userInfoSelectors";
 import { hasAccess } from "../../../utils/utils";
 import SeriesDetailsModal from "./modals/SeriesDetailsModal";
+import { EventDetailsPage } from "./modals/EventDetails";
 import { useAppDispatch, useAppSelector } from "../../../store";
 import {
-	fetchSeriesDetailsThemeNames,
 	fetchSeriesDetailsAcls,
 	fetchSeriesDetailsFeeds,
 	fetchSeriesDetailsMetadata,
 	fetchSeriesDetailsTheme,
+	fetchSeriesDetailsThemeNames,
 } from "../../../slices/seriesDetailsSlice";
 import { Event, deleteEvent } from "../../../slices/eventSlice";
 import { Tooltip } from "../../shared/Tooltip";
+import {
+	openModal,
+	setModalPage
+} from "../../../slices/eventDetailsSlice";
 
 /**
  * This component renders the action cells of events in the table view
@@ -29,9 +33,7 @@ const EventActionCell = ({
 	const dispatch = useAppDispatch();
 
 	const [displayDeleteConfirmation, setDeleteConfirmation] = useState(false);
-	const [displayEventDetailsModal, setEventDetailsModal] = useState(false);
 	const [displaySeriesDetailsModal, setSeriesDetailsModal] = useState(false);
-	const [eventDetailsTabIndex, setEventDetailsTabIndex] = useState(0);
 	const [displayEmbeddingCodeModal, setEmbeddingCodeModal] = useState(false);
 
 	const user = useAppSelector(state => getUserInformation(state));
@@ -54,11 +56,7 @@ const EventActionCell = ({
 	};
 
 	const showEventDetailsModal = () => {
-		setEventDetailsModal(true);
-	};
-
-	const hideEventDetailsModal = () => {
-		setEventDetailsModal(false);
+		dispatch(openModal(EventDetailsPage.Metadata, row))
 	};
 
 	const showSeriesDetailsModal = () => {
@@ -82,37 +80,27 @@ const EventActionCell = ({
 	};
 
 	const onClickEventDetails = () => {
-		setEventDetailsTabIndex(0);
+		dispatch(setModalPage(EventDetailsPage.Metadata));
 		showEventDetailsModal();
 	};
 
 	const onClickComments = () => {
-		setEventDetailsTabIndex(7);
+		dispatch(setModalPage(EventDetailsPage.Comments));
 		showEventDetailsModal();
 	};
 
 	const onClickWorkflow = () => {
-		setEventDetailsTabIndex(5);
+		dispatch(setModalPage(EventDetailsPage.Workflow));
 		showEventDetailsModal();
 	};
 
 	const onClickAssets = () => {
-		setEventDetailsTabIndex(3);
+		dispatch(setModalPage(EventDetailsPage.Assets));
 		showEventDetailsModal();
 	};
 
 	return (
 		<>
-			{/* Display modal for editing table view if table edit button is clicked */}
-			{displayEventDetailsModal &&
-				<EventDetailsModal
-					handleClose={hideEventDetailsModal}
-					tabIndex={eventDetailsTabIndex}
-					eventTitle={row.title}
-					eventId={row.id}
-				/>
-			}
-
 			{!!row.series && displaySeriesDetailsModal && (
 				<SeriesDetailsModal
 					handleClose={hideSeriesDetailsModal}

--- a/src/components/events/partials/EventsStatusCell.tsx
+++ b/src/components/events/partials/EventsStatusCell.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { useAppDispatch } from "../../../store";
 import { Tooltip } from "../../shared/Tooltip";
-import { EventDetailsPage } from "./modals/EventDetails";
 import { Event } from "../../../slices/eventSlice";
 import {
 	fetchWorkflowDetails,
@@ -10,6 +9,8 @@ import {
 	fetchWorkflows,
 	openModal
 } from "../../../slices/eventDetailsSlice";
+import { EventDetailsPage } from "./modals/EventDetails";
+import { hasScheduledStatus } from "../../../utils/eventDetailsUtils";
 
 /**
  * This component renders the status cells of events in the table view
@@ -22,11 +23,16 @@ const EventsStatusCell = ({
 	const { t } = useTranslation();
 	const dispatch = useAppDispatch();
 
-	const openWorkflowOperations = () => {
+	const openStatusModal = () => {
+		// Open scheduling modal for scheduled and recording events
+		if (hasScheduledStatus(row)) {
+			return dispatch(openModal(EventDetailsPage.Scheduling, row));
+		}
+
 		dispatch(fetchWorkflows(row.id)).unwrap()
 			.then(async (workflows) => {
+				// Open workflow overview modal if no workflows available
 				if (!workflows.entries.length) {
-					// Open workflow overview modal
 					return dispatch(openModal(EventDetailsPage.Workflow, row));
 				}
 
@@ -45,7 +51,7 @@ const EventsStatusCell = ({
 		<Tooltip title={t("EVENTS.EVENTS.TABLE.TOOLTIP.STATUS")}>
 			<button
 				className="button-like-anchor crosslink"
-				onClick={() => openWorkflowOperations()}
+				onClick={() => openStatusModal()}
 			>
 				{t(row.displayable_status)}
 			</button>

--- a/src/components/events/partials/EventsStatusCell.tsx
+++ b/src/components/events/partials/EventsStatusCell.tsx
@@ -25,7 +25,7 @@ const EventsStatusCell = ({
 	const openWorkflowOperations = () => {
 		dispatch(fetchWorkflows(row.id)).unwrap()
 			.then(async (workflows) => {
-				if (!workflows.entries) {
+				if (!workflows.entries.length) {
 					// Open workflow overview modal
 					return dispatch(openModal(EventDetailsPage.Workflow, row));
 				}

--- a/src/components/events/partials/EventsStatusCell.tsx
+++ b/src/components/events/partials/EventsStatusCell.tsx
@@ -4,10 +4,8 @@ import { useAppDispatch } from "../../../store";
 import { Tooltip } from "../../shared/Tooltip";
 import { Event } from "../../../slices/eventSlice";
 import {
-	fetchWorkflowDetails,
-	fetchWorkflowOperations,
 	fetchWorkflows,
-	openModal
+	openModal,
 } from "../../../slices/eventDetailsSlice";
 import { EventDetailsPage } from "./modals/EventDetails";
 import { hasScheduledStatus } from "../../../utils/eventDetailsUtils";
@@ -38,12 +36,7 @@ const EventsStatusCell = ({
 
 				// Show operations of last workflow
 				const lastWorkflow = workflows.entries[workflows.entries.length-1];
-
-				// Load necessary workflow data
-				await dispatch(fetchWorkflowDetails({ eventId: row.id, workflowId: lastWorkflow.id }));
-				await dispatch(fetchWorkflowOperations({ eventId: row.id, workflowId: lastWorkflow.id }));
-
-				dispatch(openModal(EventDetailsPage.Workflow, row, 'workflow-operations'));
+				dispatch(openModal(EventDetailsPage.Workflow, row, 'workflow-operations', 'entry', lastWorkflow.id));
 			});
 	};
 

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetAttachmentDetails.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetAttachmentDetails.tsx
@@ -6,17 +6,12 @@ import {
 } from "../../../../selectors/eventDetailsSelectors";
 import { humanReadableBytesFilter } from "../../../../utils/eventDetailsUtils";
 import { useAppSelector } from "../../../../store";
-import { AssetTabHierarchy } from "../modals/EventDetails";
 import { useTranslation } from "react-i18next";
 
 /**
  * This component manages the attachment details sub-tab for assets tab of event details modal
  */
-const EventDetailsAssetAttachmentDetails = ({
-	setHierarchy,
-}: {
-	setHierarchy: (subTabName: AssetTabHierarchy) => void,
-}) => {
+const EventDetailsAssetAttachmentDetails = () => {
 	const { t } = useTranslation();
 	const attachment = useAppSelector(state => getAssetAttachmentDetails(state));
 	const isFetching = useAppSelector(state => isFetchingAssetAttachmentDetails(state));

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetAttachments.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetAttachments.tsx
@@ -5,7 +5,7 @@ import {
 	isFetchingAssetAttachments,
 } from "../../../../selectors/eventDetailsSelectors";
 import { useAppDispatch, useAppSelector } from "../../../../store";
-import { fetchAssetAttachmentDetails } from "../../../../slices/eventDetailsSlice";
+import { fetchAssetAttachmentDetails, setModalAssetsTabHierarchy } from "../../../../slices/eventDetailsSlice";
 import { AssetTabHierarchy } from "../modals/EventDetails";
 import { useTranslation } from "react-i18next";
 
@@ -14,10 +14,8 @@ import { useTranslation } from "react-i18next";
  */
 const EventDetailsAssetAttachments = ({
 	eventId,
-	setHierarchy,
 }: {
 	eventId: string,
-	setHierarchy: (subTabName: AssetTabHierarchy) => void,
 }) => {
 	const { t } = useTranslation();
 	const dispatch = useAppDispatch();
@@ -29,7 +27,7 @@ const EventDetailsAssetAttachments = ({
 		if (subTabName === "attachment-details") {
 			dispatch(fetchAssetAttachmentDetails({eventId, attachmentId})).then();
 		}
-		setHierarchy(subTabName);
+		dispatch(setModalAssetsTabHierarchy(subTabName));
 	};
 
 	return (

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetCatalogDetails.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetCatalogDetails.tsx
@@ -6,17 +6,12 @@ import {
 } from "../../../../selectors/eventDetailsSelectors";
 import { humanReadableBytesFilter } from "../../../../utils/eventDetailsUtils";
 import { useAppSelector } from "../../../../store";
-import { AssetTabHierarchy } from "../modals/EventDetails";
 import { useTranslation } from "react-i18next";
 
 /**
  * This component manages the catalog details sub-tab for assets tab of event details modal
  */
-const EventDetailsAssetCatalogDetails = ({
-	setHierarchy,
-}: {
-	setHierarchy: (subTabName: AssetTabHierarchy) => void,
-}) => {
+const EventDetailsAssetCatalogDetails = () => {
 	const { t } = useTranslation();
 
 	const catalog = useAppSelector(state => getAssetCatalogDetails(state));

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetCatalogs.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetCatalogs.tsx
@@ -5,7 +5,7 @@ import {
 	isFetchingAssetCatalogs,
 } from "../../../../selectors/eventDetailsSelectors";
 import { useAppDispatch, useAppSelector } from "../../../../store";
-import { fetchAssetCatalogDetails } from "../../../../slices/eventDetailsSlice";
+import { fetchAssetCatalogDetails, setModalAssetsTabHierarchy } from "../../../../slices/eventDetailsSlice";
 import { AssetTabHierarchy } from "../modals/EventDetails";
 import { useTranslation } from "react-i18next";
 
@@ -14,10 +14,8 @@ import { useTranslation } from "react-i18next";
  */
 const EventDetailsAssetCatalogs = ({
 	eventId,
-	setHierarchy,
 }: {
 	eventId: string,
-	setHierarchy: (subTabName: AssetTabHierarchy) => void,
 }) => {
 	const { t } = useTranslation();
 	const dispatch = useAppDispatch();
@@ -29,7 +27,7 @@ const EventDetailsAssetCatalogs = ({
 		if (subTabName === "catalog-details") {
 			dispatch(fetchAssetCatalogDetails({eventId, catalogId})).then();
 		}
-		setHierarchy(subTabName);
+		dispatch(setModalAssetsTabHierarchy(subTabName));
 	};
 
 	return (

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetMedia.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetMedia.tsx
@@ -5,7 +5,7 @@ import {
 	isFetchingAssetMedia,
 } from "../../../../selectors/eventDetailsSelectors";
 import { useAppDispatch, useAppSelector } from "../../../../store";
-import { fetchAssetMediaDetails } from "../../../../slices/eventDetailsSlice";
+import { fetchAssetMediaDetails, setModalAssetsTabHierarchy } from "../../../../slices/eventDetailsSlice";
 import { AssetTabHierarchy } from "../modals/EventDetails";
 import { useTranslation } from "react-i18next";
 
@@ -14,10 +14,8 @@ import { useTranslation } from "react-i18next";
  */
 const EventDetailsAssetMedia = ({
 	eventId,
-	setHierarchy,
 }: {
 	eventId: string,
-	setHierarchy: (subTabName: AssetTabHierarchy) => void,
 }) => {
 	const { t } = useTranslation();
 	const dispatch = useAppDispatch();
@@ -29,7 +27,7 @@ const EventDetailsAssetMedia = ({
 		if (subTabName === "media-details") {
 			dispatch(fetchAssetMediaDetails({eventId, mediaId})).then();
 		}
-		setHierarchy(subTabName);
+		dispatch(setModalAssetsTabHierarchy(subTabName));
 	};
 
 	return (

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetMediaDetails.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetMediaDetails.tsx
@@ -9,17 +9,12 @@ import {
 	humanReadableBytesFilter,
 } from "../../../../utils/eventDetailsUtils";
 import { useAppSelector } from "../../../../store";
-import { AssetTabHierarchy } from "../modals/EventDetails";
 import { useTranslation } from "react-i18next";
 
 /**
  * This component manages the media details sub-tab for assets tab of event details modal
  */
-const EventDetailsAssetMediaDetails = ({
-	setHierarchy,
-}: {
-	setHierarchy: (subTabName: AssetTabHierarchy) => void,
-}) => {
+const EventDetailsAssetMediaDetails = () => {
 	const { t } = useTranslation();
 
 	const media = useAppSelector(state => getAssetMediaDetails(state));

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetPublicationDetails.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetPublicationDetails.tsx
@@ -6,17 +6,12 @@ import {
 } from "../../../../selectors/eventDetailsSelectors";
 import { humanReadableBytesFilter } from "../../../../utils/eventDetailsUtils";
 import { useAppSelector } from "../../../../store";
-import { AssetTabHierarchy } from "../modals/EventDetails";
 import { useTranslation } from "react-i18next";
 
 /**
  * This component manages the publication details sub-tab for assets tab of event details modal
  */
-const EventDetailsAssetPublicationDetails = ({
-	setHierarchy,
-}: {
-	setHierarchy: (subTabName: AssetTabHierarchy) => void,
-}) => {
+const EventDetailsAssetPublicationDetails = () => {
 	const { t } = useTranslation();
 
 	const publication = useAppSelector(state => getAssetPublicationDetails(state));

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetPublications.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetPublications.tsx
@@ -5,7 +5,7 @@ import {
 	isFetchingAssetPublications,
 } from "../../../../selectors/eventDetailsSelectors";
 import { useAppDispatch, useAppSelector } from "../../../../store";
-import { fetchAssetPublicationDetails } from "../../../../slices/eventDetailsSlice";
+import { fetchAssetPublicationDetails, setModalAssetsTabHierarchy } from "../../../../slices/eventDetailsSlice";
 import { AssetTabHierarchy } from "../modals/EventDetails";
 import { useTranslation } from "react-i18next";
 
@@ -14,10 +14,8 @@ import { useTranslation } from "react-i18next";
  */
 const EventDetailsAssetPublications = ({
 	eventId,
-	setHierarchy,
 }: {
 	eventId: string,
-	setHierarchy: (subTabName: AssetTabHierarchy) => void,
 }) => {
 	const { t } = useTranslation();
 	const dispatch = useAppDispatch();
@@ -29,7 +27,7 @@ const EventDetailsAssetPublications = ({
 		if (subTabName === "publication-details") {
 			dispatch(fetchAssetPublicationDetails({eventId, publicationId})).then();
 		}
-		setHierarchy(subTabName);
+		dispatch(setModalAssetsTabHierarchy(subTabName));
 	};
 
 	return (

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetsAddAsset.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetsAddAsset.tsx
@@ -6,7 +6,7 @@ import { Formik } from "formik";
 import { getAssetUploadOptions } from "../../../../selectors/eventSelectors";
 import { translateOverrideFallback } from "../../../../utils/utils";
 import { useAppDispatch, useAppSelector } from "../../../../store";
-import { updateAssets } from "../../../../slices/eventDetailsSlice";
+import { setModalAssetsTabHierarchy, updateAssets } from "../../../../slices/eventDetailsSlice";
 import { AssetTabHierarchy } from "../modals/EventDetails";
 import { useTranslation } from "react-i18next";
 
@@ -15,10 +15,8 @@ import { useTranslation } from "react-i18next";
  */
 const EventDetailsAssetsAddAsset = ({
 	eventId,
-	setHierarchy,
 }: {
 	eventId: string,
-	setHierarchy: (subTabName: AssetTabHierarchy) => void,
 }) => {
 	const { t } = useTranslation();
 	const dispatch = useAppDispatch();
@@ -31,7 +29,7 @@ const EventDetailsAssetsAddAsset = ({
 	);
 
 	const openSubTab = (subTabName: AssetTabHierarchy) => {
-		setHierarchy(subTabName);
+		dispatch(setModalAssetsTabHierarchy(subTabName));
 	};
 
 // @ts-expect-error TS(7006): Parameter 'values' implicitly has an 'any' type.

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetsTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetsTab.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from "react";
 import Notifications from "../../../shared/Notifications";
 import {
 	getAssets,
+	getModalAssetsTabHierarchy,
 	getUploadAssetOptions,
 	isFetchingAssets,
 	isTransactionReadOnly,
@@ -17,6 +18,7 @@ import {
 	fetchAssetMedia,
 	fetchAssetPublications,
 	fetchAssets,
+	setModalAssetsTabHierarchy,
 } from "../../../../slices/eventDetailsSlice";
 import { useTranslation } from "react-i18next";
 import { AssetTabHierarchy } from "../modals/EventDetails";
@@ -35,16 +37,13 @@ import EventDetailsAssetPublicationDetails from "./EventDetailsAssetPublicationD
  */
 const EventDetailsAssetsTab = ({
 	eventId,
-	assetsTabHierarchy,
-	setAssetsTabHierarchy,
 }: {
 	eventId: string,
-	assetsTabHierarchy: AssetTabHierarchy,
-	setAssetsTabHierarchy: (subTabName: AssetTabHierarchy) => void,
 }) => {
 	const { t } = useTranslation();
 	const dispatch = useAppDispatch();
 
+	const assetsTabHierarchy = useAppSelector(state => getModalAssetsTabHierarchy(state));
 	const user = useAppSelector(state => getUserInformation(state));
 	const assets = useAppSelector(state => getAssets(state));
 	const uploadAssetOptions = useAppSelector(state => getUploadAssetOptions(state));
@@ -114,7 +113,7 @@ const EventDetailsAssetsTab = ({
 		} else if (subTabName === "asset-publications") {
 			dispatch(fetchAssetPublications(eventId)).then();
 		}
-		setAssetsTabHierarchy(subTabName);
+		dispatch(setModalAssetsTabHierarchy(subTabName));
 	};
 
 	return (
@@ -298,52 +297,39 @@ const EventDetailsAssetsTab = ({
 			(assetsTabHierarchy === "add-asset" && (
 				<EventDetailsAssetsAddAsset
 					eventId={eventId}
-					setHierarchy={setAssetsTabHierarchy}
 				/>
 			)) ||
 			(assetsTabHierarchy === "asset-attachments" && (
 				<EventDetailsAssetAttachments
 					eventId={eventId}
-					setHierarchy={setAssetsTabHierarchy}
 				/>
 			)) ||
 			(assetsTabHierarchy === "attachment-details" && (
-				<EventDetailsAssetAttachmentDetails
-					setHierarchy={setAssetsTabHierarchy}
-				/>
+				<EventDetailsAssetAttachmentDetails />
 			)) ||
 			(assetsTabHierarchy === "asset-catalogs" && (
 				<EventDetailsAssetCatalogs
 					eventId={eventId}
-					setHierarchy={setAssetsTabHierarchy}
 				/>
 			)) ||
 			(assetsTabHierarchy === "catalog-details" && (
-				<EventDetailsAssetCatalogDetails
-					setHierarchy={setAssetsTabHierarchy}
-				/>
+				<EventDetailsAssetCatalogDetails />
 			)) ||
 			(assetsTabHierarchy === "asset-media" && (
 				<EventDetailsAssetMedia
 					eventId={eventId}
-					setHierarchy={setAssetsTabHierarchy}
 				/>
 			)) ||
 			(assetsTabHierarchy === "media-details" && (
-				<EventDetailsAssetMediaDetails
-					setHierarchy={setAssetsTabHierarchy}
-				/>
+				<EventDetailsAssetMediaDetails />
 			)) ||
 			(assetsTabHierarchy === "asset-publications" && (
 				<EventDetailsAssetPublications
 					eventId={eventId}
-					setHierarchy={setAssetsTabHierarchy}
 				/>
 			)) ||
 			(assetsTabHierarchy === "publication-details" && (
-				<EventDetailsAssetPublicationDetails
-					setHierarchy={setAssetsTabHierarchy}
-				/>
+				<EventDetailsAssetPublicationDetails />
 			)))}
 		</>
 	);

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowDetails.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowDetails.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from "react";
 import Notifications from "../../../shared/Notifications";
 import {
+	getModalWorkflowId,
 	getWorkflow,
 	isFetchingWorkflowDetails,
 } from "../../../../selectors/eventDetailsSelectors";
@@ -23,15 +24,14 @@ import { useTranslation } from "react-i18next";
  */
 const EventDetailsWorkflowDetails = ({
 	eventId,
-	workflowId,
 }: {
 	eventId: string,
-	workflowId: string,
 }) => {
 	const { t } = useTranslation();
 	const dispatch = useAppDispatch();
 
 	const user = useAppSelector(state => getUserInformation(state));
+	const workflowId = useAppSelector(state => getModalWorkflowId(state));
 	const workflowData = useAppSelector(state => getWorkflow(state));
 	const isFetching = useAppSelector(state => isFetchingWorkflowDetails(state));
 

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowDetails.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowDetails.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import Notifications from "../../../shared/Notifications";
 import {
 	getWorkflow,
@@ -10,8 +10,8 @@ import { hasAccess } from "../../../../utils/utils";
 import { getUserInformation } from "../../../../selectors/userInfoSelectors";
 import { useAppDispatch, useAppSelector } from "../../../../store";
 import {
-	fetchWorkflowErrors,
-	fetchWorkflowOperations, setModalWorkflowTabHierarchy,
+	fetchWorkflowDetails,
+	setModalWorkflowTabHierarchy,
 } from "../../../../slices/eventDetailsSlice";
 import { removeNotificationWizardForm } from "../../../../slices/notificationSlice";
 import { renderValidDate } from "../../../../utils/dateUtils";
@@ -23,8 +23,10 @@ import { useTranslation } from "react-i18next";
  */
 const EventDetailsWorkflowDetails = ({
 	eventId,
+	workflowId,
 }: {
 	eventId: string,
+	workflowId: string,
 }) => {
 	const { t } = useTranslation();
 	const dispatch = useAppDispatch();
@@ -33,15 +35,13 @@ const EventDetailsWorkflowDetails = ({
 	const workflowData = useAppSelector(state => getWorkflow(state));
 	const isFetching = useAppSelector(state => isFetchingWorkflowDetails(state));
 
+	useEffect(() => {
+		dispatch(fetchWorkflowDetails({eventId, workflowId}));
+	}, []);
+
 	const openSubTab = (tabType: WorkflowTabHierarchy) => {
 		dispatch(removeNotificationWizardForm());
 		dispatch(setModalWorkflowTabHierarchy(tabType));
-
-		if (tabType === "workflow-operations") {
-			dispatch(fetchWorkflowOperations({eventId, workflowId: workflowData.wiid})).then();
-		} else if (tabType === "errors-and-warnings") {
-			dispatch(fetchWorkflowErrors({eventId, workflowId: workflowData.wiid})).then();
-		}
 	};
 
 	return (

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowDetails.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowDetails.tsx
@@ -11,7 +11,7 @@ import { getUserInformation } from "../../../../selectors/userInfoSelectors";
 import { useAppDispatch, useAppSelector } from "../../../../store";
 import {
 	fetchWorkflowErrors,
-	fetchWorkflowOperations,
+	fetchWorkflowOperations, setModalWorkflowTabHierarchy,
 } from "../../../../slices/eventDetailsSlice";
 import { removeNotificationWizardForm } from "../../../../slices/notificationSlice";
 import { renderValidDate } from "../../../../utils/dateUtils";
@@ -23,10 +23,8 @@ import { useTranslation } from "react-i18next";
  */
 const EventDetailsWorkflowDetails = ({
 	eventId,
-	setHierarchy,
 }: {
 	eventId: string,
-	setHierarchy: (subTabName: WorkflowTabHierarchy) => void,
 }) => {
 	const { t } = useTranslation();
 	const dispatch = useAppDispatch();
@@ -37,7 +35,8 @@ const EventDetailsWorkflowDetails = ({
 
 	const openSubTab = (tabType: WorkflowTabHierarchy) => {
 		dispatch(removeNotificationWizardForm());
-		setHierarchy(tabType);
+		dispatch(setModalWorkflowTabHierarchy(tabType));
+
 		if (tabType === "workflow-operations") {
 			dispatch(fetchWorkflowOperations({eventId, workflowId: workflowData.wiid})).then();
 		} else if (tabType === "errors-and-warnings") {

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowDetails.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowDetails.tsx
@@ -37,6 +37,7 @@ const EventDetailsWorkflowDetails = ({
 
 	useEffect(() => {
 		dispatch(fetchWorkflowDetails({eventId, workflowId}));
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
 	const openSubTab = (tabType: WorkflowTabHierarchy) => {

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowErrorDetails.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowErrorDetails.tsx
@@ -11,15 +11,12 @@ import { removeNotificationWizardForm } from "../../../../slices/notificationSli
 import { renderValidDate } from "../../../../utils/dateUtils";
 import { WorkflowTabHierarchy } from "../modals/EventDetails";
 import { useTranslation } from "react-i18next";
+import { setModalWorkflowTabHierarchy } from "../../../../slices/eventDetailsSlice";
 
 /**
  * This component manages the workflow error details for the workflows tab of the event details modal
  */
-const EventDetailsWorkflowErrorDetails = ({
-	setHierarchy,
-}: {
-	setHierarchy: (subTabName: WorkflowTabHierarchy) => void,
-}) => {
+const EventDetailsWorkflowErrorDetails = () => {
 	const { t } = useTranslation();
 	const dispatch = useAppDispatch();
 
@@ -28,7 +25,7 @@ const EventDetailsWorkflowErrorDetails = ({
 
 	const openSubTab = (tabType: WorkflowTabHierarchy) => {
 		dispatch(removeNotificationWizardForm());
-		setHierarchy(tabType);
+		dispatch(setModalWorkflowTabHierarchy(tabType));
 	};
 
 	return (

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowErrors.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowErrors.tsx
@@ -8,7 +8,7 @@ import {
 import EventDetailsTabHierarchyNavigation from "./EventDetailsTabHierarchyNavigation";
 import { useAppDispatch, useAppSelector } from "../../../../store";
 import { removeNotificationWizardForm } from "../../../../slices/notificationSlice";
-import { fetchWorkflowErrorDetails } from "../../../../slices/eventDetailsSlice";
+import { fetchWorkflowErrorDetails, setModalWorkflowTabHierarchy } from "../../../../slices/eventDetailsSlice";
 import { renderValidDate } from "../../../../utils/dateUtils";
 import { WorkflowTabHierarchy } from "../modals/EventDetails";
 import { useTranslation } from "react-i18next";
@@ -18,10 +18,8 @@ import { useTranslation } from "react-i18next";
  */
 const EventDetailsWorkflowErrors = ({
 	eventId,
-	setHierarchy,
 }: {
 	eventId: string,
-	setHierarchy: (subTabName: WorkflowTabHierarchy) => void,
 }) => {
 	const { t } = useTranslation();
 	const dispatch = useAppDispatch();
@@ -45,7 +43,7 @@ const EventDetailsWorkflowErrors = ({
 
 	const openSubTab = (tabType: WorkflowTabHierarchy, errorId: number | undefined = undefined) => {
 		dispatch(removeNotificationWizardForm());
-		setHierarchy(tabType);
+		dispatch(setModalWorkflowTabHierarchy(tabType));
 		if (tabType === "workflow-error-details") {
 			dispatch(fetchWorkflowErrorDetails({eventId, workflowId: workflow.wiid, errorId})).then();
 		}

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowErrors.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowErrors.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from "react";
 import Notifications from "../../../shared/Notifications";
 import {
+	getModalWorkflowId,
 	getWorkflow,
 	getWorkflowErrors,
 	isFetchingWorkflowErrors,
@@ -22,14 +23,13 @@ import { useTranslation } from "react-i18next";
  */
 const EventDetailsWorkflowErrors = ({
 	eventId,
-	workflowId,
 }: {
 	eventId: string,
-	workflowId: string;
 }) => {
 	const { t } = useTranslation();
 	const dispatch = useAppDispatch();
 
+	const workflowId = useAppSelector(state => getModalWorkflowId(state));
 	const workflow = useAppSelector(state => getWorkflow(state));
 	const errors = useAppSelector(state => getWorkflowErrors(state));
 	const isFetching = useAppSelector(state => isFetchingWorkflowErrors(state));

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowErrors.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowErrors.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import Notifications from "../../../shared/Notifications";
 import {
 	getWorkflow,
@@ -8,7 +8,11 @@ import {
 import EventDetailsTabHierarchyNavigation from "./EventDetailsTabHierarchyNavigation";
 import { useAppDispatch, useAppSelector } from "../../../../store";
 import { removeNotificationWizardForm } from "../../../../slices/notificationSlice";
-import { fetchWorkflowErrorDetails, setModalWorkflowTabHierarchy } from "../../../../slices/eventDetailsSlice";
+import {
+	fetchWorkflowErrorDetails,
+	fetchWorkflowErrors,
+	setModalWorkflowTabHierarchy
+} from "../../../../slices/eventDetailsSlice";
 import { renderValidDate } from "../../../../utils/dateUtils";
 import { WorkflowTabHierarchy } from "../modals/EventDetails";
 import { useTranslation } from "react-i18next";
@@ -18,8 +22,10 @@ import { useTranslation } from "react-i18next";
  */
 const EventDetailsWorkflowErrors = ({
 	eventId,
+	workflowId,
 }: {
 	eventId: string,
+	workflowId: string;
 }) => {
 	const { t } = useTranslation();
 	const dispatch = useAppDispatch();
@@ -40,6 +46,11 @@ const EventDetailsWorkflowErrors = ({
 				return "red";
 		}
 	};
+
+	useEffect(() => {
+		dispatch(fetchWorkflowErrors({eventId, workflowId})).then();
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
 
 	const openSubTab = (tabType: WorkflowTabHierarchy, errorId: number | undefined = undefined) => {
 		dispatch(removeNotificationWizardForm());

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowOperationDetails.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowOperationDetails.tsx
@@ -8,17 +8,13 @@ import EventDetailsTabHierarchyNavigation from "./EventDetailsTabHierarchyNaviga
 import { useAppDispatch, useAppSelector } from "../../../../store";
 import { removeNotificationWizardForm } from "../../../../slices/notificationSlice";
 import { renderValidDate } from "../../../../utils/dateUtils";
-import { WorkflowTabHierarchy } from "../modals/EventDetails";
 import { useTranslation } from "react-i18next";
+import { setModalWorkflowTabHierarchy } from "../../../../slices/eventDetailsSlice";
 
 /**
  * This component manages the workflow operation details for the workflows tab of the event details modal
  */
-const EventDetailsWorkflowOperationDetails = ({
-	setHierarchy,
-}: {
-	setHierarchy: (subTabName: WorkflowTabHierarchy) => void,
-}) => {
+const EventDetailsWorkflowOperationDetails = () => {
 	const { t } = useTranslation();
 	const dispatch = useAppDispatch();
 
@@ -28,7 +24,7 @@ const EventDetailsWorkflowOperationDetails = ({
 // @ts-expect-error TS(7006): Parameter 'tabType' implicitly has an 'any' type.
 	const openSubTab = (tabType) => {
 		dispatch(removeNotificationWizardForm());
-		setHierarchy(tabType);
+		dispatch(setModalWorkflowTabHierarchy(tabType));
 	};
 
 	return (

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowOperations.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowOperations.tsx
@@ -1,9 +1,6 @@
 import React, { useEffect } from "react";
 import Notifications from "../../../shared/Notifications";
-import {
-	getWorkflow,
-	getWorkflowOperations,
-} from "../../../../selectors/eventDetailsSelectors";
+import { getWorkflowOperations } from "../../../../selectors/eventDetailsSelectors";
 import EventDetailsTabHierarchyNavigation from "./EventDetailsTabHierarchyNavigation";
 import { useAppDispatch, useAppSelector } from "../../../../store";
 import { removeNotificationWizardForm } from "../../../../slices/notificationSlice";

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowOperations.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowOperations.tsx
@@ -7,19 +7,20 @@ import {
 import EventDetailsTabHierarchyNavigation from "./EventDetailsTabHierarchyNavigation";
 import { useAppDispatch, useAppSelector } from "../../../../store";
 import { removeNotificationWizardForm } from "../../../../slices/notificationSlice";
-import { fetchWorkflowOperationDetails, fetchWorkflowOperations } from "../../../../slices/eventDetailsSlice";
+import {
+	fetchWorkflowOperationDetails,
+	fetchWorkflowOperations,
+	setModalWorkflowTabHierarchy
+} from "../../../../slices/eventDetailsSlice";
 import { useTranslation } from "react-i18next";
-import { WorkflowTabHierarchy } from "../modals/EventDetails";
 
 /**
  * This component manages the workflow operations for the workflows tab of the event details modal
  */
 const EventDetailsWorkflowOperations = ({
 	eventId,
-	setHierarchy,
 }: {
 	eventId: string,
-	setHierarchy: (subTabName: WorkflowTabHierarchy) => void,
 }) => {
 	const { t } = useTranslation();
 	const dispatch = useAppDispatch();
@@ -44,7 +45,7 @@ const EventDetailsWorkflowOperations = ({
 // @ts-expect-error TS(7006): Parameter 'tabType' implicitly has an 'any' type.
 	const openSubTab = (tabType, operationId: number | undefined = undefined) => {
 		dispatch(removeNotificationWizardForm());
-		setHierarchy(tabType);
+		dispatch(setModalWorkflowTabHierarchy(tabType));
 		if (tabType === "workflow-operation-details") {
 			dispatch(fetchWorkflowOperationDetails({eventId, workflowId: workflow.wiid, operationId})).then();
 		}

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowOperations.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowOperations.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
 import Notifications from "../../../shared/Notifications";
-import { getWorkflowOperations } from "../../../../selectors/eventDetailsSelectors";
+import { getModalWorkflowId, getWorkflowOperations } from "../../../../selectors/eventDetailsSelectors";
 import EventDetailsTabHierarchyNavigation from "./EventDetailsTabHierarchyNavigation";
 import { useAppDispatch, useAppSelector } from "../../../../store";
 import { removeNotificationWizardForm } from "../../../../slices/notificationSlice";
@@ -16,14 +16,13 @@ import { useTranslation } from "react-i18next";
  */
 const EventDetailsWorkflowOperations = ({
 	eventId,
-	workflowId,
 }: {
 	eventId: string,
-	workflowId: string,
 }) => {
 	const { t } = useTranslation();
 	const dispatch = useAppDispatch();
 
+	const workflowId = useAppSelector(state => getModalWorkflowId(state));
 	const operations = useAppSelector(state => getWorkflowOperations(state));
 
   const loadWorkflowOperations = async () => {

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowOperations.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowOperations.tsx
@@ -19,21 +19,25 @@ import { useTranslation } from "react-i18next";
  */
 const EventDetailsWorkflowOperations = ({
 	eventId,
+	workflowId,
 }: {
 	eventId: string,
+	workflowId: string,
 }) => {
 	const { t } = useTranslation();
 	const dispatch = useAppDispatch();
 
-	const workflow = useAppSelector(state => getWorkflow(state));
 	const operations = useAppSelector(state => getWorkflowOperations(state));
 
   const loadWorkflowOperations = async () => {
 		// Fetching workflow operations from server
-		dispatch(fetchWorkflowOperations({eventId, workflowId: workflow.wiid}));
+		dispatch(fetchWorkflowOperations({eventId, workflowId}));
 	};
 
   useEffect(() => {
+		// Fetch workflow operations initially
+		loadWorkflowOperations().then();
+
 		// Fetch workflow operations every 5 seconds
 		let fetchWorkflowOperationsInterval = setInterval(loadWorkflowOperations, 5000);
 
@@ -47,7 +51,7 @@ const EventDetailsWorkflowOperations = ({
 		dispatch(removeNotificationWizardForm());
 		dispatch(setModalWorkflowTabHierarchy(tabType));
 		if (tabType === "workflow-operation-details") {
-			dispatch(fetchWorkflowOperationDetails({eventId, workflowId: workflow.wiid, operationId})).then();
+			dispatch(fetchWorkflowOperationDetails({eventId, workflowId, operationId})).then();
 		}
 	};
 

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowTab.tsx
@@ -19,10 +19,10 @@ import DropDown from "../../../shared/DropDown";
 import { useAppDispatch, useAppSelector } from "../../../../store";
 import {
 	deleteWorkflow as deleteWf,
-	fetchWorkflowDetails,
 	fetchWorkflows,
 	performWorkflowAction,
 	saveWorkflowConfig,
+	setModalWorkflowId,
 	setModalWorkflowTabHierarchy,
 	updateWorkflow,
 } from "../../../../slices/eventDetailsSlice";
@@ -86,7 +86,7 @@ const EventDetailsWorkflowTab = ({
 	};
 
 	const openSubTab = (tabType: WorkflowTabHierarchy, workflowId: string) => {
-		dispatch(fetchWorkflowDetails({eventId, workflowId})).then();
+		dispatch(setModalWorkflowId(workflowId));
 		dispatch(setModalWorkflowTabHierarchy(tabType));
 		dispatch(removeNotificationWizardForm());
 	};

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowTab.tsx
@@ -23,6 +23,7 @@ import {
 	fetchWorkflows,
 	performWorkflowAction,
 	saveWorkflowConfig,
+	setModalWorkflowTabHierarchy,
 	updateWorkflow,
 } from "../../../../slices/eventDetailsSlice";
 import { removeNotificationWizardForm } from "../../../../slices/notificationSlice";
@@ -36,10 +37,8 @@ import { useTranslation } from "react-i18next";
  */
 const EventDetailsWorkflowTab = ({
 	eventId,
-	setHierarchy,
 }: {
 	eventId: string,
-	setHierarchy: (subTabName: WorkflowTabHierarchy) => void,
 }) => {
 	const { t } = useTranslation();
 	const dispatch = useAppDispatch();
@@ -88,7 +87,7 @@ const EventDetailsWorkflowTab = ({
 
 	const openSubTab = (tabType: WorkflowTabHierarchy, workflowId: string) => {
 		dispatch(fetchWorkflowDetails({eventId, workflowId})).then();
-		setHierarchy(tabType);
+		dispatch(setModalWorkflowTabHierarchy(tabType));
 		dispatch(removeNotificationWizardForm());
 	};
 

--- a/src/components/events/partials/modals/EventDetails.tsx
+++ b/src/components/events/partials/modals/EventDetails.tsx
@@ -25,7 +25,6 @@ import {
 	isFetchingStatistics,
 	getModalWorkflowTabHierarchy,
 	getModalPage,
-	getModalWorkflowId,
 } from "../../../../selectors/eventDetailsSelectors";
 import { getUserInformation } from "../../../../selectors/userInfoSelectors";
 import EventDetailsStatisticsTab from "../ModalTabsAndPages/EventDetailsStatisticsTab";
@@ -74,8 +73,6 @@ const EventDetails = ({
 }) => {
 	const { t } = useTranslation();
 	const dispatch = useAppDispatch();
-
-	const workflowId = useAppSelector(state => getModalWorkflowId(state))!;
 
 	useEffect(() => {
 		dispatch(removeNotificationWizardForm());
@@ -266,13 +263,11 @@ const EventDetails = ({
 						(workflowTabHierarchy === "workflow-details" && (
 							<EventDetailsWorkflowDetails
 								eventId={eventId}
-								workflowId={workflowId}
 							/>
 						)) ||
 						(workflowTabHierarchy === "workflow-operations" && (
 							<EventDetailsWorkflowOperations
 								eventId={eventId}
-								workflowId={workflowId}
 							/>
 						)) ||
 						(workflowTabHierarchy === "workflow-operation-details" && (
@@ -281,7 +276,6 @@ const EventDetails = ({
 						(workflowTabHierarchy === "errors-and-warnings" && (
 							<EventDetailsWorkflowErrors
 								eventId={eventId}
-								workflowId={workflowId}
 							/>
 						)) ||
 						(workflowTabHierarchy === "workflow-error-details" && (

--- a/src/components/events/partials/modals/EventDetails.tsx
+++ b/src/components/events/partials/modals/EventDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import cn from "classnames";
 import { hasAccess } from "../../../../utils/utils";
@@ -23,6 +23,8 @@ import {
 	isFetchingScheduling,
 	hasStatistics as getHasStatistics,
 	isFetchingStatistics,
+	getModalWorkflowTabHierarchy,
+	getModalPage,
 } from "../../../../selectors/eventDetailsSelectors";
 import { getUserInformation } from "../../../../selectors/userInfoSelectors";
 import EventDetailsStatisticsTab from "../ModalTabsAndPages/EventDetailsStatisticsTab";
@@ -36,8 +38,21 @@ import {
 	updateExtendedMetadata,
 	fetchSchedulingInfo,
 	fetchEventStatistics,
+	openModalTab,
 } from "../../../../slices/eventDetailsSlice";
 import { removeNotificationWizardForm } from "../../../../slices/notificationSlice";
+
+export enum EventDetailsPage {
+	Metadata,
+	ExtendedMetadata,
+	Publication,
+	Assets,
+	Scheduling,
+	Workflow,
+	AccessPolicy,
+	Comments,
+	Statistics,
+}
 
 export type WorkflowTabHierarchy = "entry" | "workflow-details" | "workflow-operations" | "workflow-operation-details" | "errors-and-warnings" | "workflow-error-details"
 export type AssetTabHierarchy = "entry" | "add-asset" | "asset-attachments" | "attachment-details" | "asset-catalogs" | "catalog-details" | "asset-media" | "media-details" | "asset-publications" | "publication-details";
@@ -46,13 +61,11 @@ export type AssetTabHierarchy = "entry" | "add-asset" | "asset-attachments" | "a
  * This component manages the pages of the event details
  */
 const EventDetails = ({
-	tabIndex,
 	eventId,
 	close,
 	policyChanged,
 	setPolicyChanged,
 }: {
-	tabIndex: number,
 	eventId: string,
 	close?: () => void,
 	policyChanged: boolean,
@@ -70,10 +83,6 @@ const EventDetails = ({
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
-	const [page, setPage] = useState(tabIndex);
-	const [workflowTabHierarchy, setWorkflowTabHierarchy] = useState<WorkflowTabHierarchy>("entry");
-	const [assetsTabHierarchy, setAssetsTabHierarchy] = useState<AssetTabHierarchy>("entry");
-
 	// TODO: Get rid of the wrappers when modernizing redux is done
 	const updateMetadataWrapper = (id: any, values: any) => {
 		dispatch(updateMetadata({eventId: id, values}));
@@ -82,6 +91,8 @@ const EventDetails = ({
 		dispatch(updateExtendedMetadata({eventId: id, values, catalog}));
 	}
 
+	const page = useAppSelector(state => getModalPage(state));
+	const workflowTabHierarchy = useAppSelector(state => getModalWorkflowTabHierarchy(state));
 	const user = useAppSelector(state => getUserInformation(state));
 	const metadata = useAppSelector(state => getMetadata(state));
 	const extendedMetadata = useAppSelector(state => getExtendedMetadata(state));
@@ -98,11 +109,13 @@ const EventDetails = ({
 			bodyHeaderTranslation: "EVENTS.EVENTS.DETAILS.METADATA.CAPTION",
 			accessRole: "ROLE_UI_EVENTS_DETAILS_METADATA_VIEW",
 			name: "metadata",
+			page: EventDetailsPage.Metadata,
 		},
 		{
 			tabNameTranslation: "EVENTS.EVENTS.DETAILS.TABS.EXTENDED-METADATA",
 			accessRole: "ROLE_UI_EVENTS_DETAILS_METADATA_VIEW",
 			name: "metadata-extended",
+			page: EventDetailsPage.ExtendedMetadata,
 			hidden: !extendedMetadata || !(extendedMetadata.length > 0),
 		},
 		{
@@ -110,18 +123,21 @@ const EventDetails = ({
 			bodyHeaderTranslation: "EVENTS.EVENTS.DETAILS.PUBLICATIONS.CAPTION",
 			accessRole: "ROLE_UI_EVENTS_DETAILS_PUBLICATIONS_VIEW",
 			name: "publications",
+			page: EventDetailsPage.Publication,
 		},
 		{
 			tabNameTranslation: "EVENTS.EVENTS.DETAILS.TABS.ASSETS",
 			bodyHeaderTranslation: "EVENTS.EVENTS.DETAILS.ASSETS.CAPTION",
 			accessRole: "ROLE_UI_EVENTS_DETAILS_ASSETS_VIEW",
 			name: "assets",
+			page: EventDetailsPage.Assets,
 		},
 		{
 			tabNameTranslation: "EVENTS.EVENTS.DETAILS.TABS.SCHEDULING",
 			bodyHeaderTranslation: "EVENTS.EVENTS.DETAILS.SCHEDULING.CAPTION",
 			accessRole: "ROLE_UI_EVENTS_DETAILS_SCHEDULING_VIEW",
 			name: "scheduling",
+			page: EventDetailsPage.Scheduling,
 			hidden:
 				!hasSchedulingProperties || !hasAnyDeviceAccess(user, captureAgents),
 		},
@@ -129,88 +145,90 @@ const EventDetails = ({
 			tabNameTranslation: "EVENTS.EVENTS.DETAILS.TABS.WORKFLOWS",
 			accessRole: "ROLE_UI_EVENTS_DETAILS_WORKFLOWS_VIEW",
 			name: "workflows",
+			page: EventDetailsPage.Workflow,
 		},
 		{
 			tabNameTranslation: "EVENTS.EVENTS.DETAILS.TABS.ACCESS",
 			bodyHeaderTranslation: "EVENTS.EVENTS.DETAILS.TABS.ACCESS",
 			accessRole: "ROLE_UI_EVENTS_DETAILS_ACL_VIEW",
 			name: "access",
+			page: EventDetailsPage.AccessPolicy,
 		},
 		{
 			tabNameTranslation: "EVENTS.EVENTS.DETAILS.TABS.COMMENTS",
 			bodyHeaderTranslation: "EVENTS.EVENTS.DETAILS.COMMENTS.CAPTION",
 			accessRole: "ROLE_UI_EVENTS_DETAILS_COMMENTS_VIEW",
 			name: "comments",
+			page: EventDetailsPage.Comments,
 		},
 		{
 			tabNameTranslation: "EVENTS.EVENTS.DETAILS.TABS.STATISTICS",
 			bodyHeaderTranslation: "EVENTS.EVENTS.DETAILS.STATISTICS.CAPTION",
 			accessRole: "ROLE_UI_EVENTS_DETAILS_STATISTICS_VIEW",
 			name: "statistics",
+			page: EventDetailsPage.Statistics,
 			hidden: !hasStatistics,
 		},
 	];
 
-	const openTab = (tabNr: number) => {
+	const openTab = (tabNr: EventDetailsPage) => {
 		dispatch(removeNotificationWizardForm());
-		setWorkflowTabHierarchy("entry");
-		setAssetsTabHierarchy("entry");
-		setPage(tabNr);
+		dispatch(openModalTab(tabNr, "entry", "entry"))
 	};
 
 	return (
 		<>
 			<nav className="modal-nav" id="modal-nav">
 				{hasAccess(tabs[0].accessRole, user) && (
-					<button className={"button-like-anchor " + cn({ active: page === 0 })} onClick={() => openTab(0)}>
+					<button className={"button-like-anchor " + cn({ active: page === tabs[0].page })} onClick={() => openTab(tabs[0].page)}>
 						{t(tabs[0].tabNameTranslation)}
 					</button>
 				)}
 				{!tabs[1].hidden && hasAccess(tabs[1].accessRole, user) && (
-					<button className={"button-like-anchor " + cn({ active: page === 1 })} onClick={() => openTab(1)}>
+					<button className={"button-like-anchor " + cn({ active: page === tabs[1].page })} onClick={() => openTab(tabs[1].page)}>
 						{t(tabs[1].tabNameTranslation)}
 					</button>
 				)}
 				{hasAccess(tabs[2].accessRole, user) && (
-					<button className={"button-like-anchor " + cn({ active: page === 2 })} onClick={() => openTab(2)}>
+					<button className={"button-like-anchor " + cn({ active: page === tabs[2].page })} onClick={() => openTab(tabs[2].page)}>
 						{t(tabs[2].tabNameTranslation)}
 					</button>
 				)}
 				{hasAccess(tabs[3].accessRole, user) && (
-					<button className={"button-like-anchor " + cn({ active: page === 3 })} onClick={() => openTab(3)}>
+					<button className={"button-like-anchor " + cn({ active: page === tabs[3].page })} onClick={() => openTab(tabs[3].page)}>
 						{t(tabs[3].tabNameTranslation)}
 					</button>
 				)}
 				{!tabs[4].hidden && hasAccess(tabs[4].accessRole, user) && (
-					<button className={"button-like-anchor " + cn({ active: page === 4 })} onClick={() => openTab(4)}>
+					<button className={"button-like-anchor " + cn({ active: page === tabs[4].page })} onClick={() => openTab(tabs[4].page)}>
 						{t(tabs[4].tabNameTranslation)}
 					</button>
 				)}
 				{hasAccess(tabs[5].accessRole, user) && (
-					<button className={"button-like-anchor " + cn({ active: page === 5 })} onClick={() => openTab(5)}>
+					<button className={"button-like-anchor " + cn({ active: page === tabs[5].page })} onClick={() => openTab(tabs[5].page)}>
 						{t(tabs[5].tabNameTranslation)}
 					</button>
 				)}
 				{hasAccess(tabs[6].accessRole, user) && (
-					<button className={"button-like-anchor " + cn({ active: page === 6 })} onClick={() => openTab(6)}>
+					<button className={"button-like-anchor " + cn({ active: page === tabs[6].page })} onClick={() => openTab(tabs[6].page)}>
 						{t(tabs[6].tabNameTranslation)}
 					</button>
 				)}
 				{hasAccess(tabs[7].accessRole, user) && (
-					<button className={"button-like-anchor " + cn({ active: page === 7 })} onClick={() => openTab(7)}>
+					<button className={"button-like-anchor " + cn({ active: page === tabs[7].page })} onClick={() => openTab(tabs[7].page)}>
 						{t(tabs[7].tabNameTranslation)}
 					</button>
 				)}
 
 				{!tabs[8].hidden && hasAccess(tabs[8].accessRole, user) && (
-					<button className={"button-like-anchor " + cn({ active: page === 8 })} onClick={() => openTab(8)}>
+					<button className={"button-like-anchor " + cn({ active: page === tabs[8].page })} onClick={() => openTab(tabs[8].page)}>
 						{t(tabs[8].tabNameTranslation)}
 					</button>
 				)}
 			</nav>
 			{/* Initialize overall modal */}
 			<div>
-				{page === 0 && !isLoadingMetadata && (
+				{page === EventDetailsPage.Metadata && !isLoadingMetadata && (
 					<DetailsMetadataTab
 						metadataFields={metadata}
 						resourceId={eventId}
@@ -219,7 +237,7 @@ const EventDetails = ({
 						editAccessRole="ROLE_UI_EVENTS_DETAILS_METADATA_EDIT"
 					/>
 				)}
-				{page === 1 && !isLoadingMetadata && (
+				{page === EventDetailsPage.ExtendedMetadata && !isLoadingMetadata && (
 					<DetailsExtendedMetadataTab
 						resourceId={eventId}
 						metadata={extendedMetadata}
@@ -228,52 +246,42 @@ const EventDetails = ({
 					/>
 				)}
 				{page === 2 && <EventDetailsPublicationTab eventId={eventId} />}
-				{page === 3 && (
+				{page === EventDetailsPage.Assets && (
 					<EventDetailsAssetsTab
 						eventId={eventId}
-						assetsTabHierarchy={assetsTabHierarchy}
-						setAssetsTabHierarchy={setAssetsTabHierarchy}
 					/>
 				)}
 				{page === 4 && !isLoadingScheduling && (
 					<EventDetailsSchedulingTab eventId={eventId} />
 				)}
-				{page === 5 &&
+				{page === EventDetailsPage.Workflow &&
 					((workflowTabHierarchy === "entry" && (
 						<EventDetailsWorkflowTab
 							eventId={eventId}
-							setHierarchy={setWorkflowTabHierarchy}
 						/>
 					)) ||
 						(workflowTabHierarchy === "workflow-details" && (
 							<EventDetailsWorkflowDetails
 								eventId={eventId}
-								setHierarchy={setWorkflowTabHierarchy}
 							/>
 						)) ||
 						(workflowTabHierarchy === "workflow-operations" && (
 							<EventDetailsWorkflowOperations
 								eventId={eventId}
-								setHierarchy={setWorkflowTabHierarchy}
 							/>
 						)) ||
 						(workflowTabHierarchy === "workflow-operation-details" && (
-							<EventDetailsWorkflowOperationDetails
-								setHierarchy={setWorkflowTabHierarchy}
-							/>
+							<EventDetailsWorkflowOperationDetails />
 						)) ||
 						(workflowTabHierarchy === "errors-and-warnings" && (
 							<EventDetailsWorkflowErrors
 								eventId={eventId}
-								setHierarchy={setWorkflowTabHierarchy}
 							/>
 						)) ||
 						(workflowTabHierarchy === "workflow-error-details" && (
-							<EventDetailsWorkflowErrorDetails
-								setHierarchy={setWorkflowTabHierarchy}
-							/>
+							<EventDetailsWorkflowErrorDetails />
 						)))}
-				{page === 6 && (
+				{page === EventDetailsPage.AccessPolicy && (
 					<EventDetailsAccessPolicyTab
 						eventId={eventId}
 						header={tabs[page].bodyHeaderTranslation ?? ""}
@@ -281,13 +289,13 @@ const EventDetails = ({
 						setPolicyChanged={setPolicyChanged}
 					/>
 				)}
-				{page === 7 && (
+				{page === EventDetailsPage.Comments && (
 					<EventDetailsCommentsTab
 						eventId={eventId}
 						header={tabs[page].bodyHeaderTranslation ?? ""}
 					/>
 				)}
-				{page === 8 && !isLoadingStatistics && (
+				{page === EventDetailsPage.Statistics && !isLoadingStatistics && (
 					<EventDetailsStatisticsTab
 						eventId={eventId}
 						header={tabs[page].bodyHeaderTranslation ?? ""}

--- a/src/components/events/partials/modals/EventDetails.tsx
+++ b/src/components/events/partials/modals/EventDetails.tsx
@@ -25,6 +25,7 @@ import {
 	isFetchingStatistics,
 	getModalWorkflowTabHierarchy,
 	getModalPage,
+	getModalWorkflowId,
 } from "../../../../selectors/eventDetailsSelectors";
 import { getUserInformation } from "../../../../selectors/userInfoSelectors";
 import EventDetailsStatisticsTab from "../ModalTabsAndPages/EventDetailsStatisticsTab";
@@ -73,6 +74,8 @@ const EventDetails = ({
 }) => {
 	const { t } = useTranslation();
 	const dispatch = useAppDispatch();
+
+	const workflowId = useAppSelector(state => getModalWorkflowId(state))!;
 
 	useEffect(() => {
 		dispatch(removeNotificationWizardForm());
@@ -263,11 +266,13 @@ const EventDetails = ({
 						(workflowTabHierarchy === "workflow-details" && (
 							<EventDetailsWorkflowDetails
 								eventId={eventId}
+								workflowId={workflowId}
 							/>
 						)) ||
 						(workflowTabHierarchy === "workflow-operations" && (
 							<EventDetailsWorkflowOperations
 								eventId={eventId}
+								workflowId={workflowId}
 							/>
 						)) ||
 						(workflowTabHierarchy === "workflow-operation-details" && (
@@ -276,6 +281,7 @@ const EventDetails = ({
 						(workflowTabHierarchy === "errors-and-warnings" && (
 							<EventDetailsWorkflowErrors
 								eventId={eventId}
+								workflowId={workflowId}
 							/>
 						)) ||
 						(workflowTabHierarchy === "workflow-error-details" && (

--- a/src/components/events/partials/modals/EventDetailsModal.tsx
+++ b/src/components/events/partials/modals/EventDetailsModal.tsx
@@ -1,40 +1,39 @@
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import EventDetails from "./EventDetails";
-import { useAppDispatch } from "../../../../store";
+import { useAppDispatch, useAppSelector } from "../../../../store";
 import { removeNotificationWizardForm } from "../../../../slices/notificationSlice";
 import { useHotkeys } from "react-hotkeys-hook";
 import { availableHotkeys } from "../../../../configs/hotkeysConfig";
+import { getModalEvent } from "../../../../selectors/eventDetailsSelectors";
+import { setModalEvent, setShowModal } from "../../../../slices/eventDetailsSlice";
 
 /**
  * This component renders the modal for displaying event details
  */
-const EventDetailsModal = ({
-	handleClose,
-	tabIndex,
-	eventTitle,
-	eventId,
-}: {
-	handleClose: () => void,
-	tabIndex: number,
-	eventTitle: string,
-	eventId: string,
-}) => {
+const EventDetailsModal = () => {
 	const { t } = useTranslation();
 	const dispatch = useAppDispatch();
 
 	// tracks, whether the policies are different to the initial value
 	const [policyChanged, setPolicyChanged] = useState(false);
 
+	const event = useAppSelector(state => getModalEvent(state))!;
+
 	const confirmUnsaved = () => {
 		return window.confirm(t("CONFIRMATIONS.WARNINGS.UNSAVED_CHANGES"));
+	};
+
+	const hideModal = () => {
+		dispatch(setModalEvent(null));
+		dispatch(setShowModal(false));
 	};
 
 	const close = () => {
 		if (!policyChanged || confirmUnsaved()) {
 			setPolicyChanged(false);
 			dispatch(removeNotificationWizardForm());
-			handleClose();
+			hideModal();
 		}
 	};
 
@@ -51,7 +50,7 @@ const EventDetailsModal = ({
 			<div className="modal-animation modal-overlay" />
 			<section
 				id="event-details-modal"
-				tabIndex={tabIndex}
+				tabIndex={0}
 				className="modal wizard modal-animation"
 			>
 				<header>
@@ -59,15 +58,14 @@ const EventDetailsModal = ({
 					<h2>
 						{
 							t("EVENTS.EVENTS.DETAILS.HEADER", {
-								resourceId: eventTitle,
+								resourceId: event.title,
 							}) /*Event details - {resourceTitle}*/
 						}
 					</h2>
 				</header>
 
 				<EventDetails
-					tabIndex={tabIndex}
-					eventId={eventId}
+					eventId={event.id}
 					policyChanged={policyChanged}
 					setPolicyChanged={(value) => setPolicyChanged(value)}
 				/>

--- a/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
@@ -612,7 +612,7 @@
 					"ASSETS": "Open asset details",
 					"START": "Filter for this start date",
 					"SERIES": "Filter for this series",
-					"STATUS": "Filter for this event status",
+					"STATUS": "Open event status",
 					"LOCATION": "Filter for this location",
 					"DETAILS": "Open event details",
 					"DELETE": "Delete event",

--- a/src/selectors/eventDetailsSelectors.ts
+++ b/src/selectors/eventDetailsSelectors.ts
@@ -1,5 +1,14 @@
 import { RootState } from "../store";
 
+/* selectors for modal */
+export const showModal = (state: RootState) => state.eventDetails.modal.show;
+export const getModalPage = (state: RootState) => state.eventDetails.modal.page;
+export const getModalEvent = (state: RootState) => state.eventDetails.modal.event;
+export const getModalWorkflowTabHierarchy = (state: RootState) =>
+	state.eventDetails.modal.workflowTabHierarchy;
+export const getModalAssetsTabHierarchy = (state: RootState) =>
+	state.eventDetails.modal.assetsTabHierarchy;
+
 /* selectors for metadata */
 export const getMetadata = (state: RootState) => state.eventDetails.metadata;
 export const getExtendedMetadata = (state: RootState) => state.eventDetails.extendedMetadata;

--- a/src/selectors/eventDetailsSelectors.ts
+++ b/src/selectors/eventDetailsSelectors.ts
@@ -4,6 +4,7 @@ import { RootState } from "../store";
 export const showModal = (state: RootState) => state.eventDetails.modal.show;
 export const getModalPage = (state: RootState) => state.eventDetails.modal.page;
 export const getModalEvent = (state: RootState) => state.eventDetails.modal.event;
+export const getModalWorkflowId = (state: RootState) => state.eventDetails.modal.workflowId;
 export const getModalWorkflowTabHierarchy = (state: RootState) =>
 	state.eventDetails.modal.workflowTabHierarchy;
 export const getModalAssetsTabHierarchy = (state: RootState) =>

--- a/src/slices/eventDetailsSlice.ts
+++ b/src/slices/eventDetailsSlice.ts
@@ -8,7 +8,7 @@ import {
 	transformMetadataForUpdate,
 } from "../utils/resourceUtils";
 import { NOTIFICATION_CONTEXT } from "../configs/modalConfig";
-import { fetchWorkflowDef } from "./workflowSlice";
+import { fetchWorkflowDef, Workflow as WorkflowDefinitions } from "./workflowSlice";
 import {
 	getMetadata,
 	getExtendedMetadata,
@@ -25,10 +25,25 @@ import {
 import { calculateDuration } from "../utils/dateUtils";
 import { fetchRecordings } from "./recordingSlice";
 import { getRecordings } from "../selectors/recordingSelectors";
-import { Workflow as WorkflowDefinitions} from "./workflowSlice";
 import { createAppAsyncThunk } from '../createAsyncThunkWithTypes';
 import { Statistics, fetchStatistics, fetchStatisticsValueUpdate } from './statisticsSlice';
 import { Ace, TransformedAcl, TransformedAcls } from './aclDetailsSlice';
+import { Event } from "./eventSlice";
+import {
+	AssetTabHierarchy,
+	EventDetailsPage,
+	WorkflowTabHierarchy
+} from "../components/events/partials/modals/EventDetails";
+import { AppDispatch } from "../store";
+
+// Contains the navigation logic for the modal
+type EventDetailsModal = {
+	show: boolean,
+	page: EventDetailsPage,
+	event: Event | null,
+	workflowTabHierarchy: WorkflowTabHierarchy,
+	assetsTabHierarchy: AssetTabHierarchy,
+}
 
 type MetadataField = {
 	collection?: { [key: string]: unknown }[],	// different for e.g. languages and presenters
@@ -169,6 +184,7 @@ type EventDetailsState = {
 	statusStatisticsValue: 'uninitialized' | 'loading' | 'succeeded' | 'failed',
 	errorStatisticsValue: SerializedError | null,
 	eventId: string,
+	modal: EventDetailsModal,
 	metadata: MetadataCatalog,
 	extendedMetadata: MetadataCatalog[],
 	assets: {
@@ -408,6 +424,13 @@ const initialState: EventDetailsState = {
 	statusStatisticsValue: 'uninitialized',
 	errorStatisticsValue: null,
 	eventId: "",
+	modal: {
+		show: false,
+		page: EventDetailsPage.Metadata,
+		event: null,
+		workflowTabHierarchy: 'entry',
+		assetsTabHierarchy: 'entry',
+	},
 	metadata: {
 		title: "",
 		flavor: "",
@@ -1393,6 +1416,35 @@ export const fetchWorkflowOperations = createAppAsyncThunk('eventDetails/fetchWo
 	return { entries: workflowOperationsData };
 });
 
+/**
+ * Open event details modal externally
+ *
+ * @param page modal page
+ * @param event event to show
+ * @param workflowTab workflow tab
+ * @param assetsTab assets tab
+ */
+export const openModal = (
+	page: EventDetailsPage,
+	event: Event,
+	workflowTab: WorkflowTabHierarchy = 'entry',
+	assetsTab: AssetTabHierarchy = 'entry',
+) => (dispatch: AppDispatch) => {
+	dispatch(setModalEvent(event));
+	dispatch(openModalTab(page, workflowTab, assetsTab))
+	dispatch(setShowModal(true));
+};
+
+export const openModalTab = (
+	page: EventDetailsPage,
+	workflowTab: WorkflowTabHierarchy,
+	assetsTab: AssetTabHierarchy
+) => (dispatch: AppDispatch) => {
+	dispatch(setModalPage(page));
+	dispatch(setModalWorkflowTabHierarchy(workflowTab));
+	dispatch(setModalAssetsTabHierarchy(assetsTab));
+};
+
 export const fetchWorkflowOperationDetails = createAppAsyncThunk('eventDetails/fetchWorkflowOperationDetails', async (params: {
 	eventId: string,
 	workflowId: string,
@@ -1769,6 +1821,31 @@ const eventDetailsSlice = createSlice({
 	name: 'eventDetails',
 	initialState,
 	reducers: {
+		setShowModal(state, action: PayloadAction<
+			EventDetailsState["modal"]["show"]
+		>) {
+			state.modal.show = action.payload;
+		},
+		setModalPage(state, action: PayloadAction<
+			EventDetailsState["modal"]["page"]
+		>) {
+			state.modal.page = action.payload;
+		},
+		setModalEvent(state, action: PayloadAction<
+			EventDetailsState["modal"]["event"]
+		>) {
+			state.modal.event = action.payload;
+		},
+		setModalWorkflowTabHierarchy(state, action: PayloadAction<
+			EventDetailsState["modal"]["workflowTabHierarchy"]
+		>) {
+			state.modal.workflowTabHierarchy = action.payload;
+		},
+		setModalAssetsTabHierarchy(state, action: PayloadAction<
+			EventDetailsState["modal"]["assetsTabHierarchy"]
+		>) {
+			state.modal.assetsTabHierarchy = action.payload;
+		},
 		setEventMetadata(state, action: PayloadAction<
 			EventDetailsState["metadata"]
 		>) {
@@ -2416,6 +2493,11 @@ const eventDetailsSlice = createSlice({
 });
 
 export const {
+	setShowModal,
+	setModalPage,
+	setModalEvent,
+	setModalWorkflowTabHierarchy,
+	setModalAssetsTabHierarchy,
 	setEventMetadata,
 	setExtendedEventMetadata,
 	setEventWorkflow,

--- a/src/slices/eventDetailsSlice.ts
+++ b/src/slices/eventDetailsSlice.ts
@@ -43,6 +43,7 @@ type EventDetailsModal = {
 	event: Event | null,
 	workflowTabHierarchy: WorkflowTabHierarchy,
 	assetsTabHierarchy: AssetTabHierarchy,
+	workflowId: string,
 }
 
 type MetadataField = {
@@ -430,6 +431,7 @@ const initialState: EventDetailsState = {
 		event: null,
 		workflowTabHierarchy: 'entry',
 		assetsTabHierarchy: 'entry',
+		workflowId: "",
 	},
 	metadata: {
 		title: "",
@@ -1423,14 +1425,17 @@ export const fetchWorkflowOperations = createAppAsyncThunk('eventDetails/fetchWo
  * @param event event to show
  * @param workflowTab workflow tab
  * @param assetsTab assets tab
+ * @param workflowId workflow id required for workflow sub tabs
  */
 export const openModal = (
 	page: EventDetailsPage,
 	event: Event,
 	workflowTab: WorkflowTabHierarchy = 'entry',
 	assetsTab: AssetTabHierarchy = 'entry',
+	workflowId: string = '',
 ) => (dispatch: AppDispatch) => {
 	dispatch(setModalEvent(event));
+	dispatch(setModalWorkflowId(workflowId));
 	dispatch(openModalTab(page, workflowTab, assetsTab))
 	dispatch(setShowModal(true));
 };
@@ -1835,6 +1840,11 @@ const eventDetailsSlice = createSlice({
 			EventDetailsState["modal"]["event"]
 		>) {
 			state.modal.event = action.payload;
+		},
+		setModalWorkflowId(state, action: PayloadAction<
+			EventDetailsState["modal"]["workflowId"]
+		>) {
+			state.modal.workflowId = action.payload;
 		},
 		setModalWorkflowTabHierarchy(state, action: PayloadAction<
 			EventDetailsState["modal"]["workflowTabHierarchy"]
@@ -2496,6 +2506,7 @@ export const {
 	setShowModal,
 	setModalPage,
 	setModalEvent,
+	setModalWorkflowId,
 	setModalWorkflowTabHierarchy,
 	setModalAssetsTabHierarchy,
 	setEventMetadata,

--- a/src/utils/eventDetailsUtils.ts
+++ b/src/utils/eventDetailsUtils.ts
@@ -1,4 +1,5 @@
 import moment from "moment";
+import { Event } from "../slices/eventSlice";
 
 /**
  * This file contains functions and constants that are needed in the event details modal
@@ -61,4 +62,9 @@ export const humanReadableBytesFilter = (bytesValue: string | number) => {
 	} while (Math.abs(bytes) >= thresh && u < units.length - 1);
 
 	return bytes.toFixed(1) + " " + units[u];
+};
+
+export const hasScheduledStatus = (event: Event) => {
+	return event.event_status.toUpperCase().indexOf("SCHEDULED") > -1 ||
+		event.event_status.toUpperCase().indexOf("RECORDING") > -1
 };


### PR DESCRIPTION
Open the workflow operations of the last workflow.

Changes:
- Move navigation logic of event details modal to the redux store to allow modals to be opened from different locations.
- When clicking on status in the events table, open the operations of the last workflow. If no workflow exists in the event, show the workflow overview.

Close #391