### PR TITLE
Fix test containers

### DIFF
--- a/.github/workflows/deploy-container-image.yaml
+++ b/.github/workflows/deploy-container-image.yaml
@@ -22,6 +22,9 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
 
+      - name: Prepare commit hash
+        run: git rev-parse HEAD > commit
+
       - name: Log in to the container registry
         uses: docker/login-action@v3
         with:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import viteTsconfigPaths from "vite-tsconfig-paths";
 import preserveDirectives from "rollup-preserve-directives";
 import child from "child_process";
 
-const commitHash = child.execSync("git rev-parse HEAD").toString().trim();
+const commitHash = child.execSync("giat rev-parse HEAD || cat commit || :").toString().trim();
 
 export default defineConfig({
     base: process.env.PUBLIC_URL || "",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import viteTsconfigPaths from "vite-tsconfig-paths";
 import preserveDirectives from "rollup-preserve-directives";
 import child from "child_process";
 
-const commitHash = child.execSync("giat rev-parse HEAD || cat commit || :").toString().trim();
+const commitHash = child.execSync("git rev-parse HEAD || cat commit || echo 'unknown'").toString().trim();
 
 export default defineConfig({
     base: process.env.PUBLIC_URL || "",


### PR DESCRIPTION
This patch fixes the test containers, which were failing since `git` is now required for building/running the admin interface.