### PR TITLE
Don't show episode role ids for events

### DIFF
--- a/src/slices/eventDetailsSlice.ts
+++ b/src/slices/eventDetailsSlice.ts
@@ -874,6 +874,9 @@ export const fetchAccessPolicies = createAppAsyncThunk('eventDetails/fetchAccess
 		policies = policyRoles.map((role) => newPolicies[role]);
 	}
 
+	// Ignore episode role ids. They are supposed to be implicit and we don't need them
+	policies = policies.filter(acl => !acl.role.startsWith("ROLE_EPISODE"));
+
 	return policies;
 });
 


### PR DESCRIPTION
Supposed to accompany https://github.com/opencast/opencast/pull/5056.

Due to unfortunate technical limitations, 5056 (linked above) requires episode role ids to be added to the index for events.  This is nothing users should concern themselves with, so this filters those roles out right after we get them.