### PR TITLE
Fix border around date selector

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -255,10 +255,6 @@ td.editable {
     resize: vertical;
   }
 
-  span {
-    border-bottom: 1px dashed #999;
-  }
-
   i.saved, i.edit {
     float: right;
     cursor: pointer;


### PR DESCRIPTION
Fixes #881

Caused by a CSS rule we don't seem to be needing, so this fixes the issue by deleting said rule.