### PR TITLE
Fix "invalid scale configuration" error and more

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5500,9 +5500,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.5.tgz",
+      "integrity": "sha512-ZVJrKKYunU38/76t0RMOulHOnUcbU9GbpWKAOZ0mhjr7CX6FVrH+4FrAapSOekrgFQ3f/8gwMEuIft0aKq6Hug==",
       "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsStatisticsTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsStatisticsTab.tsx
@@ -4,9 +4,10 @@ import {
 	hasStatisticsError,
 } from "../../../../selectors/eventDetailsSelectors";
 import TimeSeriesStatistics from "../../../shared/TimeSeriesStatistics";
-import { useAppDispatch, useAppSelector } from "../../../../store";
+import { useAppSelector } from "../../../../store";
 import { fetchEventStatisticsValueUpdate } from "../../../../slices/eventDetailsSlice";
 import { useTranslation } from "react-i18next";
+import { createChartOptions } from "../../../../utils/statisticsUtils";
 
 /**
  * This component manages the statistics tab of the event details modal
@@ -19,15 +20,9 @@ const EventDetailsStatisticsTab = ({
 	header: string,
 }) => {
 	const { t } = useTranslation();
-	const dispatch = useAppDispatch();
 
 	const statistics = useAppSelector(state => getStatistics(state));
 	const hasError = useAppSelector(state => hasStatisticsError(state));
-
-	// TODO: Get rid of the wrappers when modernizing redux is done
-	const fetchEventStatisticsValueUpdateWrapper = (eventId: any, providerId: any, from: any, to: any, dataResolution: any, timeMode: any) => {
-		dispatch(fetchEventStatisticsValueUpdate({eventId, providerId, from, to, dataResolution, timeMode}));
-	}
 
 	/* generates file name for download-link for a statistic */
 	const statisticsCsvFileName = (statsTitle: string) => {
@@ -68,13 +63,13 @@ const EventDetailsStatisticsTab = ({
 											timeMode={stat.timeMode}
 											dataResolution={stat.dataResolution}
 											statDescription={stat.description}
-											onChange={fetchEventStatisticsValueUpdateWrapper}
+											onChange={fetchEventStatisticsValueUpdate}
 											exportUrl={stat.csvUrl}
 											exportFileName={statisticsCsvFileName}
 											totalValue={stat.totalValue}
 											sourceData={stat.values}
 											chartLabels={stat.labels}
-											chartOptions={stat.options}
+											chartOptions={createChartOptions(stat.timeMode, stat.dataResolution)}
 										/>
 									</div>
 								) : (

--- a/src/components/events/partials/ModalTabsAndPages/SeriesDetailsStatisticTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/SeriesDetailsStatisticTab.tsx
@@ -6,7 +6,8 @@ import {
 } from "../../../../selectors/seriesDetailsSelectors";
 import { fetchSeriesStatisticsValueUpdate } from "../../../../slices/seriesDetailsSlice";
 import TimeSeriesStatistics from "../../../shared/TimeSeriesStatistics";
-import { useAppDispatch, useAppSelector } from "../../../../store";
+import { useAppSelector } from "../../../../store";
+import { createChartOptions } from "../../../../utils/statisticsUtils";
 
 const SeriesDetailsStatisticTab = ({
 	seriesId,
@@ -16,15 +17,9 @@ const SeriesDetailsStatisticTab = ({
 	header: string,
 }) => {
 	const { t } = useTranslation();
-	const dispatch = useAppDispatch();
 
 	const statistics = useAppSelector(state => getStatistics(state));
 	const hasError = useAppSelector(state => hasStatisticsError(state));
-
-		// TODO: Get rid of the wrappers when modernizing redux is done
-		const fetchSeriesStatisticsValueUpdateWrapper = (seriesId: any, providerId: any, from: any, to: any, dataResolution: any, timeMode: any) => {
-			dispatch(fetchSeriesStatisticsValueUpdate({seriesId, providerId, from, to, dataResolution, timeMode}));
-		}
 
 	/* generates file name for download-link for a statistic */
 	const statisticsCsvFileName = (statsTitle: string) => {
@@ -65,13 +60,13 @@ const SeriesDetailsStatisticTab = ({
 											timeMode={stat.timeMode}
 											dataResolution={stat.dataResolution}
 											statDescription={stat.description}
-											onChange={fetchSeriesStatisticsValueUpdateWrapper}
+											onChange={fetchSeriesStatisticsValueUpdate}
 											exportUrl={stat.csvUrl}
 											exportFileName={statisticsCsvFileName}
 											totalValue={stat.totalValue}
 											sourceData={stat.values}
 											chartLabels={stat.labels}
-											chartOptions={stat.options}
+											chartOptions={createChartOptions(stat.timeMode, stat.dataResolution)}
 										/>
 									</div>
 								) : (

--- a/src/components/shared/BarChart.tsx
+++ b/src/components/shared/BarChart.tsx
@@ -1,6 +1,10 @@
 import React from "react";
 import { Bar } from "react-chartjs-2";
-import type { ChartDataset, ChartOptions } from 'chart.js';
+import type { ChartData, ChartOptions } from 'chart.js';
+import { Chart, registerables } from 'chart.js'
+
+Chart.register(...registerables)
+
 
 /**
  * This component provides a bar chart for visualising (statistics) data
@@ -10,11 +14,11 @@ const BarChart = ({
 	axisLabels,
 	options
 }: {
-	values: ChartDataset<'bar'>,
+	values: number[],
 	axisLabels: string[],
 	options: ChartOptions<'bar'>,
 }) => {
-	const data = {
+	const data: ChartData<'bar'> = {
 		labels: axisLabels,
 		datasets: [
 			{

--- a/src/components/statistics/Statistics.tsx
+++ b/src/components/statistics/Statistics.tsx
@@ -25,6 +25,7 @@ import {
 	fetchStatisticsPageStatistics,
 	fetchStatisticsPageStatisticsValueUpdate,
 } from "../../slices/statisticsSlice";
+import { createChartOptions } from "../../utils/statisticsUtils";
 
 const Statistics: React.FC = () => {
 	const { t } = useTranslation();
@@ -39,18 +40,15 @@ const Statistics: React.FC = () => {
 	const hasError = useAppSelector(state => hasStatisticsError(state));
 	const isLoadingStatistics = useAppSelector(state => isFetchingStatistics(state));
 
-	// TODO: Get rid of the wrappers when modernizing redux is done
-	const fetchStatisticsPageStatisticsValueUpdateWrapper = (organizationId: any, providerId: any, from: any, to: any, dataResolution: any, timeMode: any) => {
-		dispatch(fetchStatisticsPageStatisticsValueUpdate({organizationId, providerId, from, to, dataResolution, timeMode}))
-	}
-
+	// fetch user information for organization id, then fetch statistics
 	useEffect(() => {
-		// fetch user information for organization id, then fetch statistics
-		dispatch(fetchUserInfo()).then(() => {
-			dispatch(fetchStatisticsPageStatistics(organizationId)).then();
-		})
+		dispatch(fetchUserInfo())
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
+	useEffect(() => {
+			dispatch(fetchStatisticsPageStatistics(organizationId)).then();
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [organizationId]);
 
 	const toggleNavigation = () => {
 		setNavigation(!displayNavigation);
@@ -71,7 +69,7 @@ const Statistics: React.FC = () => {
 	};
 
 	return (
-                <span>
+		<span>
 			<Header />
 			<NavBar>
 				{/* Include Burger-button menu */}
@@ -128,13 +126,13 @@ const Statistics: React.FC = () => {
 												timeMode={stat.timeMode}
 												dataResolution={stat.dataResolution}
 												statDescription={stat.description}
-												onChange={fetchStatisticsPageStatisticsValueUpdateWrapper}
+												onChange={fetchStatisticsPageStatisticsValueUpdate}
 												exportUrl={stat.csvUrl}
 												exportFileName={statisticsCsvFileName}
 												totalValue={stat.totalValue}
 												sourceData={stat.values}
 												chartLabels={stat.labels}
-												chartOptions={stat.options}
+												chartOptions={createChartOptions(stat.timeMode, stat.dataResolution)}
 											/>
 										</div>
 									) : (

--- a/src/configs/statisticsConfig.ts
+++ b/src/configs/statisticsConfig.ts
@@ -17,9 +17,14 @@ export const statisticTimeModes = [
 ];
 
 // data resolutions (or time granularity) for statistics with year or month timeframe
-export const fixedStatisticDataResolutions = {
-	month: "daily",
-	year: "monthly",
+export const fixedStatisticDataResolutions = (timeMode: "month" | "year") => {
+	if (timeMode === "month") {
+		return "daily"
+	}
+	if (timeMode === "year") {
+		return "monthly"
+	}
+	return "monthly"
 };
 
 // available data resolutions (or time granularity) for statistics with custom timeframe

--- a/src/slices/eventDetailsSlice.ts
+++ b/src/slices/eventDetailsSlice.ts
@@ -26,7 +26,7 @@ import { calculateDuration } from "../utils/dateUtils";
 import { fetchRecordings } from "./recordingSlice";
 import { getRecordings } from "../selectors/recordingSelectors";
 import { createAppAsyncThunk } from '../createAsyncThunkWithTypes';
-import { Statistics, fetchStatistics, fetchStatisticsValueUpdate } from './statisticsSlice';
+import { DataResolution, Statistics, TimeMode, fetchStatistics, fetchStatisticsValueUpdate } from './statisticsSlice';
 import { TransformedAcl } from './aclDetailsSlice';
 import { MetadataCatalog } from './eventSlice';
 import { Event } from "./eventSlice";
@@ -1535,21 +1535,21 @@ export const fetchEventStatistics = createAppAsyncThunk('eventDetails/fetchEvent
 
 // TODO: Fix this after the modernization of statisticsThunks happened
 export const fetchEventStatisticsValueUpdate = createAppAsyncThunk('eventDetails/fetchEventStatisticsValueUpdate', async (params: {
-	eventId: string,
+	id: string,
 	providerId: string,
-	from: string,
-	to: string,
-	dataResolution: string[],
-	timeMode: any
+	from: string | Date,
+	to: string | Date,
+	dataResolution: DataResolution,
+	timeMode: TimeMode
 }, { getState }) => {
-	const { eventId, providerId, from, to, dataResolution, timeMode } = params;
+	const { id, providerId, from, to, dataResolution, timeMode } = params;
 	// get prior statistics
 	const state = getState();
 	const statistics = getStatistics(state);
 
 	return await (
 		fetchStatisticsValueUpdate(
-			eventId,
+			id,
 			"episode",
 			providerId,
 			from,
@@ -2499,7 +2499,7 @@ const eventDetailsSlice = createSlice({
 			})
 			//fetchEventStatisticsValueUpdate
 			.addCase(fetchEventStatisticsValueUpdate.pending, (state) => {
-				state.statusStatistics = 'loading';
+				state.statusStatisticsValue = 'loading';
 			})
 			.addCase(fetchEventStatisticsValueUpdate.fulfilled, (state, action: PayloadAction<
 				any

--- a/src/slices/seriesDetailsSlice.ts
+++ b/src/slices/seriesDetailsSlice.ts
@@ -16,7 +16,7 @@ import {
 import { transformToIdValueArray } from "../utils/utils";
 import { NOTIFICATION_CONTEXT } from "../configs/modalConfig";
 import { createAppAsyncThunk } from '../createAsyncThunkWithTypes';
-import { Statistics, fetchStatistics, fetchStatisticsValueUpdate } from './statisticsSlice';
+import { DataResolution, Statistics, TimeMode, fetchStatistics, fetchStatisticsValueUpdate } from './statisticsSlice';
 import { Ace } from './aclSlice';
 import { TransformedAcl } from './aclDetailsSlice';
 import { MetadataCatalog } from './eventSlice';
@@ -467,14 +467,14 @@ export const fetchSeriesStatistics = createAppAsyncThunk('seriesDetails/fetchSer
 });
 
 export const fetchSeriesStatisticsValueUpdate = createAppAsyncThunk('seriesDetails/fetchSeriesStatisticsValueUpdate', async (params: {
-	seriesId: string,
+	id: string,
 	providerId: string,
-	from: string,
-	to: string,
-	dataResolution: string[],
-	timeMode: any
+	from: string | Date,
+	to: string | Date,
+	dataResolution: DataResolution,
+	timeMode: TimeMode
 }, {getState}) => {
-	const {seriesId, providerId, from, to, dataResolution, timeMode } = params;
+	const {id, providerId, from, to, dataResolution, timeMode } = params;
 
 	// get prior statistics
 	const state = getState();
@@ -482,7 +482,7 @@ export const fetchSeriesStatisticsValueUpdate = createAppAsyncThunk('seriesDetai
 
 	return await (
 		fetchStatisticsValueUpdate(
-			seriesId,
+			id,
 			"series",
 			providerId,
 			from,

--- a/src/styles/components/_statistics-graph.scss
+++ b/src/styles/components/_statistics-graph.scss
@@ -88,8 +88,8 @@
   .total {
     float: left;
     position: absolute;
-    padding-top: 14px;
-    padding-left: 70px;
+    padding-top: 17px;
+    padding-left: 20px;
     font-size: 12px;
   }
 


### PR DESCRIPTION
Fixes #282.

The statistics page (and statistics tab in the event and series details) is currently broken. The web console shows the error "Invalid scale configuration for scale: XAxes".

This fixes the error and a few less critical bugs to get the statistics page up and running again.

Unfortunately, testing this is not straightforward. To thoroughly test this, you would need an Opencast with a statistics provider set up and configured, which is more difficult than it sounds. The interested may check the docs: https://docs.opencast.org/develop/admin/#configuration/admin-ui/statistics/