### PR TITLE
Make header icons look the same when focused

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -181,7 +181,7 @@ const Header = () => {
 										}
 										target="_blank" rel="noreferrer"
 									>
-										<span className="fa fa-play-circle" />
+										<i className="fa fa-play-circle" />
 									</a>
 								</Tooltip>
 							</div>
@@ -192,7 +192,7 @@ const Header = () => {
 						<div className="nav-dd">
 							<Tooltip  title={t("STUDIO")}>
 								<a href={studioURL} target="_blank" rel="noreferrer">
-									<span className="fa fa-video-camera" />
+									<i className="fa fa-video-camera" />
 								</a>
 							</Tooltip>
 						</div>

--- a/src/styles/components/_header.scss
+++ b/src/styles/components/_header.scss
@@ -72,6 +72,16 @@
             opacity: 1;
             visibility: visible;
         }
+
+        // Make anchor elements look like buttons when tab targeted
+        > a {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            height: 39px;
+            width: 28px;
+            margin-left: 12px;
+        }
     }
 
     .dropdown-ul {


### PR DESCRIPTION
Fixes #790.

Some of the icons in the header are cointained within anchor elements, making their border outline when focused look different from the icons cointained in buttons. This patch throws some css at the anchor elements to make them look the same as their button counterparts.

Before:
![Bildschirmfoto vom 2025-01-14 09-20-48](https://github.com/user-attachments/assets/c8e72126-68f2-4abb-be49-50ff00b30b83)

After:
![Bildschirmfoto vom 2025-01-14 09-21-00](https://github.com/user-attachments/assets/15983cf7-94ba-45ab-98c8-1a012ebc1b23)

### How to test this

Can be tested as usual.