### PR TITLE
Properly hide Tobira tab

### DIFF
--- a/src/components/events/partials/modals/EventDetails.tsx
+++ b/src/components/events/partials/modals/EventDetails.tsx
@@ -164,7 +164,7 @@ const EventDetails = ({
 			accessRole: "ROLE_UI_EVENTS_DETAILS_COMMENTS_VIEW",
 			name: "tobira",
 			page: EventDetailsPage.Tobira,
-			hidden: tobiraError?.message?.includes("503"),
+			hidden: (tobiraError === undefined || tobiraError?.message === undefined || tobiraError?.message?.includes("503")),
 		},
 		{
 			tabNameTranslation: "EVENTS.EVENTS.DETAILS.TABS.STATISTICS",

--- a/src/components/events/partials/modals/EventDetails.tsx
+++ b/src/components/events/partials/modals/EventDetails.tsx
@@ -26,6 +26,7 @@ import {
 	getModalWorkflowTabHierarchy,
 	getModalPage,
 	getEventDetailsTobiraDataError,
+	getEventDetailsTobiraStatus,
 } from "../../../../selectors/eventDetailsSelectors";
 import { getUserInformation } from "../../../../selectors/userInfoSelectors";
 import EventDetailsStatisticsTab from "../ModalTabsAndPages/EventDetailsStatisticsTab";
@@ -84,6 +85,7 @@ const EventDetails = ({
 		dispatch(fetchSchedulingInfo(eventId)).then();
 		dispatch(fetchEventStatistics(eventId)).then();
 		dispatch(fetchAssetUploadOptions()).then();
+		dispatch(fetchEventDetailsTobira(eventId));
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
@@ -98,6 +100,7 @@ const EventDetails = ({
 	const hasStatistics = useAppSelector(state => getHasStatistics(state));
 	const isLoadingStatistics = useAppSelector(state => isFetchingStatistics(state));
 	const captureAgents = useAppSelector(state => getRecordings(state));
+	const tobiraStatus = useAppSelector(state => getEventDetailsTobiraStatus(state));
 	const tobiraError = useAppSelector(state => getEventDetailsTobiraDataError(state));
 
 	const tabs = [
@@ -164,7 +167,7 @@ const EventDetails = ({
 			accessRole: "ROLE_UI_EVENTS_DETAILS_COMMENTS_VIEW",
 			name: "tobira",
 			page: EventDetailsPage.Tobira,
-			hidden: (tobiraError === undefined || tobiraError?.message === undefined || tobiraError?.message?.includes("503")),
+			hidden: tobiraStatus === "failed" && tobiraError?.message?.includes("503"),
 		},
 		{
 			tabNameTranslation: "EVENTS.EVENTS.DETAILS.TABS.STATISTICS",
@@ -178,9 +181,6 @@ const EventDetails = ({
 
 	const openTab = (tabNr: EventDetailsPage) => {
 		dispatch(removeNotificationWizardForm());
-		if (tabNr === EventDetailsPage.Tobira) {
-			dispatch(fetchEventDetailsTobira(eventId));
-		}
 		dispatch(openModalTab(tabNr, "entry", "entry"))
 	};
 

--- a/src/components/events/partials/modals/SeriesDetails.tsx
+++ b/src/components/events/partials/modals/SeriesDetails.tsx
@@ -8,6 +8,7 @@ import {
 	getSeriesDetailsTheme,
 	getSeriesDetailsThemeNames,
 	getSeriesDetailsTobiraDataError,
+	getSeriesDetailsTobiraStatus,
 	hasStatistics as seriesHasStatistics,
 } from "../../../../selectors/seriesDetailsSelectors";
 import { getOrgProperties, getUserInformation } from "../../../../selectors/userInfoSelectors";
@@ -20,6 +21,7 @@ import DetailsMetadataTab from "../ModalTabsAndPages/DetailsMetadataTab";
 import DetailsExtendedMetadataTab from "../ModalTabsAndPages/DetailsExtendedMetadataTab";
 import { useAppDispatch, useAppSelector } from "../../../../store";
 import {
+	fetchSeriesDetailsTobira,
 	fetchSeriesStatistics,
 	setTobiraTabHierarchy,
 	updateExtendedSeriesMetadata,
@@ -48,10 +50,12 @@ const SeriesDetails = ({
 	const theme = useAppSelector(state => getSeriesDetailsTheme(state));
 	const themeNames = useAppSelector(state => getSeriesDetailsThemeNames(state));
 	const hasStatistics = useAppSelector(state => seriesHasStatistics(state));
+	const tobiraStatus = useAppSelector(state => getSeriesDetailsTobiraStatus(state));
 	const tobiraError = useAppSelector(state => getSeriesDetailsTobiraDataError(state));
 
 	useEffect(() => {
 		dispatch(fetchSeriesStatistics(seriesId));
+		dispatch(fetchSeriesDetailsTobira(seriesId));
 		dispatch(setTobiraTabHierarchy("main"));
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
@@ -90,7 +94,7 @@ const SeriesDetails = ({
 			tabNameTranslation: "EVENTS.SERIES.DETAILS.TABS.TOBIRA",
 			accessRole: "ROLE_UI_SERIES_DETAILS_TOBIRA_VIEW",
 			name: "tobira",
-			hidden: (tobiraError === undefined || tobiraError?.message === undefined || tobiraError?.message?.includes("503")),
+			hidden: tobiraStatus === "failed" && tobiraError?.message?.includes("503"),
 		},
 		{
 			tabNameTranslation: "EVENTS.SERIES.DETAILS.TABS.STATISTICS",

--- a/src/components/events/partials/modals/SeriesDetails.tsx
+++ b/src/components/events/partials/modals/SeriesDetails.tsx
@@ -90,7 +90,7 @@ const SeriesDetails = ({
 			tabNameTranslation: "EVENTS.SERIES.DETAILS.TABS.TOBIRA",
 			accessRole: "ROLE_UI_SERIES_DETAILS_TOBIRA_VIEW",
 			name: "tobira",
-			hidden: tobiraError?.message?.includes("503"),
+			hidden: (tobiraError === undefined || tobiraError?.message === undefined || tobiraError?.message?.includes("503")),
 		},
 		{
 			tabNameTranslation: "EVENTS.SERIES.DETAILS.TABS.STATISTICS",

--- a/src/components/events/partials/wizards/NewSeriesWizard.tsx
+++ b/src/components/events/partials/wizards/NewSeriesWizard.tsx
@@ -6,6 +6,7 @@ import {
 	getSeriesExtendedMetadata,
 	getSeriesMetadata,
 	getSeriesTobiraPageError,
+	getSeriesTobiraPageStatus,
 } from "../../../../selectors/seriesSeletctor";
 import NewMetadataPage from "../ModalTabsAndPages/NewMetadataPage";
 import NewMetadataExtendedPage from "../ModalTabsAndPages/NewMetadataExtendedPage";
@@ -15,7 +16,7 @@ import { initialFormValuesNewSeries } from "../../../../configs/modalConfig";
 import { MetadataSchema, NewSeriesSchema } from "../../../../utils/validate";
 import { getInitialMetadataFieldValues } from "../../../../utils/resourceUtils";
 import { useAppDispatch, useAppSelector } from "../../../../store";
-import { TobiraPage, postNewSeries } from "../../../../slices/seriesSlice";
+import { TobiraPage, fetchSeriesDetailsTobiraNew, postNewSeries } from "../../../../slices/seriesSlice";
 import { MetadataCatalog } from "../../../../slices/eventSlice";
 import NewTobiraPage from "../ModalTabsAndPages/NewTobiraPage";
 import { getOrgProperties, getUserInformation } from "../../../../selectors/userInfoSelectors";
@@ -34,6 +35,7 @@ const NewSeriesWizard: React.FC<{
 
 	const metadataFields = useAppSelector(state => getSeriesMetadata(state));
 	const extendedMetadata = useAppSelector(state => getSeriesExtendedMetadata(state));
+	const tobiraStatus = useAppSelector(state => getSeriesTobiraPageStatus(state));
 	const tobiraError = useAppSelector(state => getSeriesTobiraPageError(state));
 	const user = useAppSelector(state => getUserInformation(state));
 	const orgProperties = useAppSelector(state => getOrgProperties(state));
@@ -45,6 +47,13 @@ const NewSeriesWizard: React.FC<{
 	const [page, setPage] = useState(0);
 	const [snapshot, setSnapshot] = useState(initialValues);
 	const [pageCompleted, setPageCompleted] = useState<{ [key: number]: boolean }>({});
+
+	useEffect(() => {
+		// This should set off a web request that will intentionally fail, in order
+		// to check if tobira is available at all
+		dispatch(fetchSeriesDetailsTobiraNew(""));
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
 
 	// Caption of steps used by Stepper
 	const steps = [
@@ -71,7 +80,7 @@ const NewSeriesWizard: React.FC<{
 		{
 			translation: "EVENTS.SERIES.NEW.TOBIRA.CAPTION",
 			name: "tobira",
-			hidden: (tobiraError === undefined || tobiraError?.message === undefined || tobiraError?.message?.includes("503")),
+			hidden: !!(tobiraStatus === "failed" && tobiraError?.message?.includes("503")),
 		},
 		{
 			translation: "EVENTS.SERIES.NEW.SUMMARY.CAPTION",

--- a/src/components/events/partials/wizards/NewSeriesWizard.tsx
+++ b/src/components/events/partials/wizards/NewSeriesWizard.tsx
@@ -71,7 +71,7 @@ const NewSeriesWizard: React.FC<{
 		{
 			translation: "EVENTS.SERIES.NEW.TOBIRA.CAPTION",
 			name: "tobira",
-			hidden: !!tobiraError?.message?.includes("503"),
+			hidden: (tobiraError === undefined || tobiraError?.message === undefined || tobiraError?.message?.includes("503")),
 		},
 		{
 			translation: "EVENTS.SERIES.NEW.SUMMARY.CAPTION",

--- a/src/selectors/seriesDetailsSelectors.ts
+++ b/src/selectors/seriesDetailsSelectors.ts
@@ -13,6 +13,8 @@ export const getSeriesDetailsThemeNames = (state: RootState) =>
 
 export const getSeriesDetailsTobiraData = (state: RootState) =>
 	state.seriesDetails.tobiraData;
+export const getSeriesDetailsTobiraStatus = (state: RootState) =>
+	state.seriesDetails.statusTobiraData;
 export const getSeriesDetailsTobiraDataError = (state: RootState) =>
 	state.seriesDetails.errorTobiraData;
 export const getTobiraTabHierarchy = (state: RootState) =>

--- a/src/slices/shared/tobiraErrors.ts
+++ b/src/slices/shared/tobiraErrors.ts
@@ -24,7 +24,6 @@ type AxiosErrorResponse = {
 // as it isn't really helpful and might not even be considered as one (see TODO comment below).
 export const handleTobiraError = (response: AxiosErrorResponse, dispatch: AppDispatch) => {
     const data = response.response;
-    console.info(response.message);
 
     if (data.status === 503) {
         // TODO: figure out what to do:
@@ -42,7 +41,6 @@ export const handleTobiraError = (response: AxiosErrorResponse, dispatch: AppDis
         //     context: NOTIFICATION_CONTEXT,
         // }));
 
-        console.info(data.data);
         throw Error(response.message);
     } else if (data.status === 500) {
         dispatch(addNotification({
@@ -53,7 +51,6 @@ export const handleTobiraError = (response: AxiosErrorResponse, dispatch: AppDis
             noDuplicates: true,
         }));
 
-        console.error(response);
         throw Error(response.message);
     } else if (data.status === 404) {
         dispatch(addNotification({
@@ -64,7 +61,6 @@ export const handleTobiraError = (response: AxiosErrorResponse, dispatch: AppDis
             noDuplicates: true,
         }));
 
-        console.error(response);
         throw Error(response.message);
     }
 };


### PR DESCRIPTION
In the event details tabs, the Tobira tab is showing up even if Tobira is not configured. This patch should fix that.

### How to test this

Ideally this is tested by someone with a Tobira setup, so that they can confirm that the tobira tab still correctly shows up if Tobira is indeed configured. Properly setting up Tobira is somewhat involved, so I'll direct all questions about that to the Tobira docs and the main Tobira developers.