### PR TITLE
Fix recursion in effect when fetching series acls

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/NewAccessPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewAccessPage.tsx
@@ -68,8 +68,7 @@ const NewAccessPage = ({
 		if (initEventAclWithSeriesAcl && formik.values.isPartOf) {
 			dispatch(fetchSeriesDetailsAcls(formik.values.isPartOf));
 		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [formik.values.isPartOf, initEventAclWithSeriesAcl]);
+	}, [formik.values.isPartOf, initEventAclWithSeriesAcl, dispatch]);
 
 	// If we have to use series ACL, overwrite existing rules
 	useEffect(() => {

--- a/src/components/events/partials/ModalTabsAndPages/NewAccessPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewAccessPage.tsx
@@ -66,10 +66,10 @@ const NewAccessPage = ({
 	// If we have to use series ACL, fetch it
 	useEffect(() => {
 		if (initEventAclWithSeriesAcl && formik.values.isPartOf) {
-			dispatch(fetchSeriesDetailsAcls(formik.values.isPartOf))
+			dispatch(fetchSeriesDetailsAcls(formik.values.isPartOf));
 		}
-	// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [formik.values, initEventAclWithSeriesAcl]);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [formik.values.isPartOf, initEventAclWithSeriesAcl]);
 
 	// If we have to use series ACL, overwrite existing rules
 	useEffect(() => {


### PR DESCRIPTION
Fixes the mentionied bug in #829.

Due to the React.stric mode, the ACLs are loaded twice and the notification is displayed twice, see https://react.dev/reference/react/StrictMode:

![image](https://github.com/user-attachments/assets/abc19fa1-4edb-4e79-8bcc-a07b02ab6876)

This problem could not be solved by simply putting `dispatch(removeNotificationWizardForm());` at the beginning of the effect because the fetch is asynchronous. Is this a problem and should we fix it?

Close #829
