### PR TITLE
Fix ICLA Check

### DIFF
--- a/.github/workflows/check-icla.yml
+++ b/.github/workflows/check-icla.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Python module
-        run: pip install apereocla
+        run: pip install --break-system-packages apereocla
 
       - name: Check Apereo ICLA for GitHub user
         run: apereocla -g "${{ github.event.pull_request.user.login }}"


### PR DESCRIPTION
Copied from https://github.com/opencast/opencast/pull/6238

The tool we use for checking if contributors signed their ICLA is failing to install on CI runs with new Python versions since we just install it system wide. While that may not be good practice on your local machine, this shouldn't matter in the CI since we immediately throw away the machine anyway.