### PR TITLE
Fix pipelines adding comments

### DIFF
--- a/.github/workflows/deploy-container-image.yaml
+++ b/.github/workflows/deploy-container-image.yaml
@@ -50,7 +50,7 @@ jobs:
         if: github.event_name == 'pull_request_target'
         uses: thollander/actions-comment-pull-request@v3
         with:
-          comment_tag: container-image
+          comment-tag: container-image
           message: |
             Use `docker` or `podman` to test this pull request locally.
 

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -98,7 +98,7 @@ jobs:
       - name: add comment with deployment location
         uses: thollander/actions-comment-pull-request@v3
         with:
-          comment_tag: static-test-deployment
+          comment-tag: static-test-deployment
           message: >
             This pull request is deployed at
             [test.admin-interface.opencast.org/${{ steps.build-path.outputs.build }}


### PR DESCRIPTION
When updating `thollander/actions-comment-pull-request` to `v3`, the underscore in `comment_tag` no longer works because now it's a dash, and we have to use `comment-tag`. The README.md was fixed with this PR https://github.com/thollander/actions-comment-pull-request/issues/397.

The pipeline will be fixed AFTER merging this... :D