### PR TITLE
auto select workflow when there is only one

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/NewProcessingPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewProcessingPage.tsx
@@ -37,6 +37,13 @@ const NewProcessingPage = <T extends RequiredFormProps>({
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
+	// Preselect the first item
+	useEffect(() => {
+		if (workflowDef.length == 1) {
+			setDefaultValues(workflowDef[0].id);
+		}
+	}, [workflowDef]);
+
 	const previous = () => {
 		// if not UPLOAD is chosen as source mode, then back to source page
 		if (formik.values.sourceMode !== "UPLOAD") {

--- a/src/components/events/partials/ModalTabsAndPages/NewProcessingPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewProcessingPage.tsx
@@ -39,9 +39,10 @@ const NewProcessingPage = <T extends RequiredFormProps>({
 
 	// Preselect the first item
 	useEffect(() => {
-		if (workflowDef.length == 1) {
+		if (workflowDef.length === 1) {
 			setDefaultValues(workflowDef[0].id);
 		}
+	// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [workflowDef]);
 
 	const previous = () => {

--- a/src/components/events/partials/ModalTabsAndPages/StartTaskWorkflowPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/StartTaskWorkflowPage.tsx
@@ -40,12 +40,13 @@ const StartTaskWorkflowPage = <T extends RequiredFormProps>({
 
 	// Preselect the first item
 	useEffect(() => {
-		if (workflowDef.length == 1) {
+		if (workflowDef.length === 1) {
 			setDefaultValues(workflowDef[0].id);
 		}
+	// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [workflowDef]);
 
-// @ts-expect-error TS(7006): Parameter 'value' implicitly has an 'any' type.
+	// @ts-expect-error TS(7006): Parameter 'value' implicitly has an 'any' type.
 	const setDefaultValues = (value) => {
 		let workflowId = value;
 		// fill values with default configuration of chosen workflow

--- a/src/components/events/partials/ModalTabsAndPages/StartTaskWorkflowPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/StartTaskWorkflowPage.tsx
@@ -38,6 +38,13 @@ const StartTaskWorkflowPage = <T extends RequiredFormProps>({
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
+	// Preselect the first item
+	useEffect(() => {
+		if (workflowDef.length == 1) {
+			setDefaultValues(workflowDef[0].id);
+		}
+	}, [workflowDef]);
+
 // @ts-expect-error TS(7006): Parameter 'value' implicitly has an 'any' type.
 	const setDefaultValues = (value) => {
 		let workflowId = value;


### PR DESCRIPTION
Closes #849

When there is only one workflow to choose from, this one should be automatically selected.

![image](https://github.com/user-attachments/assets/03176be3-0e84-4e56-b42f-cf468d9be984)
