### PR TITLE
Fix undefined values in adopter registration

### DIFF
--- a/src/components/shared/RegistrationModal.tsx
+++ b/src/components/shared/RegistrationModal.tsx
@@ -66,6 +66,7 @@ const RegistrationModal = ({
 	useEffect(() => {
 		fetchRegistrationInfos().then((r) => console.log(r));
 		fetchStatisticSummary();
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
 	const onClickContinue = async () => {

--- a/src/components/shared/RegistrationModal.tsx
+++ b/src/components/shared/RegistrationModal.tsx
@@ -80,8 +80,8 @@ const RegistrationModal = ({
 	const fetchRegistrationInfos = async () => {
 		let registrationInfo = await fetchAdopterRegistration();
 
-		// set response as initial values for formik
-		setInitialValues(registrationInfo);
+		// merge response into initial values for formik
+		setInitialValues({...initialValues, ...registrationInfo});
 	};
 
 	const fetchStatisticSummary = async () => {


### PR DESCRIPTION
Currently, the adopter registration shows undefined values after a new registration is created:

[Screencast from 01.08.2024 13:23:05.webm](https://github.com/user-attachments/assets/bc315361-74a2-4624-afa8-8b4a923bd28e)

This PR should fix this problem.