### PR TITLE
Open event details on the center of the page

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -130,6 +130,9 @@ a {
 
 .modal {
   top: 30px;
+  position: fixed;
+  max-height: 90vh;
+  overflow: scroll;
   input[readonly] {
     border: none;
   }


### PR DESCRIPTION
This patch updates the position the event details dialog is opened in and make it a fixed position on the display instead opening it at the top of the page. The previous behaviour caused the dialog to open outside the visible area in some cases – like opening the details from the bottom of a long events table – causing a confusing user experience.

This fixes #919