### PR TITLE
Open player directly

### DIFF
--- a/src/components/events/partials/PublishedCell.tsx
+++ b/src/components/events/partials/PublishedCell.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Event } from "../../../slices/eventSlice";
+import { Tooltip } from "../../shared/Tooltip";
 
 // References for detecting a click outside of the container of the popup listing publications of an event
 const containerPublications = React.createRef<HTMLDivElement>();
@@ -38,9 +39,23 @@ const PublishCell = ({
 		};
 	}, []);
 
+	const onlyEngage = row.publications.length === 1
+		&& row.publications[0].enabled
+		&& !row.publications[0].hiding
+		&& row.publications[0].id === 'engage-player';
+
 	return (
 		<div className="popover-wrapper">
-			{row.publications.length ? (
+			{onlyEngage && (
+				<Tooltip title={t("EVENTS.EVENTS.TABLE.TOOLTIP.PLAYER")}>
+					<a href={row.publications[0].url} rel='noreferrer' target="_blank">
+						<button className="button-like-anchor">
+							{t("YES")}
+						</button>
+					</a>
+				</Tooltip>
+			)}
+			{!onlyEngage && row.publications.length > 0 && (
 				<>
 					<button className="button-like-anchor popover-wrapper__trigger">
 						<span onClick={() => setShowPopup(!showPopup)}>{t("YES")}</span>
@@ -58,7 +73,7 @@ const PublishCell = ({
 												href={publication.url}
 												className="popover__list-item"
 												target="_blank"
-                        rel='noreferrer'
+												rel='noreferrer'
 												key={key}
 											>
 												<span>{t(publication.name)}</span>
@@ -74,7 +89,7 @@ const PublishCell = ({
 						</div>
 					)}
 				</>
-			) : null}
+			)}
 		</div>
 	);
 };

--- a/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
@@ -621,6 +621,7 @@
 					"EDITOR_NEEDS_CUTTING": "Open video Editor (a comment indicates that cutting the video has been requested)",
 					"COMMENTS": "View comments",
 					"PAUSED_WORKFLOW": "View paused workflow",
+					"PLAYER": "Open player",
 					"PRESENTER": "Filter for this presenter"
 				},
 				"SELECT_ALL": "Select all events",


### PR DESCRIPTION
By default, opencast only publishes the engage publications. That is why most installations only have one publication and do not need a menu to choose the publication from.

This patch makes the admin interface link the player directly if there is just the engage publication. If more or different publications exist, we fall back to the old behavior.