### PR TITLE
Display active workflow warning

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/DetailsExtendedMetadataTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/DetailsExtendedMetadataTab.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { Formik } from "formik";
 import { Field } from "../../../shared/Field";
@@ -14,8 +14,10 @@ import {
 	parseValueForBooleanStrings,
 } from "../../../../utils/utils";
 import { getMetadataCollectionFieldName } from "../../../../utils/resourceUtils";
-import { useAppSelector } from "../../../../store";
-import { MetadataCatalog } from "../../../../slices/eventDetailsSlice";
+import { useAppDispatch, useAppSelector } from "../../../../store";
+import { MetadataCatalog, fetchHasActiveTransactions } from "../../../../slices/eventDetailsSlice";
+import { addNotification, removeNotificationWizardForm } from "../../../../slices/notificationSlice";
+import { NOTIFICATION_CONTEXT } from "../../../../configs/modalConfig";
 
 /**
  * This component renders metadata details of a certain event or series
@@ -32,8 +34,27 @@ const DetailsExtendedMetadataTab = ({
 	updateResource: (id: string, values: { [key: string]: any }, catalog: MetadataCatalog) => void,
 }) => {
 	const { t } = useTranslation();
+	const dispatch = useAppDispatch();
 
 	const user = useAppSelector(state => getUserInformation(state));
+
+	useEffect(() => {
+		dispatch(removeNotificationWizardForm());
+		dispatch(fetchHasActiveTransactions(resourceId)).then((fetchTransactionResult) => {
+			if (
+				fetchTransactionResult.payload.active === undefined ||
+				fetchTransactionResult.payload.active
+			) {
+				dispatch(addNotification({
+					type: "warning",
+					key: "ACTIVE_TRANSACTION",
+					duration: -1,
+					parameter: null,
+					context: NOTIFICATION_CONTEXT
+				}));
+			}
+		});
+	}, []);
 
 	const handleSubmit = (values: { [key: string]: any }, catalog: MetadataCatalog) => {
 		updateResource(resourceId, values, catalog);

--- a/src/components/events/partials/ModalTabsAndPages/DetailsMetadataTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/DetailsMetadataTab.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { Formik } from "formik";
 import { Field } from "../../../shared/Field";
@@ -11,8 +11,10 @@ import RenderField from "../../../shared/wizard/RenderField";
 import { getUserInformation } from "../../../../selectors/userInfoSelectors";
 import { hasAccess, isJson } from "../../../../utils/utils";
 import { getMetadataCollectionFieldName } from "../../../../utils/resourceUtils";
-import { useAppSelector } from "../../../../store";
-import { MetadataCatalog } from "../../../../slices/eventDetailsSlice";
+import { useAppDispatch, useAppSelector } from "../../../../store";
+import { MetadataCatalog, fetchHasActiveTransactions } from "../../../../slices/eventDetailsSlice";
+import { addNotification, removeNotificationWizardForm } from "../../../../slices/notificationSlice";
+import { NOTIFICATION_CONTEXT } from "../../../../configs/modalConfig";
 
 /**
  * This component renders metadata details of a certain event or series
@@ -31,8 +33,27 @@ const DetailsMetadataTab = ({
 	editAccessRole: string,
 }) => {
 	const { t } = useTranslation();
+	const dispatch = useAppDispatch();
 
 	const user = useAppSelector(state => getUserInformation(state));
+
+	useEffect(() => {
+		dispatch(removeNotificationWizardForm());
+		dispatch(fetchHasActiveTransactions(resourceId)).then((fetchTransactionResult) => {
+			if (
+				fetchTransactionResult.payload.active === undefined ||
+				fetchTransactionResult.payload.active
+			) {
+				dispatch(addNotification({
+					type: "warning",
+					key: "ACTIVE_TRANSACTION",
+					duration: -1,
+					parameter: null,
+					context: NOTIFICATION_CONTEXT
+				}));
+			}
+		});
+	}, []);
 
 	const handleSubmit = (values: { [key: string]: any }) => {
 		updateResource(resourceId, values);
@@ -68,18 +89,18 @@ const DetailsMetadataTab = ({
 	};
 
 	return (
-		// initialize form
-		<Formik
-			enableReinitialize
-			initialValues={getInitialValues()}
-			onSubmit={(values) => handleSubmit(values)}
-		>
-			{(formik) => (
-				<>
-					<div className="modal-content">
-						<div className="modal-body">
-							<Notifications context="not-corner" />
-							<div className="full-col">
+		<div className="modal-content">
+			<div className="modal-body">
+			<Notifications context="not-corner" />
+				<div className="full-col">
+					{/* initialize form */}
+					<Formik
+						enableReinitialize
+						initialValues={getInitialValues()}
+						onSubmit={(values) => handleSubmit(values)}
+					>
+						{(formik) => (
+							<>
 								<div className="obj tbl-list">
 									<header className="no-expand">{t(header)}</header>
 									<div className="obj-container">
@@ -183,12 +204,12 @@ const DetailsMetadataTab = ({
 										</>
 									)}
 								</div>
-							</div>
-						</div>
-					</div>
-				</>
-			)}
-		</Formik>
+							</>
+						)}
+					</Formik>
+				</div>
+			</div>
+		</div>
 	);
 };
 

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsPublicationTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsPublicationTab.tsx
@@ -3,7 +3,9 @@ import { useTranslation } from "react-i18next";
 import Notifications from "../../../shared/Notifications";
 import { getPublications } from "../../../../selectors/eventDetailsSelectors";
 import { useAppDispatch, useAppSelector } from "../../../../store";
