### PR TITLE
Improve highlighting of active step

### DIFF
--- a/src/styles/components/_steps.scss
+++ b/src/styles/components/_steps.scss
@@ -26,6 +26,16 @@
         color: $color-gray !important;
     }
 
+    .MuiStepLabel-labelContainer .Mui-active {
+        border-bottom: 1px solid $primary-color-blue;
+        font-weight: 800;
+    }
+
+    .Mui-active svg {
+        color: $primary-color-blue !important;
+        transform: none !important;
+    }
+
     .MuiStepLabel-labelContainer span {
         color: $color-darkgray;
         margin: 3px 10px;


### PR DESCRIPTION
This patch causes active steps in wizards to be better highlighted.

I always found the slight size difference while using the same colors, font, … a bit less than I would want from an indicator.


https://github.com/user-attachments/assets/753a4580-36d5-4f44-b8b0-d7093329d442

*Old and new style in action*