### PR TITLE
Simplify Opencast version display

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -20,6 +20,9 @@ const Footer: React.FC = () => {
 	const user = useAppSelector(state => getUserInformation(state));
 	const orgProperties = useAppSelector(state => getOrgProperties(state));
 
+	const version = (user?.ocVersion?.version ?? '')
+		.replace(/0\.0\.SNAPSHOT/, 'x')
+		.replace(/\.([0-9]+)\.0/, '.$1');
 	const lastModified = user?.ocVersion?.['last-modified']
 		? new Date(user.ocVersion['last-modified']).toISOString().substring(0, 10)
 		: 'unknown';
@@ -33,7 +36,7 @@ const Footer: React.FC = () => {
 					{user.ocVersion && (
 						<li>
 							{"Opencast "}
-							<Tooltip title={t('BUILD.VERSION')}><span>{user.ocVersion.version}</span></Tooltip>
+							<Tooltip title={t('BUILD.VERSION')}><span>{version}</span></Tooltip>
 							{hasAccess("ROLE_ADMIN", user) && (
 								<span>
 								{user.ocVersion.buildNumber && (


### PR DESCRIPTION
Instead of using the Opencast bundle version directly which would be, for example, 16.2.0 for Opencast 16.2 or 15.0.0-SNAPSHOT for a build from the release branch, this patch turn the version into what users actually use. That means, people need less inside information like that 17.0.0 does not mean 17.0 if there is a `SNAPSHOT` suffix.

This will now convert:
- `17.0.0-SNAPSHOT` to `17.x`
- `17.8.0` to `17.8`