### PR TITLE
Replace MUI DatePicker with react-datepicker

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsSchedulingTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsSchedulingTab.tsx
@@ -296,6 +296,9 @@ const EventDetailsSchedulingTab = ({
 																			checkConflictsWrapper
 																		)
 																	}
+																	showYearDropdown
+																	showMonthDropdown
+																	yearDropdownItemNumber={2}
 																	dateFormat="P"
 																	popperClassName="datepicker-custom"
 																	className="datepicker-custom-input"

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsSchedulingTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsSchedulingTab.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
 import cn from "classnames";
 import _ from "lodash";
-import { DatePicker } from "@mui/x-date-pickers/DatePicker";
+import DatePicker from "react-datepicker";
 import { Formik, FormikErrors, FormikProps } from "formik";
 import { Field } from "../../../shared/Field";
 import Notifications from "../../../shared/Notifications";
@@ -195,12 +195,12 @@ const EventDetailsSchedulingTab = ({
 			: [];
 
 		return {
-			scheduleStartDate: startDate.setHours(0, 0, 0).toString(),
+			scheduleStartDate: startDate.toString(),
 			scheduleStartHour: source.start.hour != null ? makeTwoDigits(source.start.hour) : "",
 			scheduleStartMinute: source.start.minute != null ? makeTwoDigits(source.start.minute) : "",
 			scheduleDurationHours: source.duration.hour != null ? makeTwoDigits(source.duration.hour) : "",
 			scheduleDurationMinutes: source.duration.minute != null ? makeTwoDigits(source.duration.minute): "",
-			scheduleEndDate: endDate.setHours(0, 0, 0).toString(),
+			scheduleEndDate: endDate.toString(),
 			scheduleEndHour: source.end.hour != null ? makeTwoDigits(source.end.hour): "",
 			scheduleEndMinute: source.end.minute != null ? makeTwoDigits(source.end.minute): "",
 			captureAgent: source.device.name,
@@ -286,8 +286,7 @@ const EventDetailsSchedulingTab = ({
 																/* date picker for start date */
 																<DatePicker
 																	name="scheduleStartDate"
-																	// tabIndex={1}
-																	value={new Date(formik.values.scheduleStartDate)}
+																	selected={new Date(formik.values.scheduleStartDate)}
 																	onChange={(value: Date | null) =>
 																		value && changeStartDate(
 																			value,
@@ -297,6 +296,11 @@ const EventDetailsSchedulingTab = ({
 																			checkConflictsWrapper
 																		)
 																	}
+																	dateFormat="P"
+																	popperClassName="datepicker-custom"
+																	className="datepicker-custom-input"
+																	portalId="root"
+																	locale={currentLanguage?.dateLocale}
 																/>
 															) : (
 																<>

--- a/src/components/events/partials/ModalTabsAndPages/NewSourcePage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewSourcePage.tsx
@@ -460,6 +460,9 @@ const Schedule = <T extends {
 											);
 										}
 									}}
+									showYearDropdown
+									showMonthDropdown
+									yearDropdownItemNumber={2}
 									dateFormat="P"
 									popperClassName="datepicker-custom"
 									className="datepicker-custom-input"
@@ -487,6 +490,9 @@ const Schedule = <T extends {
 													formik.setFieldValue
 												)
 											}
+											showYearDropdown
+											showMonthDropdown
+											yearDropdownItemNumber={2}
 											dateFormat="P"
 											popperClassName="datepicker-custom"
 											className="datepicker-custom-input"

--- a/src/components/events/partials/ModalTabsAndPages/NewSourcePage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewSourcePage.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import cn from "classnames";
 import Notifications from "../../../shared/Notifications";
-import { DatePicker } from "@mui/x-date-pickers/DatePicker";
+import DatePicker from "react-datepicker";
 import {
 	getCurrentLanguageInformation,
 	getTimezoneOffset,
@@ -444,7 +444,7 @@ const Schedule = <T extends {
 							<td>
 								<DatePicker
 									name="scheduleStartDate"
-									value={typeof formik.values.scheduleStartDate === "string" ? parseISO(formik.values.scheduleStartDate): formik.values.scheduleStartDate}
+									selected={typeof formik.values.scheduleStartDate === "string" ? parseISO(formik.values.scheduleStartDate): formik.values.scheduleStartDate}
 									onChange={(value) => {
 										if (formik.values.sourceMode === "SCHEDULE_MULTIPLE") {
 											value && changeStartDateMultiple(
@@ -460,6 +460,11 @@ const Schedule = <T extends {
 											);
 										}
 									}}
+									dateFormat="P"
+									popperClassName="datepicker-custom"
+									className="datepicker-custom-input"
+									portalId="root"
+									locale={currentLanguage?.dateLocale}
 								/>
 							</td>
 						</tr>
@@ -474,7 +479,7 @@ const Schedule = <T extends {
 									<td>
 										<DatePicker
 											name="scheduleEndDate"
-											value={typeof formik.values.scheduleEndDate === "string" ? parseISO(formik.values.scheduleEndDate) : formik.values.scheduleEndDate}
+											selected={typeof formik.values.scheduleEndDate === "string" ? parseISO(formik.values.scheduleEndDate) : formik.values.scheduleEndDate}
 											onChange={(value) =>
 												value && changeEndDateMultiple(
 													value,
@@ -482,6 +487,11 @@ const Schedule = <T extends {
 													formik.setFieldValue
 												)
 											}
+											dateFormat="P"
+											popperClassName="datepicker-custom"
+											className="datepicker-custom-input"
+											portalId="root"
+											locale={currentLanguage?.dateLocale}
 										/>
 									</td>
 								</tr>

--- a/src/components/shared/TableFilters.tsx
+++ b/src/components/shared/TableFilters.tsx
@@ -432,6 +432,9 @@ const FilterSwitch = ({
 						startDate={startDate}
 						endDate={endDate}
 						selectsRange
+						showYearDropdown
+						showMonthDropdown
+						yearDropdownItemNumber={2}
 						swapRange
 						allowSameDay
 						dateFormat="P"

--- a/src/components/shared/TableFilters.tsx
+++ b/src/components/shared/TableFilters.tsx
@@ -1,6 +1,6 @@
-import React, { useRef, useState, useEffect } from "react";
+import React, { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { DatePicker } from "@mui/x-date-pickers/DatePicker";
+import DatePicker from "react-datepicker";
 import {
 	getFilters,
 	getSecondFilter,
@@ -26,6 +26,7 @@ import { useHotkeys } from "react-hotkeys-hook";
 import moment from "moment";
 import { AppThunk, useAppDispatch, useAppSelector } from "../../store";
 import { renderValidDate } from "../../utils/dateUtils";
+import { getCurrentLanguageInformation } from "../../utils/utils";
 import { Tooltip } from "./Tooltip";
 import DropDown from "./DropDown";
 import { AsyncThunk } from "@reduxjs/toolkit";
@@ -147,77 +148,34 @@ const TableFilters = ({
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [itemValue]);
 
-	// Set the sate of startDate and endDate picked with datepicker
-	const handleDatepickerChange = async (date: Date | null, isStart = false) => {
-		if (date === null) {
-			return;
-		}
+	const handleDatepicker = async (dates?:  [Date | undefined | null, Date | undefined | null]) => {
+		if (dates != null) {
+			let [start, end] = dates;
 
-		if (isStart) {
-			date.setHours(0);
-			date.setMinutes(0);
-			date.setSeconds(0);
-			setStartDate(date);
-		} else {
-			date.setHours(23);
-			date.setMinutes(59);
-			date.setSeconds(59);
-			setEndDate(date);
-		}
-	};
+			start?.setHours(0);
+			start?.setMinutes(0);
+			start?.setSeconds(0)
+			end?.setHours(23);
+			end?.setMinutes(59);
+			end?.setSeconds(59);
 
-	// If both dates are set, set the value for the startDate filter
-	// If the just changed, it can be passed here so we don't have wait a render
-	// cycle for the useState state to update
-	const handleDatepickerConfirm = async (date?: Date | null, isStart = false) => {
-		if (date === null) {
-			return;
-		}
-
-		let myStartDate = startDate;
-		let myEndDate = endDate;
-		if (date && isStart) {
-			myStartDate = date;
-			myStartDate.setHours(0);
-			myStartDate.setMinutes(0);
-			myStartDate.setSeconds(0);
-		}
-		if (date && !isStart) {
-			myEndDate = date;
-			myEndDate.setHours(23);
-			myEndDate.setMinutes(59);
-			myEndDate.setSeconds(59);
-		}
-
-		if (myStartDate && myEndDate && moment(myStartDate).isValid() && moment(myEndDate).isValid()) {
-			let filter = filterMap.find(({ name }) => name === selectedFilter);
-			if (filter) {
-				dispatch(editFilterValue({
-					filterName: filter.name,
-					value: myStartDate.toISOString() + "/" + myEndDate.toISOString()
-				}));
-				setFilterSelector(false);
-				dispatch(removeSelectedFilter());
-				// Reload of resource after going to very first page.
-				dispatch(goToPage(0))
-				await dispatch(loadResource());
-				dispatch(loadResourceIntoTable());
+			if (start && end && moment(start).isValid() && moment(end).isValid()) {
+				let filter = filterMap.find(({ name }) => name === selectedFilter);
+				if (filter) {
+					dispatch(editFilterValue({
+						filterName: filter.name,
+						value: start.toISOString() + "/" + end.toISOString()
+					}));
+					setFilterSelector(false);
+					dispatch(removeSelectedFilter());
+					// Reload of resource after going to very first page.
+					dispatch(goToPage(0))
+					await dispatch(loadResource());
+					dispatch(loadResourceIntoTable());
+				}
 			}
-		}
-
-		if (myStartDate && isStart && !endDate) {
-			let tmp = new Date(myStartDate.getTime());
-			tmp.setHours(23);
-			tmp.setMinutes(59);
-			tmp.setSeconds(59);
-			setEndDate(tmp);
-		}
-		if (myEndDate && !isStart && !startDate) {
-			let tmp = new Date(myEndDate.getTime());
-			tmp.setHours(0);
-			tmp.setMinutes(0);
-			tmp.setSeconds(0);
-			setStartDate(tmp);
+			if (start) setStartDate(start);
+			if (end) setEndDate(end);
 		}
 	}
 
@@ -316,8 +274,7 @@ const TableFilters = ({
 										secondFilter={secondFilter}
 										startDate={startDate}
 										endDate={endDate}
-										handleDate={handleDatepickerChange}
-										handleDateConfirm={handleDatepickerConfirm}
+										handleDate={handleDatepicker}
 										handleChange={handleChange}
 										openSecondFilterMenu={openSecondFilterMenu}
 										setOpenSecondFilterMenu={setOpenSecondFilterMenu}
@@ -399,7 +356,6 @@ const FilterSwitch = ({
 	startDate,
 	endDate,
 	handleDate,
-	handleDateConfirm,
 	secondFilter,
 	openSecondFilterMenu,
 	setOpenSecondFilterMenu,
@@ -408,16 +364,12 @@ const FilterSwitch = ({
 	handleChange: (name: string, value: string) => void,
 	startDate: Date | undefined,
 	endDate: Date | undefined,
-	handleDate: (date: Date | null, isStart?: boolean) => void,
-	handleDateConfirm: (date: Date | undefined | null, isStart?: boolean) => void,
+	handleDate: (dates: [Date | undefined | null, Date | undefined | null]) => void,
 	secondFilter: string,
 	openSecondFilterMenu: boolean,
 	setOpenSecondFilterMenu: (open: boolean) => void,
 }) => {
 	const { t } = useTranslation();
-
-	const startDateRef = useRef<HTMLInputElement>(null);
-	const endDateRef = useRef<HTMLInputElement>(null);
 
 	if (!filter) {
 		return null;
@@ -472,51 +424,23 @@ const FilterSwitch = ({
 		case "period":
 			return (
 				<div>
-					{/* Show datepicker for start date */}
 					<DatePicker
-						autoFocus={true}
-						inputRef={startDateRef}
-						className="small-search start-date"
-						value={startDate ?? null}
-						format="dd/MM/yyyy"
-						onChange={(date) => handleDate(date as Date | null, true)}
-						// FixMe: onAccept does not trigger if the already set value is the same as the selected value
-						// This prevents us from confirming from confirming our filter, if someone wants to selected the same
-						// day for both start and end date (since we automatically set one to the other)
-						onAccept={(e) => {handleDateConfirm(e as Date | null, true)}}
-						slotProps={{
-							textField: {
-								onKeyDown: (event) => {
-									if (event.key === "Enter") {
-										handleDateConfirm(undefined, true)
-										if (endDateRef.current && startDate && moment(startDate).isValid()) {
-											endDateRef.current.focus();
-										}
-									}
-								},
-							},
-						}}
-					/>
-					<DatePicker
-						inputRef={endDateRef}
-						className="small-search end-date"
-						value={endDate ?? null}
-						format="dd/MM/yyyy"
-						onChange={(date) => handleDate(date as Date | null)}
-						// FixMe: See above
-						onAccept={(e) => handleDateConfirm(e as Date | null, false)}
-						slotProps={{
-							textField: {
-								onKeyDown: (event) => {
-									if (event.key === "Enter") {
-										handleDateConfirm(undefined, false)
-										if (startDateRef.current && endDate && moment(endDate).isValid()) {
-											startDateRef.current.focus();
-										}
-									}
-								},
-							},
-						}}
+						startOpen
+						showIcon
+						icon="fa fa-calendar"
+						selected={startDate}
+						onChange={(dates) => handleDate(dates)}
+						startDate={startDate}
+						endDate={endDate}
+						selectsRange
+						swapRange
+						allowSameDay
+						dateFormat="P"
+						popperPlacement="bottom"
+						popperClassName="datepicker-custom"
+						className="datepicker-custom-input"
+						locale={getCurrentLanguageInformation()?.dateLocale}
+
 					/>
 				</div>
 			);

--- a/src/components/shared/TableFilters.tsx
+++ b/src/components/shared/TableFilters.tsx
@@ -426,8 +426,7 @@ const FilterSwitch = ({
 				<div>
 					<DatePicker
 						startOpen
-						showIcon
-						icon="fa fa-calendar"
+						autoFocus
 						selected={startDate}
 						onChange={(dates) => handleDate(dates)}
 						startDate={startDate}

--- a/src/components/shared/wizard/RenderField.tsx
+++ b/src/components/shared/wizard/RenderField.tsx
@@ -181,15 +181,13 @@ const EditableDateValue = ({
 }) => editMode ? (
 	<div>
 		<DatePicker
-			showIcon
+			autoFocus
 			selected={typeof field.value === "string" ? parseISO(field.value) : field.value}
 			onChange={(value) => setFieldValue(field.name, value)}
 			onClickOutside={() => setEditMode(false)}
-			onBlur={() => setEditMode(false)}
 			showTimeInput
 			dateFormat="Pp"
-			startOpen
-			popperPlacement="bottom"
+			popperPlacement="bottom-start"
 			popperClassName="datepicker-custom"
 			className="datepicker-custom-input"
 			wrapperClassName="datepicker-custom-wrapper"
@@ -386,16 +384,14 @@ const EditableSingleValueTime = ({
 	return editMode ? (
 		<div>
 			<DatePicker
-				showIcon
+				autoFocus
 				selected={typeof field.value === "string" ? parseISO(field.value) : field.value}
 				onChange={(value) => setFieldValue(field.name, value)}
 				onClickOutside={() => setEditMode(false)}
-				onBlur={() => setEditMode(false)}
 				showTimeSelect
       			showTimeSelectOnly
 				dateFormat="p"
-				startOpen
-				popperPlacement="bottom"
+				popperPlacement="bottom-start"
 				popperClassName="datepicker-custom"
 				className="datepicker-custom-input"
 				wrapperClassName="datepicker-custom-wrapper"

--- a/src/components/shared/wizard/RenderField.tsx
+++ b/src/components/shared/wizard/RenderField.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { DateTimePicker } from "@mui/x-date-pickers/DateTimePicker";
+import DatePicker from "react-datepicker";
 import cn from "classnames";
 import { useClickOutsideField } from "../../../hooks/wizardHooks";
 import { getMetadataCollectionFieldName } from "../../../utils/resourceUtils";
+import { getCurrentLanguageInformation } from "../../../utils/utils";
 import DropDown, { DropDownType } from "../DropDown";
 import RenderDate from "../RenderDate";
 import { parseISO } from "date-fns";
@@ -179,24 +180,20 @@ const EditableDateValue = ({
 	handleKeyDown: (event: React.KeyboardEvent, type: string) => void
 }) => editMode ? (
 	<div>
-		<DateTimePicker
-			name={field.name}
-			value={typeof field.value === "string" ? parseISO(field.value) : field.value}
+		<DatePicker
+			showIcon
+			selected={typeof field.value === "string" ? parseISO(field.value) : field.value}
 			onChange={(value) => setFieldValue(field.name, value)}
-			onClose={() => setEditMode(false)}
-			slotProps={{
-				textField: {
-					fullWidth: true,
-					onKeyDown: (event) => {
-						if (event.key === "Enter") {
-							handleKeyDown(event, "date")
-						}
-					},
-					onBlur: (event) => {
-						setEditMode(false)
-					}
-				}
-			}}
+			onClickOutside={() => setEditMode(false)}
+			onBlur={() => setEditMode(false)}
+			showTimeInput
+			dateFormat="Pp"
+			startOpen
+			popperPlacement="bottom"
+			popperClassName="datepicker-custom"
+			className="datepicker-custom-input"
+			wrapperClassName="datepicker-custom-wrapper"
+			locale={getCurrentLanguageInformation()?.dateLocale}
 		/>
 	</div>
 ) : (
@@ -388,24 +385,21 @@ const EditableSingleValueTime = ({
 
 	return editMode ? (
 		<div>
-			<DateTimePicker
-				name={field.name}
-				value={parseISO(field.value)}
+			<DatePicker
+				showIcon
+				selected={typeof field.value === "string" ? parseISO(field.value) : field.value}
 				onChange={(value) => setFieldValue(field.name, value)}
-				onClose={() => setEditMode(false)}
-				slotProps={{
-					textField: {
-						fullWidth: true,
-						onKeyDown: (event) => {
-							if (event.key === "Enter") {
-								handleKeyDown(event, "date")
-							}
-						},
-						onBlur: () => {
-							setEditMode(false)
-						}
-					}
-				}}
+				onClickOutside={() => setEditMode(false)}
+				onBlur={() => setEditMode(false)}
+				showTimeSelect
+      			showTimeSelectOnly
+				dateFormat="p"
+				startOpen
+				popperPlacement="bottom"
+				popperClassName="datepicker-custom"
+				className="datepicker-custom-input"
+				wrapperClassName="datepicker-custom-wrapper"
+				locale={getCurrentLanguageInformation()?.dateLocale}
 			/>
 		</div>
 	) : (

--- a/src/components/shared/wizard/RenderField.tsx
+++ b/src/components/shared/wizard/RenderField.tsx
@@ -186,6 +186,9 @@ const EditableDateValue = ({
 			onChange={(value) => setFieldValue(field.name, value)}
 			onClickOutside={() => setEditMode(false)}
 			showTimeInput
+			showYearDropdown
+			showMonthDropdown
+			yearDropdownItemNumber={2}
 			dateFormat="Pp"
 			popperPlacement="bottom-start"
 			popperClassName="datepicker-custom"

--- a/src/styles/components/_datepicker-custom.scss
+++ b/src/styles/components/_datepicker-custom.scss
@@ -18,7 +18,7 @@
  * the License.
  *
  */
-
+ @use "sass:color";
 
  .datepicker-custom {
     z-index: 10000 !important;
@@ -30,4 +30,32 @@
     &-input {
       height: 25px !important;
     }
- }
+  }
+
+ .react-datepicker__navigation--years {
+    &::before {
+      border-color: #ccc;
+      border-style: solid;
+      border-width: 3px 3px 0 0;
+      content: '';
+      display: block;
+      height: 9px;
+      left: 11px;
+      position: absolute;
+      width: 9px;
+    }
+
+    &-upcoming::before {
+      top: 17px;
+      transform: rotate(315deg);
+    }
+
+    &-previous::before {
+      top: 6px;
+      transform: rotate(135deg);
+    }
+
+    &:hover::before {
+      border-color: color.adjust(#ccc, $lightness: -15%);
+    }
+  }

--- a/src/styles/components/_datepicker-custom.scss
+++ b/src/styles/components/_datepicker-custom.scss
@@ -20,36 +20,14 @@
  */
 
 
-@import "simple-box";
-@import "helper-classes";
-@import "cal";
-@import "ui";
-@import "dropdowns";
-@import "menu-dropdown";
-@import "form";
-@import "multi-select";
-@import "steps";
-@import "breadcrumbs";
-@import "header";
-@import "menu";
-@import "footer";
-@import "tables";
-@import "date-picker";
-@import "datepicker-custom";
-@import "alerts";
-@import "inputs";
-@import "stats";
-@import "popover";
-@import "collapsible-box";
-@import "about";
-@import "tooltips";
+ .datepicker-custom {
+    z-index: 10000 !important;
 
-// Integrated From Extensions
-@import "labels";
-@import "progress-bar";
-@import "toggle-buttons";
-@import "statistics-graph";
+    &-wrapper {
+      width: 100%;
+    }
 
-// Large Components
-@import "modals/modals-config";
-@import "data-filter/data-filter-config";
+    &-input {
+      height: 25px !important;
+    }
+ }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -23,7 +23,11 @@ export const getCurrentLanguageInformation = () => {
 	// Get code, flag, name and date locale of the current language
 	let currentLang = languages.find(({ code }) => code === i18n.language);
 	if (typeof currentLang === "undefined") {
-		currentLang = languages.find(({ code }) => code === "en-US");
+		// If detected language code, like "de-CH", isn't part of translations try 2-digit language code
+		currentLang = languages.find(({ code }) => code === i18n.language.split("-")[0]);
+		if (typeof currentLang === "undefined") {
+			currentLang = languages.find(({ code }) => code === "en-US");
+		}
 	}
 
 	return currentLang;


### PR DESCRIPTION
This PR fixes #948 #920 #614 and, as mentioned in https://github.com/opencast/opencast-admin-interface/issues/614#issuecomment-2491486182, the react-datepicker brings also some advantages over the MUI DatePicker.

With this PR, there is still the statistics component that uses the MUI DatePicker. I haven't been able to replace it because the stats feature doesn't work properly in the new admin UI, see https://github.com/opencast/opencast-admin-interface/issues/282. Once this is working again, the MUI DatePicker can also be replaced there and the dependencies can be cleaned up.