### PR TITLE
Allow series path removal via Tobira tab in series details

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/DetailsTobiraTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/DetailsTobiraTab.tsx
@@ -11,6 +11,8 @@ import EventDetailsTabHierarchyNavigation from "./EventDetailsTabHierarchyNaviga
 import NewTobiraPage, { TobiraFormProps } from "./NewTobiraPage";
 import { fetchSeriesDetailsTobira, setTobiraTabHierarchy, TobiraData, updateSeriesTobiraPath } from "../../../../slices/seriesDetailsSlice";
 import { fetchSeriesDetailsTobiraNew, TobiraPage } from "../../../../slices/seriesSlice";
+import ConfirmModal from "../../../shared/ConfirmModal";
+import { Tooltip } from "../../../shared/Tooltip";
 
 
 export type TobiraTabHierarchy = "main" | "edit-path";
@@ -92,6 +94,15 @@ const DetailsTobiraTab = ({ kind, id }: DetailsTobiraTabProps) => {
 		dispatch(setTobiraTabHierarchy("main"));
 	};
 
+	const handleDelete = async (hostPage: TobiraPage) => {
+		await dispatch(updateSeriesTobiraPath({
+			seriesId: id,
+			currentPath: hostPage.path,
+			breadcrumbs: [],
+			remove: true,
+		})).then(() => dispatch(fetchSeriesDetailsTobira(id)))
+	}
+
 	const openSubTab = async (tabType: TobiraTabHierarchy, currentPage?: TobiraPage) => {
 		if (!!currentPage) {
 			const breadcrumbs = getBreadcrumbs(currentPage);
@@ -139,16 +150,13 @@ const DetailsTobiraTab = ({ kind, id }: DetailsTobiraTabProps) => {
 					{kind === "series" && <p className="tab-description">
 						{t("EVENTS.SERIES.DETAILS.TOBIRA.DESCRIPTION")}
 					</p>}
-					<div className="obj-container">
-						<div className="obj tbl-list">
-							<header>
-								{t(`EVENTS.${i18nKey}.DETAILS.TOBIRA.PAGES`)}
-							</header>
-							<div className="obj-container">
-								<TobiraTable {...{ tobiraData, i18nKey, openSubTab }} />
-							</div>
-						</div>
-					</div>
+					<TobiraTable {...{
+						tobiraData,
+						i18nKey,
+						openSubTab,
+						dispatch,
+						handleDelete,
+					}} />
 				</>}
 			</div>}
 		</div>
@@ -175,59 +183,79 @@ const DetailsTobiraTab = ({ kind, id }: DetailsTobiraTabProps) => {
 type TobiraTableProps = {
 	tobiraData: TobiraData;
 	i18nKey: "SERIES" | "EVENTS";
-	openSubTab: (tabType: TobiraTabHierarchy, currentPage?: TobiraPage) => Promise<void>
+	openSubTab: (tabType: TobiraTabHierarchy, currentPage?: TobiraPage) => Promise<void>;
+	handleDelete: (hostPage: TobiraPage) => Promise<void>;
 };
 
-const TobiraTable: React.FC<TobiraTableProps> = ({ tobiraData, i18nKey, openSubTab }) => {
+const TobiraTable = ({ tobiraData, i18nKey, openSubTab, handleDelete }: TobiraTableProps) => {
 	const { t } = useTranslation();
-	return <table className="main-tbl">
-		<tbody>
-			{tobiraData.hostPages.length === 0 && <tr>
-				<td className="tobira-not-mounted">
-					{t(`EVENTS.${i18nKey}.DETAILS.TOBIRA.NOT_MOUNTED`)}
-					{i18nKey === "SERIES" && (
-						<button
-							style={{ margin: 5 }}
-							className="button-like-anchor details-link pull-right"
-							onClick={() => openSubTab("edit-path")}
-						>
-							{t("EVENTS.SERIES.DETAILS.TOBIRA.MOUNT_SERIES")}
-						</button>
-					)}
-				</td>
-			</tr>}
-			{tobiraData.hostPages.map(hostPage => <tr key={hostPage.path}>
-				<td>
-					<a href={tobiraData.baseURL + hostPage.path}>
-						{hostPage.path !== '/' && <>
-							<span className="tobira-page-separator">/</span>
-							{hostPage.ancestors.map((ancestor, key) => (
-								<span key={key}>
-									{ancestor.title}
-									<span className="tobira-page-separator">/</span>
-								</span>
-							))}
+	const [showConfirmationModal, setShowConfirmationModal] = useState(false);
+
+	return <div className="obj">
+		<header>{t(`EVENTS.${i18nKey}.DETAILS.TOBIRA.PAGES`)}</header>
+		<table className="main-tbl">
+			<tbody>
+				{tobiraData.hostPages.length === 0 && <tr>
+					<td className="tobira-not-mounted">
+						{t(`EVENTS.${i18nKey}.DETAILS.TOBIRA.NOT_MOUNTED`)}
+						{i18nKey === "SERIES" && <Tooltip title={t("EVENTS.SERIES.DETAILS.TOBIRA.MOUNT_SERIES")}>
+							<button
+								style={{ margin: 5 }}
+								className="button-like-anchor edit fa fa-pencil-square pull-right"
+								onClick={() => openSubTab("edit-path")}
+								/>
+						</Tooltip>}
+					</td>
+				</tr>}
+				{tobiraData.hostPages.map(hostPage => <tr key={hostPage.path}>
+					<td>
+						<a href={tobiraData.baseURL + hostPage.path}>
+							{hostPage.path !== '/' && <>
+								<span className="tobira-page-separator">/</span>
+								{hostPage.ancestors.map((ancestor, key) => (
+									<span key={key}>
+										{ancestor.title}
+										<span className="tobira-page-separator">/</span>
+									</span>
+								))}
+							</>}
+							<span className="tobira-leaf-page">
+								{hostPage.path !== '/' && <span>
+									{hostPage.title}
+								</span>}
+								{hostPage.path === '/' && <span>
+									{t(`EVENTS.${i18nKey}.DETAILS.TOBIRA.HOMEPAGE`)}
+								</span>}
+							</span>
+						</a>
+						{i18nKey === "SERIES" && hostPage.blocks?.length === 1 && <>
+							<Tooltip title={t("EVENTS.SERIES.DETAILS.TOBIRA.REMOVE_PATH")}>
+								<button
+									style={{ margin: 5 }}
+									onClick={() => setShowConfirmationModal(true)}
+									className="button-like-anchor remove pull-right"
+								/>
+							</Tooltip>
+							<Tooltip title={t("EVENTS.SERIES.DETAILS.TOBIRA.EDIT_PATH")}>
+								<button
+									style={{ margin: 5 }}
+									className="button-like-anchor edit fa fa-pencil-square pull-right"
+									onClick={() => openSubTab("edit-path", hostPage)}
+								/>
+							</Tooltip>
+							{showConfirmationModal && <ConfirmModal
+								close={() => setShowConfirmationModal(false)}
+								resourceName={hostPage.path}
+								resourceId={null}
+								deleteMethod={() => handleDelete(hostPage)}
+								resourceType="TOBIRA_PATH"
+							/>}
 						</>}
-						<span className="tobira-leaf-page">
-							{hostPage.path !== '/' && <span>
-								{hostPage.title}
-							</span>}
-							{hostPage.path === '/' && <span>
-								{t(`EVENTS.${i18nKey}.DETAILS.TOBIRA.HOMEPAGE`)}
-							</span>}
-						</span>
-					</a>
-					{i18nKey === "SERIES" && hostPage.blocks?.length === 1 && <button
-						style={{ margin: 5 }}
-						className="button-like-anchor details-link pull-right"
-						onClick={() => openSubTab("edit-path", hostPage)}
-					>
-						{t("EVENTS.SERIES.DETAILS.TOBIRA.EDIT_PATH")}
-					</button>}
-				</td>
-			</tr>)}
-		</tbody>
-	</table>;
+					</td>
+				</tr>)}
+			</tbody>
+		</table>
+	</div>;
 };
 
 export default DetailsTobiraTab;

--- a/src/components/events/partials/ModalTabsAndPages/DetailsTobiraTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/DetailsTobiraTab.tsx
@@ -9,7 +9,7 @@ import { Formik } from "formik";
 import { useState } from "react";
 import EventDetailsTabHierarchyNavigation from "./EventDetailsTabHierarchyNavigation";
 import NewTobiraPage, { TobiraFormProps } from "./NewTobiraPage";
-import { fetchSeriesDetailsTobira, setTobiraTabHierarchy, TobiraData, updateSeriesTobiraPath } from "../../../../slices/seriesDetailsSlice";
+import { fetchSeriesDetailsTobira, removeSeriesTobiraPath, setTobiraTabHierarchy, TobiraData, updateSeriesTobiraPath } from "../../../../slices/seriesDetailsSlice";
 import { fetchSeriesDetailsTobiraNew, TobiraPage } from "../../../../slices/seriesSlice";
 import ConfirmModal from "../../../shared/ConfirmModal";
 import { Tooltip } from "../../../shared/Tooltip";
@@ -95,11 +95,9 @@ const DetailsTobiraTab = ({ kind, id }: DetailsTobiraTabProps) => {
 	};
 
 	const handleDelete = async (hostPage: TobiraPage) => {
-		await dispatch(updateSeriesTobiraPath({
+		await dispatch(removeSeriesTobiraPath({
 			seriesId: id,
 			currentPath: hostPage.path,
-			breadcrumbs: [],
-			remove: true,
 		})).then(() => dispatch(fetchSeriesDetailsTobira(id)))
 	}
 

--- a/src/components/events/partials/ModalTabsAndPages/DetailsTobiraTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/DetailsTobiraTab.tsx
@@ -159,7 +159,10 @@ const DetailsTobiraTab = ({ kind, id }: DetailsTobiraTabProps) => {
 				onSubmit={values => handleSubmit(values)}
 			>
 				{formik => <NewTobiraPage
-					editMode
+					mode={{
+						edit: true,
+						mount: tobiraData.hostPages.length === 0,
+					}}
 					formik={formik}
 					nextPage={() => {}}
 					previousPage={() => {}}

--- a/src/components/events/partials/ModalTabsAndPages/NewTobiraPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewTobiraPage.tsx
@@ -24,12 +24,16 @@ const NewTobiraPage = <T extends TobiraFormProps>({
 	formik,
 	nextPage,
 	previousPage,
-	editMode,
+	mode,
 }: {
 	formik: FormikProps<T>,
 	nextPage: (values: T) => void,
 	previousPage:(values: T) => void,
 	editMode?: boolean,
+	mode: {
+		edit?: boolean,
+		mount?: boolean,
+	},
 }) => {
 	const { t } = useTranslation();
 	const dispatch = useAppDispatch();
@@ -202,7 +206,7 @@ const NewTobiraPage = <T extends TobiraFormProps>({
 			<div className="modal-body">
 				{/* Notifications */}
 				<Notifications context="tobira" />
-				{!editMode && <p className="tab-description">{t("EVENTS.SERIES.NEW.TOBIRA.DESCRIPTION")}</p>}
+				<p className="tab-description">{t("EVENTS.SERIES.NEW.TOBIRA.DESCRIPTION")}</p>
 				{!error && <>
 					<div className="obj-container padded">
 						<div className="obj">
@@ -226,7 +230,7 @@ const NewTobiraPage = <T extends TobiraFormProps>({
 							<table className="main-tbl highlight-hover">
 								<thead>
 									<tr>
-										<th className="small"/>
+										{currentPage.children.length > 0 && <th className="small"/>}
 										<th>
 											{t("EVENTS.SERIES.NEW.TOBIRA.PAGE_TITLE") /* Title */}
 										</th>
@@ -337,14 +341,17 @@ const NewTobiraPage = <T extends TobiraFormProps>({
 									{formik.values.selectedPage.path}
 								</code>
 							</>
-							: t("EVENTS.SERIES.NEW.TOBIRA.NO_PAGE_SELECTED")
+							: (mode.edit && !mode.mount
+								? t("EVENTS.SERIES.NEW.TOBIRA.NO_PAGE_SELECTED_EDIT")
+								: t("EVENTS.SERIES.NEW.TOBIRA.NO_PAGE_SELECTED")
+							)
 						}
 					</p>
-					<p style={{ fontSize: 12 }}>{t("EVENTS.SERIES.NEW.TOBIRA.DIRECT_LINK")}</p>
+					{!mode.edit && <p style={{ fontSize: 12 }}>{t("EVENTS.SERIES.NEW.TOBIRA.DIRECT_LINK")}</p>}
 				</>}
 			</div>
 			{/* Render buttons for saving or resetting updated path */}
-			{editMode && <SaveEditFooter
+			{mode.edit && <SaveEditFooter
 				active={formik.values.selectedPage !== undefined}
 				reset={() => formik.setFieldValue("selectedPage", undefined)}
 				submit={() => formik.handleSubmit()}
@@ -353,7 +360,7 @@ const NewTobiraPage = <T extends TobiraFormProps>({
 		</div>
 
 		{/* Button for navigation to next page and previous page */}
-		{!editMode && <WizardNavigationButtons
+		{!mode.edit && <WizardNavigationButtons
 			formik={formik}
 			nextPage={nextPage}
 			previousPage={previousPage}

--- a/src/components/events/partials/ModalTabsAndPages/NewTobiraPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewTobiraPage.tsx
@@ -300,7 +300,15 @@ const NewTobiraPage = <T extends TobiraFormProps>({
 										</td>
 										{editing && <td>
 											{page.new && <button
-												onClick={() => select(undefined)}
+												onClick={() => {
+													dispatch(setTobiraPage({
+														...currentPage,
+														children: currentPage.children.filter((_, idx) => (
+															idx !== currentPage.children.length - 1
+														))
+													}));
+													select(undefined);
+												}}
 												title={t('EVENTS.SERIES.NEW.TOBIRA.CANCEL')}
 												className="button-like-anchor remove"
 											/>}

--- a/src/components/events/partials/modals/EventDetails.tsx
+++ b/src/components/events/partials/modals/EventDetails.tsx
@@ -266,12 +266,11 @@ const EventDetails = ({
 						header={tabs[page].bodyHeaderTranslation ?? ""}
 					/>
 				)}
-				{page === EventDetailsPage.Tobira && (<>
+				{page === EventDetailsPage.Tobira && (
 					<DetailsTobiraTab
 						kind="event"
 						id={eventId}
 					/>
-				</>
 				)}
 				{page === EventDetailsPage.Statistics && !isLoadingStatistics && (
 					<EventDetailsStatisticsTab

--- a/src/components/events/partials/modals/SeriesDetailsModal.tsx
+++ b/src/components/events/partials/modals/SeriesDetailsModal.tsx
@@ -3,6 +3,8 @@ import { useTranslation } from "react-i18next";
 import SeriesDetails from "./SeriesDetails";
 import { useHotkeys } from "react-hotkeys-hook";
 import { availableHotkeys } from "../../../../configs/hotkeysConfig";
+import { removeNotificationWizardForm } from "../../../../slices/notificationSlice";
+import { useAppDispatch } from "../../../../store";
 
 /**
  * This component renders the modal for displaying series details
@@ -17,6 +19,7 @@ const SeriesDetailsModal = ({
 	seriesId: string
 }) => {
 	const { t } = useTranslation();
+	const dispatch = useAppDispatch();
 
 	// tracks, whether the policies are different to the initial value
 	const [policyChanged, setPolicyChanged] = useState(false);
@@ -28,6 +31,7 @@ const SeriesDetailsModal = ({
 	const close = () => {
 		if (!policyChanged || confirmUnsaved()) {
 			setPolicyChanged(false);
+			dispatch(removeNotificationWizardForm());
 			handleClose();
 		}
 	};

--- a/src/components/events/partials/wizards/NewSeriesWizard.tsx
+++ b/src/components/events/partials/wizards/NewSeriesWizard.tsx
@@ -207,6 +207,7 @@ const NewSeriesWizard: React.FC<{
 								)}
 								{page === 4 && (
 									<NewTobiraPage
+										mode={{ mount: true }}
 										formik={formik}
 										nextPage={nextPage}
 										previousPage={previousPage}

--- a/src/components/shared/ConfirmModal.tsx
+++ b/src/components/shared/ConfirmModal.tsx
@@ -15,7 +15,7 @@ const ConfirmModal = <T,>({
 	deleteWithCautionMessage = "",
 }: {
 	close: () => void,
-	resourceType: "EVENT" | "SERIES" | "LOCATION" | "USER" | "GROUP" | "ACL" | "THEME",
+	resourceType: "EVENT" | "SERIES" | "LOCATION" | "USER" | "GROUP" | "ACL" | "THEME" | "TOBIRA_PATH",
 	resourceName: string,
 	resourceId: T,
 	deleteMethod: (id: T) => void,
@@ -68,7 +68,7 @@ const ConfirmModal = <T,>({
 
 						<div>
 							<p>
-								<span>
+								<span style={{ padding: "0px 4px"}}>
 									{t("CONFIRMATIONS.METADATA.NOTICE." + resourceType)}
 								</span>
 							</p>

--- a/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
@@ -1146,6 +1146,7 @@
 					"HOMEPAGE": "Homepage",
 					"SELECTED_PAGE": "Series will be mounted under the following path",
 					"NO_PAGE_SELECTED": "No page selected. Series will not be mounted in Tobira.",
+					"NO_PAGE_SELECTED_EDIT": "No page selected. Series path will not be changed.",
 					"PATH": "Path",
 					"DIRECT_LINK": "A direct link will be available.",
 					"MOUNT_DISCLAIMER": "Series can only be mounted in empty pages"

--- a/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
@@ -119,7 +119,8 @@
 				"GROUP": "The following group will be deleted",
 				"USER": "The following user will be deleted",
 				"THEME": "The following theme will be deleted",
-				"LOCATION": "The following location will be deleted"
+				"LOCATION": "The following location will be deleted",
+				"TOBIRA_PATH": "The series will be removed from the following path in Tobira:"
 			},
 			"NAME": "Name"
 		},
@@ -171,7 +172,9 @@
 		"SERIES_ADDED": "The series has been created",
 		"SERIES_NOT_SAVED": "The series could not be saved",
 		"SERIES_PATH_UPDATED": "The series path has been updated",
+		"SERIES_PATH_REMOVED": "The series path has been removed",
 		"SERIES_PATH_NOT_UPDATED": "The series path could not be updated",
+		"SERIES_PATH_NOT_REMOVED": "The series path could not be removed",
 		"EVENTS_CREATED": "The event has been created",
 		"EVENTS_UPLOAD_STARTED": "The event is being uploaded… {{ progress }}%",
 		"EVENTS_NOT_CREATED": "The event could not be created",
@@ -1235,6 +1238,7 @@
 					"PAGES": "Pages in Tobira that contain this series",
 					"SHOW_PAGES": "Show all pages",
 					"EDIT_PATH" : "Edit path",
+					"REMOVE_PATH" : "Remove path",
 					"MOUNT_SERIES": "Mount series",
 					"DESCRIPTION": "You may edit the path of pages containing this series if the page has no other content."
 				},

--- a/src/slices/seriesDetailsSlice.ts
+++ b/src/slices/seriesDetailsSlice.ts
@@ -672,6 +672,7 @@ const seriesDetailsSlice = createSlice({
 			.addCase(fetchSeriesDetailsTobira.fulfilled, (state, action: PayloadAction<
 				SeriesDetailsState["tobiraData"]
 			>) => {
+				state.errorTobiraData = null;
 				state.statusTobiraData = 'succeeded';
 				state.tobiraData = action.payload;
 			})

--- a/src/slices/seriesDetailsSlice.ts
+++ b/src/slices/seriesDetailsSlice.ts
@@ -429,11 +429,14 @@ export const fetchSeriesDetailsTobira = createAppAsyncThunk('seriesDetails/fetch
 });
 
 export const updateSeriesTobiraPath = createAppAsyncThunk('series/updateSeriesTobiraData', async (
-	params: TobiraFormProps & { seriesId: string },
+	params: TobiraFormProps & {
+		seriesId: string,
+		remove?: boolean,
+	},
 	{ dispatch },
 ) => {
 	const tobiraParams = new URLSearchParams();
-	
+	const operation = params.remove ? "REMOVED" : "UPDATED";
 	const pathComponents = params.breadcrumbs.slice(1).map(crumb => ({
 		name: crumb.title,
 		pathSegment: crumb.segment,
@@ -445,11 +448,11 @@ export const updateSeriesTobiraPath = createAppAsyncThunk('series/updateSeriesTo
 			name: params.selectedPage.title ?? "dummy",
 			pathSegment: params.selectedPage.segment,
 		});
-		
+
 		tobiraParams.append("pathComponents", JSON.stringify(pathComponents));
 		tobiraParams.append("targetPath", params.selectedPage.path);
 	}
-	
+
 	if (params.currentPath) {
 		tobiraParams.append("currentPath", params.currentPath);
 	}
@@ -460,21 +463,21 @@ export const updateSeriesTobiraPath = createAppAsyncThunk('series/updateSeriesTo
 				'Content-Type': 'application/x-www-form-urlencoded',
 			},
 		});
-  
+
 		console.info(response);
 		dispatch(addNotification({
 			type: 'success',
-			key: 'SERIES_PATH_UPDATED',
-			context: NOTIFICATION_CONTEXT_TOBIRA
+			key: `SERIES_PATH_${operation}`,
+			context: NOTIFICATION_CONTEXT_TOBIRA,
 		}));
-		
+
 		return response.data;
 	} catch (error) {
 		console.error(error);
 		dispatch(addNotification({
 			type: 'error',
-			key: 'SERIES_PATH_NOT_UPDATED',
-			context: NOTIFICATION_CONTEXT_TOBIRA
+			key: `SERIES_PATH_NOT_${operation}`,
+			context: NOTIFICATION_CONTEXT_TOBIRA,
 		}));
 		throw error;
 	}}

--- a/src/slices/seriesDetailsSlice.ts
+++ b/src/slices/seriesDetailsSlice.ts
@@ -429,14 +429,10 @@ export const fetchSeriesDetailsTobira = createAppAsyncThunk('seriesDetails/fetch
 });
 
 export const updateSeriesTobiraPath = createAppAsyncThunk('series/updateSeriesTobiraData', async (
-	params: TobiraFormProps & {
-		seriesId: string,
-		remove?: boolean,
-	},
+	params: TobiraFormProps & { seriesId: string },
 	{ dispatch },
 ) => {
 	const tobiraParams = new URLSearchParams();
-	const operation = params.remove ? "REMOVED" : "UPDATED";
 	const pathComponents = params.breadcrumbs.slice(1).map(crumb => ({
 		name: crumb.title,
 		pathSegment: crumb.segment,
@@ -467,7 +463,7 @@ export const updateSeriesTobiraPath = createAppAsyncThunk('series/updateSeriesTo
 		console.info(response);
 		dispatch(addNotification({
 			type: 'success',
-			key: `SERIES_PATH_${operation}`,
+			key: 'SERIES_PATH_UPDATED',
 			context: NOTIFICATION_CONTEXT_TOBIRA,
 		}));
 
@@ -476,7 +472,37 @@ export const updateSeriesTobiraPath = createAppAsyncThunk('series/updateSeriesTo
 		console.error(error);
 		dispatch(addNotification({
 			type: 'error',
-			key: `SERIES_PATH_NOT_${operation}`,
+			key: 'SERIES_PATH_NOT_UPDATED',
+			context: NOTIFICATION_CONTEXT_TOBIRA,
+		}));
+		throw error;
+	}}
+);
+
+export const removeSeriesTobiraPath = createAppAsyncThunk('series/removeSeriesTobiraData', async (
+	params: Required<Pick<TobiraFormProps, 'currentPath'>> & { seriesId: string },
+	{ dispatch },
+) => {
+	const path = encodeURIComponent(params.currentPath);
+
+	try {
+		const response = await axios.delete(
+			`/admin-ng/series/${params.seriesId}/tobira/${path}`,
+		);
+
+		console.info(response);
+		dispatch(addNotification({
+			type: 'success',
+			key: 'SERIES_PATH_REMOVED',
+			context: NOTIFICATION_CONTEXT_TOBIRA,
+		}));
+
+		return response.data;
+	} catch (error) {
+		console.error(error);
+		dispatch(addNotification({
+			type: 'error',
+			key: 'SERIES_PATH_NOT_REMOVED',
 			context: NOTIFICATION_CONTEXT_TOBIRA,
 		}));
 		throw error;


### PR DESCRIPTION
This modifies the UI from https://github.com/opencast/opencast-admin-interface/pull/878 to include the option to remove a series path in Tobira ("unmounting").
Needs https://github.com/opencast/opencast/pull/6317 to work.

Also fixes a minor bug and introduces icon buttons for the series path editing (see screenshots):
<img width="511" alt="Bildschirmfoto 2024-11-19 um 16 19 53" src="https://github.com/user-attachments/assets/9ce93f42-6a45-473e-b550-eb54b105a17b">
<img width="511" alt="Bildschirmfoto 2024-11-19 um 16 19 58" src="https://github.com/user-attachments/assets/df2e1a2c-5101-4046-b48d-dce7090a2b2b">
<img width="511" alt="Bildschirmfoto 2024-11-19 um 16 20 15" src="https://github.com/user-attachments/assets/b590af63-b074-4076-a898-8d790cdaa84f">
<img width="511" alt="Bildschirmfoto 2024-11-19 um 16 20 20" src="https://github.com/user-attachments/assets/cfe31bb6-f2b7-4fc1-ab13-61279fefafee">
