### PR TITLE
Fix workflow selection for scheduled events

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowTab.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import { Formik, FormikErrors } from "formik";
+import { Formik } from "formik";
 import {
 	deletingWorkflow as getDeletingWorkflow,
 	getBaseWorkflow,
@@ -14,7 +14,6 @@ import Notifications from "../../../shared/Notifications";
 import RenderWorkflowConfig from "../wizards/RenderWorkflowConfig";
 import { getUserInformation } from "../../../../selectors/userInfoSelectors";
 import { hasAccess, parseBooleanInObject } from "../../../../utils/utils";
-import { setDefaultConfig } from "../../../../utils/workflowPanelUtils";
 import DropDown from "../../../shared/DropDown";
 import { useAppDispatch, useAppSelector } from "../../../../store";
 import {
@@ -24,7 +23,6 @@ import {
 	saveWorkflowConfig,
 	setModalWorkflowId,
 	setModalWorkflowTabHierarchy,
-	updateWorkflow,
 } from "../../../../slices/eventDetailsSlice";
 import { removeNotificationWizardForm } from "../../../../slices/notificationSlice";
 import { renderValidDate } from "../../../../utils/dateUtils";
@@ -94,20 +92,6 @@ const EventDetailsWorkflowTab = ({
 	const hasCurrentAgentAccess = () => {
 		//todo
 		return true;
-	};
-
-	const changeWorkflow = (value: string, changeFormikValue: (field: string, value: unknown) => Promise<void | FormikErrors<any>>) => {
-		let currentConfiguration = {};
-
-		if (value === baseWorkflow.workflowId) {
-			currentConfiguration = parseBooleanInObject(baseWorkflow.configuration as { [key: string]: any });
-		} else {
-			currentConfiguration = setDefaultConfig(workflowDefinitions, value);
-		}
-
-		changeFormikValue("configuration", currentConfiguration);
-		changeFormikValue("workflowDefinition", value);
-		dispatch(updateWorkflow(value));
 	};
 
 	const setInitialValues = () => {
@@ -357,10 +341,7 @@ const EventDetailsWorkflowTab = ({
 																					required={true}
 																					handleChange={(element) => {
 																						if (element) {
-																							changeWorkflow(
-																								element.value,
-																								formik.setFieldValue
-																							)
+																							formik.setFieldValue("workflowDefinition", element.value)
 																						}
 																					}}
 																					placeholder={
@@ -453,10 +434,6 @@ const EventDetailsWorkflowTab = ({
 																<button
 																	type="reset"
 																	onClick={() => {
-																		changeWorkflow(
-																			baseWorkflow.workflowId,
-																			formik.setFieldValue
-																		);
 																		formik.resetForm();
 																	}}
 																	disabled={!formik.isValid}

--- a/src/slices/eventDetailsSlice.ts
+++ b/src/slices/eventDetailsSlice.ts
@@ -13,7 +13,6 @@ import {
 	getMetadata,
 	getExtendedMetadata,
 	getSchedulingSource,
-	getWorkflowDefinitions,
 	getWorkflows,
 	getStatistics,
 } from "../selectors/eventDetailsSelectors";
@@ -1841,19 +1840,6 @@ export const deleteCommentReply = createAppAsyncThunk('eventDetails/deleteCommen
 	return true;
 });
 
-export const updateWorkflow = createAppAsyncThunk('eventDetails/updateWorkflow', async (workflowId: string, { dispatch, getState }) => {
-	const state = getState();
-	const workflowDefinitions = getWorkflowDefinitions(state);
-	const workflowDef = workflowDefinitions.find((def) => def.id === workflowId);
-	await dispatch(
-		setEventWorkflow({
-			workflowId: workflowId,
-			description: workflowDef?.description,
-			configuration: workflowDef?.configuration_panel_json // previously `workflowDef.configuration`. Might cause error
-		})
-	);
-});
-
 export const saveWorkflowConfig = createAppAsyncThunk('eventDetails/saveWorkflowConfig', async (params: {
 	values: {
 		workflowDefinition: string,
@@ -2564,13 +2550,6 @@ const eventDetailsSlice = createSlice({
 			})
 			.addCase(deleteComment.rejected, (state, action) => {
 				console.error(action.error);
-			})
-			.addCase(updateWorkflow.fulfilled, (state, action) => {
-				if ("workflowId" in state.workflows.workflow && !!state.workflows.workflow.workflowId) {
-					state.workflowConfiguration = state.workflows.workflow;
-				} else {
-					state.workflowConfiguration = state.baseWorkflow;
-				}
 			})
 			// fetch Tobira data
 			.addCase(fetchEventDetailsTobira.pending, (state) => {


### PR DESCRIPTION
When changing a workflow for a scheduled event in the event details, the selected workflow would not be saved. This patch fixes that.

### How to test this

Can be tested as usual, no configuration or Opencast patch necessary. To test, schedule an event, then go to the workflow tab of the scheduled event and change and save values.