### PR TITLE
Sort series table by date per default

### DIFF
--- a/src/thunks/tableThunks.ts
+++ b/src/thunks/tableThunks.ts
@@ -139,8 +139,8 @@ export const loadSeriesIntoTable = (): AppThunk => (dispatch, getState) => {
 
 		tableData = {
 			...tableData,
-			sortBy: "title",
-			reverse: "ASC",
+			sortBy: "createdDateTime",
+			reverse: "DESC",
 			multiSelect: multiSelect,
 		};
 	}


### PR DESCRIPTION
Changes the default sorting order of the series table from title to the created date. This brings it in line with the events table and should generally prove a more useful default.

### How to test this

PR can be tested as is, no other dependencies or configuration necessary.