### PR TITLE
Fix wf config values not showing for scheduled events

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowTab.tsx
@@ -113,8 +113,6 @@ const EventDetailsWorkflowTab = ({
 	const setInitialValues = () => {
 		let initialConfig = undefined;
 
-		// TODO: Scheduled events are missing configuration for their workflow
-		// Figure out why the config is missing
 		if (baseWorkflow.configuration) {
 			initialConfig = parseBooleanInObject(baseWorkflow.configuration);
 		}

--- a/src/slices/eventDetailsSlice.ts
+++ b/src/slices/eventDetailsSlice.ts
@@ -1830,7 +1830,8 @@ export const saveWorkflowConfig = createAppAsyncThunk('eventDetails/saveWorkflow
 
 	let header = getHttpHeaders();
 	let data = new URLSearchParams();
-	data.append("configuration", JSON.stringify(jsonData));
+	// Scheduler service in Opencast expects values to be strings, so we convert them here
+	data.append("configuration", JSON.stringify(jsonData, (k, v) => v && typeof v === 'object' ? v : '' + v));
 
 	axios
 		.put(`/admin-ng/event/${eventId}/workflows`, data, header)

--- a/src/slices/eventDetailsSlice.ts
+++ b/src/slices/eventDetailsSlice.ts
@@ -1314,7 +1314,7 @@ export const fetchWorkflows = createAppAsyncThunk('eventDetails/fetchWorkflows',
 			workflow: {
 				workflowId: workflowsData.workflowId,
 				description: undefined,
-				configuration: undefined
+				configuration: workflowsData.configuration,
 			},
 			scheduling: true,
 			entries: [],


### PR DESCRIPTION
Fixes #916.

When looking at the workflow tab of a scheduled event, the workflow configuration for the workflow would always display default values, regardless of what was initially set. This should fix that.

Example screenshot:
![Bildschirmfoto vom 2024-11-06 11-34-45](https://github.com/user-attachments/assets/9e7ac7a9-618f-4d3c-9e58-b4f1af316590)
(Disclaimer: Using the duplicate event workflow for a scheduled event makes no sense, it is used here purely for demonstration purposes)