### PR TITLE
Fix "TypeError: pages[offset] is undefined"

### DIFF
--- a/src/thunks/tableThunks.ts
+++ b/src/thunks/tableThunks.ts
@@ -429,7 +429,9 @@ export const goToPage = (pageNumber: number) => async (dispatch: AppDispatch, ge
 	const offset = getPageOffset(state);
 	const pages = getTablePages(state);
 
-	dispatch(setPageActive(pages[offset].number));
+	if (pages) {
+		dispatch(setPageActive(offset ? pages[offset].number : pageNumber));
+	}
 
 	// Get resources of page and load them into table
 	// eslint-disable-next-line default-case


### PR DESCRIPTION
This patch fixes the above error from the webconsole.

### How to test this

The error message in the web console can only consistently be seen when running the admin locally via `npm start`, so I suggest doing that. Functionality should otherwise remain unchanged, so test that all pages load as usual.