### PR TITLE
Remember table sorting

### DIFF
--- a/src/selectors/tableSelectors.ts
+++ b/src/selectors/tableSelectors.ts
@@ -14,8 +14,8 @@ export const getPageLimit = (state: RootState) => state.table.pagination.limit;
 export const getPageOffset = (state: RootState) => state.table.pagination.offset;
 export const getNumberDirectAccessiblePages = (state: RootState) => state.table.pagination.directAccessibleNo;
 export const getResourceType = (state: RootState) => state.table.resource;
-export const getTableSorting = (state: RootState) => state.table.sortBy;
-export const getTableDirection = (state: RootState) => state.table.reverse;
+export const getTableSorting = (state: RootState) => state.table.sortBy[state.table.resource];
+export const getTableDirection = (state: RootState) => state.table.reverse[state.table.resource];
 export const getTable = (state: RootState) => state.table;
 export const getDeactivatedColumns = (state: RootState) =>
 	state.table.columns.filter((column) => column.deactivated);

--- a/src/slices/tableSlice.ts
+++ b/src/slices/tableSlice.ts
@@ -77,9 +77,9 @@ type TableState = {
 	resource: string,
 	pages: Page[],
 	columns: TableConfig["columns"],
-	sortBy: string,
+	sortBy: { [key: string]: string },  // Key is resource, value is actual sorting parameter
 	predicate: string,
-	reverse: string,
+	reverse: { [key: string]: string },  // Key is resource, value is actual sorting parameter
 	rows: Row[],
 	maxLabel: string,
 	pagination: Pagination,
@@ -93,9 +93,31 @@ const initialState: TableState = {
 	resource: "",
 	pages: [],
 	columns: [],
-	sortBy: "date",
+	sortBy: {
+		events: "date",
+		series: "createdDateTime",
+		recordings: "status",
+		jobs: "id",
+		servers: "online",
+		services: "status",
+		users: "name",
+		groups: "name",
+		acls: "name",
+		themes: "name",
+	},
 	predicate: "",
-	reverse: "DESC",
+	reverse: {
+		events: "DESC",
+		series: "DESC",
+		recordings: "ASC",
+		jobs: "ASC",
+		servers: "ASC",
+		services: "ASC",
+		users: "ASC",
+		groups: "ASC",
+		acls: "ASC",
+		theme: "ASC",
+	},
 	rows: [],
 	maxLabel: "",
 	pagination: {
@@ -116,8 +138,8 @@ const tableSlice = createSlice({
 			resource: TableState["resource"],
 			pages: TableState["pages"],
 			rows: TableState["rows"],
-			sortBy: TableState["sortBy"],
-			reverse: TableState["reverse"],
+			sortBy: TableState["sortBy"][0],
+			reverse: TableState["reverse"][0],
 			totalItems: TableState["pagination"]["totalItems"],
 		}>) {
 			state.multiSelect = action.payload.multiSelect;
@@ -125,8 +147,8 @@ const tableSlice = createSlice({
 			state.resource = action.payload.resource;
 			state.pages = action.payload.pages;
 			state.rows = action.payload.rows;
-			state.sortBy = action.payload.sortBy;
-			state.reverse = action.payload.reverse;
+			state.sortBy[action.payload.resource] = action.payload.sortBy;
+			state.reverse[action.payload.resource] = action.payload.reverse;
 			state.pagination = {
 				...state.pagination,
 				totalItems: action.payload.totalItems,
@@ -168,14 +190,14 @@ const tableSlice = createSlice({
 			})
 		},
 		reverseTable(state, action: PayloadAction<
-			TableState["reverse"]
+			TableState["reverse"][0]
 		>) {
-			state.reverse = action.payload;
+			state.reverse[state.resource] = action.payload;
 		},
 		setSortBy(state, action: PayloadAction<
-			TableState["sortBy"]
+			TableState["sortBy"][0]
 		>) {
-			state.sortBy = action.payload;
+			state.sortBy[state.resource] = action.payload;
 		},
 		createPage(state, action: PayloadAction<
 			Page

--- a/src/thunks/tableThunks.ts
+++ b/src/thunks/tableThunks.ts
@@ -80,8 +80,8 @@ export const loadEventsIntoTable = (): AppThunk => async (dispatch, getState) =>
 		columns: events.columns,
 		multiSelect: table.multiSelect,
 		pages: pages,
-		sortBy: table.sortBy,
-		reverse: table.reverse,
+		sortBy: table.sortBy["events"],
+		reverse: table.reverse["events"],
 		totalItems: total,
 	};
 
@@ -90,8 +90,6 @@ export const loadEventsIntoTable = (): AppThunk => async (dispatch, getState) =>
 
 		tableData = {
 			...tableData,
-			sortBy: "date",
-			reverse: "DESC",
 			multiSelect: multiSelect,
 		};
 	}
@@ -129,8 +127,8 @@ export const loadSeriesIntoTable = (): AppThunk => (dispatch, getState) => {
 		columns: series.columns,
 		multiSelect: table.multiSelect,
 		pages: pages,
-		sortBy: table.sortBy,
-		reverse: table.reverse,
+		sortBy: table.sortBy["series"],
+		reverse: table.reverse["series"],
 		totalItems: total,
 	};
 
@@ -139,8 +137,6 @@ export const loadSeriesIntoTable = (): AppThunk => (dispatch, getState) => {
 
 		tableData = {
 			...tableData,
-			sortBy: "title",
-			reverse: "ASC",
 			multiSelect: multiSelect,
 		};
 	}
@@ -160,8 +156,8 @@ export const loadRecordingsIntoTable = (): AppThunk => (dispatch, getState) => {
 		columns: recordings.columns,
 		multiSelect: table.multiSelect,
 		pages: pages,
-		sortBy: table.sortBy,
-		reverse: table.reverse,
+		sortBy: table.sortBy["recordings"],
+		reverse: table.reverse["recordings"],
 		rows: resource.map((obj) => {
 			return { ...obj, selected: false }
 		}),
@@ -173,8 +169,6 @@ export const loadRecordingsIntoTable = (): AppThunk => (dispatch, getState) => {
 
 		tableData = {
 			...tableData,
-			sortBy: "status",
-			reverse: "ASC",
 			multiSelect: multiSelect,
 		};
 	}
@@ -198,8 +192,8 @@ export const loadJobsIntoTable = (): AppThunk => (dispatch, getState) => {
 		columns: jobs.columns,
 		multiSelect: table.multiSelect,
 		pages: pages,
-		sortBy: table.sortBy,
-		reverse: table.reverse,
+		sortBy: table.sortBy["jobs"],
+		reverse: table.reverse["jobs"],
 		totalItems: total,
 	};
 
@@ -208,8 +202,6 @@ export const loadJobsIntoTable = (): AppThunk => (dispatch, getState) => {
 
 		tableData = {
 			...tableData,
-			sortBy: "id",
-			reverse: "ASC",
 			multiSelect: multiSelect,
 		};
 	}
@@ -232,8 +224,8 @@ export const loadServersIntoTable = (): AppThunk => (dispatch, getState) => {
 		columns: servers.columns,
 		multiSelect: table.multiSelect,
 		pages: pages,
-		sortBy: table.sortBy,
-		reverse: table.reverse,
+		sortBy: table.sortBy["servers"],
+		reverse: table.reverse["servers"],
 		totalItems: total,
 	};
 
@@ -242,8 +234,6 @@ export const loadServersIntoTable = (): AppThunk => (dispatch, getState) => {
 
 		tableData = {
 			...tableData,
-			sortBy: "online",
-			reverse: "ASC",
 			multiSelect: multiSelect,
 		};
 	}
@@ -267,8 +257,8 @@ export const loadServicesIntoTable = (): AppThunk => (dispatch, getState) => {
 		resource: "services",
 		columns: services.columns,
 		multiSelect: table.multiSelect,
-		sortBy: table.sortBy,
-		reverse: table.reverse,
+		sortBy: table.sortBy["services"],
+		reverse: table.reverse["services"],
 	};
 
 	if (table.resource !== "services") {
@@ -276,8 +266,6 @@ export const loadServicesIntoTable = (): AppThunk => (dispatch, getState) => {
 
 		tableData = {
 			...tableData,
-			sortBy: "status",
-			reverse: "ASC",
 			multiSelect: multiSelect,
 		};
 	}
@@ -301,8 +289,8 @@ export const loadUsersIntoTable = (): AppThunk => (dispatch, getState) => {
 		columns: users.columns,
 		multiSelect: table.multiSelect,
 		pages: pages,
-		sortBy: table.sortBy,
-		reverse: table.reverse,
+		sortBy: table.sortBy["users"],
+		reverse: table.reverse["users"],
 		totalItems: total,
 	};
 
@@ -311,8 +299,6 @@ export const loadUsersIntoTable = (): AppThunk => (dispatch, getState) => {
 
 		tableData = {
 			...tableData,
-			sortBy: "name",
-			reverse: "ASC",
 			multiSelect: multiSelect,
 		};
 	}
@@ -335,8 +321,8 @@ export const loadGroupsIntoTable = (): AppThunk => (dispatch, getState) => {
 		columns: groups.columns,
 		multiSelect: table.multiSelect,
 		pages: pages,
-		sortBy: table.sortBy,
-		reverse: table.reverse,
+		sortBy: table.sortBy["groups"],
+		reverse: table.reverse["groups"],
 		totalItems: total,
 	};
 
@@ -345,8 +331,6 @@ export const loadGroupsIntoTable = (): AppThunk => (dispatch, getState) => {
 
 		tableData = {
 			...tableData,
-			sortBy: "name",
-			reverse: "ASC",
 			multiSelect: multiSelect,
 		};
 	}
@@ -369,8 +353,8 @@ export const loadAclsIntoTable = (): AppThunk => (dispatch, getState) => {
 		columns: acls.columns,
 		multiSelect: table.multiSelect,
 		pages: pages,
-		sortBy: table.sortBy,
-		reverse: table.reverse,
+		sortBy: table.sortBy["acls"],
+		reverse: table.reverse["acls"],
 		totalItems: total,
 	};
 
@@ -378,8 +362,6 @@ export const loadAclsIntoTable = (): AppThunk => (dispatch, getState) => {
 		const multiSelect = aclsTableConfig.multiSelect;
 		tableData = {
 			...tableData,
-			sortBy: "name",
-			reverse: "ASC",
 			multiSelect: multiSelect,
 		};
 	}
@@ -402,8 +384,8 @@ export const loadThemesIntoTable = (): AppThunk => (dispatch, getState) => {
 		columns: themes.columns,
 		multiSelect: table.multiSelect,
 		pages: pages,
-		sortBy: table.sortBy,
-		reverse: table.reverse,
+		sortBy: table.sortBy["themes"],
+		reverse: table.reverse["themes"],
 		totalItems: total,
 	};
 
@@ -412,8 +394,6 @@ export const loadThemesIntoTable = (): AppThunk => (dispatch, getState) => {
 
 		tableData = {
 			...tableData,
-			sortBy: "name",
-			reverse: "ASC",
 			multiSelect: multiSelect,
 		};
 	}


### PR DESCRIPTION
Tables can be sorted by columns, ascending or descending. However, when switching to a different tab and back again, the sorting reverts to the default. With this change, the sorting is remembered.

Does not persist the sorting, meaning it still reverts to the default after a page reload. I did not do this because the only to way to get rid of persisted sorting would be to the clear the browsers cache, and I did not want alienate people.

Also sneakily changes the default sorting of the series table in the same way as #1008.

### How to test this

PR can be tested as is, no other dependencies or configuration necessary.

[Bildschirmaufzeichnung vom 2024-12-12 11-44-03.webm](https://github.com/user-attachments/assets/e6366bd7-a733-4324-ad17-b4c3e3beae9a)
