### PR TITLE
Fix missing `agreedToPolicy` parameter when add adopter

### DIFF
--- a/src/utils/adopterRegistrationUtils.ts
+++ b/src/utils/adopterRegistrationUtils.ts
@@ -29,6 +29,7 @@ export type Registration = {
 	street: string,
 	streetNo: string,
 	email: string,
+	agreedToPolicy: boolean,
 }
 
 // post request for adopter information
@@ -50,6 +51,7 @@ export const postRegistration = async (
 	body.append("street", values.street);
 	body.append("streetNo", values.streetNo);
 	body.append("email", values.email);
+	body.append("agreedToPolicy", values.agreedToPolicy.toString());
 	body.append("registered", "true");
 
 	// save adopter information and return next state


### PR DESCRIPTION
No parameter `agreedToPolicy` is sent to Opencast, which means that the new policy will not be accepted in Opencast, but the old one will be. Thus, the data will not be sent to register.opencast.org. This pull request adds this missing parameter.

Related lines in Opencast:
- https://github.com/opencast/opencast/blob/904bf85b0c8085b7f157ebf38e1fc3ab2252f0c9/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/ScheduledDataCollector.java#L218

- https://github.com/opencast/opencast/blob/904bf85b0c8085b7f157ebf38e1fc3ab2252f0c9/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/registration/Form.java#L164-L166

