### PR TITLE
Set lower maximum z-index than tooltip index

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -160,7 +160,7 @@ const Header = ({
 				<nav className="header-nav nav-dd-container" id="nav-dd-container">
 					{/* Select language */}
 					<div className="nav-dd lang-dd" id="lang-dd" ref={containerLang}>
-						<Tooltip title={t("LANGUAGE")}>
+						<Tooltip active={!displayMenuLang} title={t("LANGUAGE")}>
 							<button className="lang" onClick={() => setMenuLang(!displayMenuLang)}>
 								<IconContext.Provider value={{ style: {fontSize: "20px"} }}>
 									<HiTranslate />
@@ -208,7 +208,7 @@ const Header = ({
 							id="info-dd"
 							ref={containerNotify}
 						>
-							<Tooltip title={t("SYSTEM_NOTIFICATIONS")}>
+							<Tooltip active={!displayMenuNotify} title={t("SYSTEM_NOTIFICATIONS")}>
 								<button onClick={() => setMenuNotify(!displayMenuNotify)}>
 									<i className="fa fa-bell" aria-hidden="true" />
 									{errorCounter !== 0 && (
@@ -216,15 +216,15 @@ const Header = ({
 											{errorCounter}
 										</span>
 									)}
-									{/* Click on the bell icon, a dropdown menu with all services in serviceList and their status opens */}
-									{displayMenuNotify && (
-										<MenuNotify
-											healthStatus={healthStatus}
-											redirectToServices={redirectToServices}
-										/>
-									)}
 								</button>
 							</Tooltip>
+							{/* Click on the bell icon, a dropdown menu with all services in serviceList and their status opens */}
+							{displayMenuNotify && (
+								<MenuNotify
+									healthStatus={healthStatus}
+									redirectToServices={redirectToServices}
+								/>
+							)}
 						</div>
 					)}
 
@@ -244,7 +244,7 @@ const Header = ({
 								id="help-dd"
 								ref={containerHelp}
 							>
-								<Tooltip title={t("HELP.HELP")}>
+								<Tooltip active={!displayMenuHelp} title={t("HELP.HELP")}>
 									<button
 										onClick={() => setMenuHelp(!displayMenuHelp)}
 									>

--- a/src/components/shared/Tooltip.tsx
+++ b/src/components/shared/Tooltip.tsx
@@ -1,7 +1,11 @@
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import MuiTooltip, { TooltipProps } from "@mui/material/Tooltip";
 
-export const Tooltip = ({ className, placement="top", ...props }: TooltipProps) => {
+export const Tooltip = (
+	{ active=true, className, placement="top", ...props }: TooltipProps & { active?: boolean },
+) => {
+	const [open, setOpen] = useState(false);
+
 	const positionRef = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
 	const areaRef = useRef<HTMLDivElement>(null);
 
@@ -43,6 +47,9 @@ export const Tooltip = ({ className, placement="top", ...props }: TooltipProps) 
 	return (
 		<MuiTooltip
 			{...props}
+			open={open && active}
+			onOpen={() => setOpen(true)}
+			onClose={() => setOpen(false)}
 			classes={{ popper: className }}
 			arrow
 			describeChild

--- a/src/styles/base/_variables.scss
+++ b/src/styles/base/_variables.scss
@@ -170,7 +170,7 @@ $z-70:                          700;
 $z-80:                          800;
 $z-90:                          900;
 $z-100:                         1000;
-$max-z:                         2147483647 - 100;
+$max-z:                         1400;  // Prevent tooltip overlap as tooltip has index of 1500
 
 // Global Values
 $modal-container-padding:       20px;


### PR DESCRIPTION
Fixes the tooltip from being overlapped by the stored filter menu. The z-indices of the mui components are documented at https://mui.com/material-ui/customization/z-index/.

Close #810