### PR TITLE
Use UTC consistently

### DIFF
--- a/src/slices/eventSlice.ts
+++ b/src/slices/eventSlice.ts
@@ -994,7 +994,7 @@ export const checkForConflicts = async (
 				device: device,
 				duration: duration.toString(),
 				end: endDate,
-				rrule: `FREQ=WEEKLY;BYDAY=${repeatOn.join()};BYHOUR=${startDate.getHours()};BYMINUTE=${startDate.getMinutes()}`,
+				rrule: `FREQ=WEEKLY;BYDAY=${repeatOn.join()};BYHOUR=${startDate.getUTCHours()};BYMINUTE=${startDate.getUTCMinutes()}`,
 			}
 		: {
 				start: startDate,


### PR DESCRIPTION
This PR fixes https://github.com/opencast/opencast-admin-interface/issues/942 . 

As proposed in the issue, I changed the calls to `getUTCHours` and `getUTCMinutes` which seems to have solved the issue. 

For testing try to schedule multiple events. Repeat the process and check that the error message only occurs when there really is a conflict i.e. overlapping times for the same capture agent. 