### PR TITLE
Media type specific player

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetMediaDetails.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetMediaDetails.tsx
@@ -25,6 +25,8 @@ const EventDetailsAssetMediaDetails = ({
 	const media = useAppSelector(state => getAssetMediaDetails(state));
 	const isFetching = useAppSelector(state => isFetchingAssetMediaDetails(state));
 
+	const PlayerType = media.has_video ? 'video' : 'audio';
+
 	const videoRef = useRef<HTMLVideoElement>(null);
 
 	// Make sure to reload the video player when the url changes, React will not do that for us
@@ -364,24 +366,26 @@ const EventDetailsAssetMediaDetails = ({
 						</div>
 					</div>
 
-					{/* preview video player */}
-					<div className="obj tbl-container media-stream-details">
-						<header>
-							{t("EVENTS.EVENTS.DETAILS.ASSETS.PREVIEW") /* Preview */}
-						</header>
-						<div className="obj-container">
-							<div>
-								{/* video player */}
-								<div className="video-player">
-									<div>
-										<video ref={videoRef} id="player" controls>
-											<source src={media.url} type={media.mimetype}/>
-										</video>
+					{/* preview video/audio player (only if we actually have video/audio) */}
+					{(media.has_video || media.has_audio) && (
+						<div className="obj tbl-container media-stream-details">
+							<header>
+								{t("EVENTS.EVENTS.DETAILS.ASSETS.PREVIEW") /* Preview */}
+							</header>
+							<div className="obj-container">
+								<div>
+									{/* video player */}
+									<div className="video-player">
+										<div>
+											<PlayerType ref={videoRef} id="player" controls>
+													<source src={media.url} type={media.mimetype}/>
+											</PlayerType>
+										</div>
 									</div>
 								</div>
 							</div>
 						</div>
-					</div>
+					)}
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
This patch changes the type of player for media assets based on their type so we actually have player that work with the specific types.

- if `media.has_video` → `<video …`
- else if `media.has_audio` → `<audio …`
- else hide player section

This basically implements my suggestion from https://github.com/opencast/opencast-admin-interface/pull/814#discussion_r1671210608