### PR TITLE
Simplify minimum of 0

### DIFF
--- a/src/components/shared/wizard/WizardStepperEvent.tsx
+++ b/src/components/shared/wizard/WizardStepperEvent.tsx
@@ -38,7 +38,7 @@ const WizardStepperEvent = ({
 				await setPage(key);
 			}
 
-			let previousPageIndex = key - 1 > 0 ? key - 1 : 0;
+			let previousPageIndex = Math.max(0, key - 1);
 			while (previousPageIndex >= 0) {
 				if (steps[previousPageIndex].hidden) {
 					previousPageIndex = previousPageIndex - 1;


### PR DESCRIPTION
It took me a second to understand that the check for `key - 1 > 0` is meant to ensure a minimum value of `0`. A second is too long. There are easier ways. Like `Math.max(…)`.