-import { fetchEventPublications } from "../../../../slices/eventDetailsSlice";
+import { fetchEventPublications, fetchHasActiveTransactions } from "../../../../slices/eventDetailsSlice";
+import { addNotification, removeNotificationWizardForm } from "../../../../slices/notificationSlice";
+import { NOTIFICATION_CONTEXT } from "../../../../configs/modalConfig";
 
 const EventDetailsPublicationTab = ({
 	eventId,
@@ -22,7 +24,24 @@ const EventDetailsPublicationTab = ({
 	};
 
 	useEffect(() => {
+		dispatch(removeNotificationWizardForm());
 		dispatch(fetchEventPublications(eventId)).then((r) => console.info(r));
+
+		dispatch(fetchHasActiveTransactions(eventId)).then((fetchTransactionResult) => {
+			if (
+				fetchTransactionResult.payload.active === undefined ||
+				fetchTransactionResult.payload.active
+			) {
+				dispatch(addNotification({
+					type: "warning",
+					key: "ACTIVE_TRANSACTION",
+					duration: -1,
+					parameter: null,
+					context: NOTIFICATION_CONTEXT
+				}));
+			}
+		});
+
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
@@ -30,7 +49,7 @@ const EventDetailsPublicationTab = ({
 		<>
 			<div className="modal-content">
 				<div className="modal-body">
-					<Notifications />
+					<Notifications context="not_corner" />
 					<div className="full-col">
 						<div className="obj list-obj">
 							<header>{t("EVENTS.EVENTS.DETAILS.PUBLICATIONS.CAPTION")}</header>

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowTab.tsx
@@ -19,17 +19,19 @@ import DropDown from "../../../shared/DropDown";
 import { useAppDispatch, useAppSelector } from "../../../../store";
 import {
 	deleteWorkflow as deleteWf,
+	fetchHasActiveTransactions,
 	fetchWorkflowDetails,
 	fetchWorkflows,
 	performWorkflowAction,
 	saveWorkflowConfig,
 	updateWorkflow,
 } from "../../../../slices/eventDetailsSlice";
-import { removeNotificationWizardForm } from "../../../../slices/notificationSlice";
+import { addNotification, removeNotificationWizardForm } from "../../../../slices/notificationSlice";
 import { renderValidDate } from "../../../../utils/dateUtils";
 import { Tooltip } from "../../../shared/Tooltip";
 import { WorkflowTabHierarchy } from "../modals/EventDetails";
 import { useTranslation } from "react-i18next";
+import { NOTIFICATION_CONTEXT } from "../../../../configs/modalConfig";
 
 /**
  * This component manages the workflows tab of the event details modal
@@ -66,6 +68,20 @@ const EventDetailsWorkflowTab = ({
 	useEffect(() => {
 		dispatch(removeNotificationWizardForm());
 		dispatch(fetchWorkflows(eventId)).then();
+		dispatch(fetchHasActiveTransactions(eventId)).then((fetchTransactionResult) => {
+			if (
+				fetchTransactionResult.payload.active === undefined ||
+				fetchTransactionResult.payload.active
+			) {
+				dispatch(addNotification({
+					type: "warning",
+					key: "ACTIVE_TRANSACTION",
+					duration: -1,
+					parameter: null,
+					context: NOTIFICATION_CONTEXT
+				}));
+			}
+		});
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 

--- a/src/slices/eventDetailsSlice.ts
+++ b/src/slices/eventDetailsSlice.ts
@@ -1234,9 +1234,6 @@ if (endDate < now) {
 });
 
 export const fetchWorkflows = createAppAsyncThunk('eventDetails/fetchWorkflows', async (eventId: string, { dispatch, getState }) => {
-	// todo: show notification if there are active transactions
-	// dispatch(addNotification('warning', 'ACTIVE_TRANSACTION', -1, null, NOTIFICATION_CONTEXT));
-
 	const data = await axios.get(`/admin-ng/event/${eventId}/workflows.json`);
 	const workflowsData = await data.data;
 	let workflows: Workflow;


### PR DESCRIPTION
An event with an active workflow cannot be edited. However, the warning informing the user about that was only shown on the access tab of the event details. This aims at showing the warning no matter what tab the user is on.

Does not work on the main metadata tab for reasons yet unknown to me.