### PR TITLE
Properly set theme default configuration

### DIFF
--- a/src/components/events/partials/modals/SeriesDetails.tsx
+++ b/src/components/events/partials/modals/SeriesDetails.tsx
@@ -62,7 +62,7 @@ const SeriesDetails = ({
 
 	const user = useAppSelector(state => getUserInformation(state));
 	const orgProperties = useAppSelector(state => getOrgProperties(state));
-	const themesEnabled = (orgProperties['admin.themes.enabled'] || 'true').toLowerCase() === 'true';
+	const themesEnabled = (orgProperties['admin.themes.enabled'] || 'false').toLowerCase() === 'true';
 
 	// information about each tab
 	const tabs = [

--- a/src/components/events/partials/wizards/NewSeriesWizard.tsx
+++ b/src/components/events/partials/wizards/NewSeriesWizard.tsx
@@ -35,7 +35,7 @@ const NewSeriesWizard: React.FC<{
 	const user = useAppSelector(state => getUserInformation(state));
 	const orgProperties = useAppSelector(state => getOrgProperties(state));
 
-	const themesEnabled = (orgProperties['admin.themes.enabled'] || 'true').toLowerCase() === 'true';
+	const themesEnabled = (orgProperties['admin.themes.enabled'] || 'false').toLowerCase() === 'true';
 
 	const initialValues = getInitialValues(metadataFields, extendedMetadata, user);
 

--- a/src/components/shared/MainNav.tsx
+++ b/src/components/shared/MainNav.tsx
@@ -52,7 +52,7 @@ const MainNav = ({
 	const orgProperties = useAppSelector(state => getOrgProperties(state));
 
 	const statisticsEnabled = (orgProperties['admin.statistics.enabled'] || 'false').toLowerCase() === 'true';
-	const themesEnabled = (orgProperties['admin.themes.enabled'] || 'true').toLowerCase() === 'true';
+	const themesEnabled = (orgProperties['admin.themes.enabled'] || 'false').toLowerCase() === 'true';
 
 	const loadEvents = () => {
 		dispatch(fetchFilters("events"));


### PR DESCRIPTION
Instead of properly setting the default value for `admin.themes.enabled` in the admin interface, we temporarily set it in the Opencast configuration. That's not a great workaround and it has a few problems, but I let us backport the admin interface to `r/15.x` to fix the major problems there.

Not that 15 is our legacy release and we already have a two 16.x versions out, it's time to properly set the default value.