### PR TITLE
Fix the URL for the "about" configuration in the admin UI

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -23,7 +23,7 @@ const About: React.FC = () => {
 
 	useEffect(() => {
 		const getURL = (language: string) => {
-			return `ui/config/admin-ui/${location.pathname.split("/").pop()}.${language}.html`;
+			return `/ui/config/admin-ui/${location.pathname.split("/").pop()}.${language}.html`;
 		};
 
 		axios.get(getURL(i18n.language))


### PR DESCRIPTION
The admin UI can fetch HTML files from the `ui-config` module
to display in its "about" view which you can reach by the links
in the footer. (If you have that feature enabled.)

The URL used to fetch these was a relative one, which works
in "dev mode" since the site is served from the root,
but it doesn't work in production, where the link is resolved
relative to `/admin-ui`.

NB for reviewers: See https://github.com/opencast/opencast-admin-interface/pull/306 for what you need to test this.