### PR TITLE
Fix request to /staticfiles failing during dev

### DIFF
--- a/src/components/shared/wizard/FileUpload.tsx
+++ b/src/components/shared/wizard/FileUpload.tsx
@@ -55,7 +55,7 @@ const FileUpload = <T extends RequiredFormProps>({
 		const data = new FormData();
 		data.append("BODY", file, file.name);
 		axios
-			.post("/staticfiles", data, {
+			.post("/staticfiles/", data, {
 				headers: {
 					"Content-Type": "multipart/form-data",
 				},


### PR DESCRIPTION
Fixes #1023.

The created request to /staticfiles were not matching our proxy regex. This fixes that.

### How to test this

This only affects development, not completed builds, so you will have to install this PR yourself and run it locally. You will also need an Opencasts with themes enabled that you can proxy against. Then open the "Create Theme" dialog and check if you can successfully upload a file in any of the file uploads.