### PR TITLE
Include admin interface version

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <meta name="git-commit" content="%VITE_GIT_COMMIT_HASH%">
+    <meta name="build-date" content="%VITE_APP_BUILD_DATE%">
     <meta charset="utf-8" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,10 +3,17 @@ import react from "@vitejs/plugin-react-swc";
 import svgr from "vite-plugin-svgr";
 import viteTsconfigPaths from "vite-tsconfig-paths";
 import preserveDirectives from "rollup-preserve-directives";
+import child from "child_process";
+
+const commitHash = child.execSync("git rev-parse HEAD").toString().trim();
 
 export default defineConfig({
     base: process.env.PUBLIC_URL || "",
     plugins: [react(), svgr(), viteTsconfigPaths(), preserveDirectives()],
+    define: {
+        'import.meta.env.VITE_GIT_COMMIT_HASH': JSON.stringify(commitHash),
+        'import.meta.env.VITE_APP_BUILD_DATE': JSON.stringify(new Date().toISOString()),
+    },
     build: {
         outDir: "build",
         sourcemap: true,


### PR DESCRIPTION
This patch adds the admin interface build date and the git commit it was built from to the top of the HTML head section. This makes it easy for developers to check which version of the admin interface exactly they are dealing with.

This is hidden from regular users and therefor shouldn't make them confuse this with the version of Opencast itself.