### PR TITLE
Fix scheduling for negative timezones

### DIFF
--- a/src/components/events/partials/wizards/NewEventSummary.tsx
+++ b/src/components/events/partials/wizards/NewEventSummary.tsx
@@ -190,7 +190,7 @@ const NewEventSummary = <T extends RequiredFormProps>({
 												</td>
 												<td>
 													{t("dateFormats.date.short", {
-														date: formik.values.scheduleStartDate,
+														date: renderValidDate(formik.values.scheduleStartDate),
 													})}
 												</td>
 											</tr>
@@ -210,7 +210,7 @@ const NewEventSummary = <T extends RequiredFormProps>({
 													</td>
 													<td>
 														{t("dateFormats.date.short", {
-															date: formik.values.scheduleEndDate,
+															date: renderValidDate(formik.values.scheduleEndDate),
 														})}
 													</td>
 												</tr>

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -6,11 +6,6 @@ import { FormikErrors } from "formik";
  * This File contains methods concerning dates
  */
 
-// Get the ISO date string based on local time
-const getISODateString = (date: Date) => {
-	return moment(date).format('YYYY-MM-DD');
-}
-
 // check if date can be parsed
 export const renderValidDate = (date: string) => {
 	return !isNaN(Date.parse(date)) ? new Date(date) : ""
@@ -126,8 +121,8 @@ const changeStart = (
 	}
 
 	setDuration(startDate, endDate, setFieldValue);
-	setFieldValue("scheduleEndDate", getISODateString(endDate));
-	setFieldValue("scheduleStartDate", getISODateString(startDate));
+	setFieldValue("scheduleEndDate", endDate.toISOString());
+	setFieldValue("scheduleStartDate", startDate.toISOString());
 
 	if (!!checkConflicts && !!formikValues.captureAgent) {
 		checkConflicts(
@@ -230,7 +225,7 @@ const changeEnd = (
 	}
 
 	setDuration(startDate, endDate, setFieldValue);
-	setFieldValue("scheduleEndDate", getISODateString(endDate));
+	setFieldValue("scheduleEndDate", endDate.toISOString());
 
 	if (!!checkConflicts && !!formikValues.captureAgent) {
 		checkConflicts(
@@ -304,7 +299,7 @@ const changeDuration = (
 
 	setFieldValue("scheduleEndHour", makeTwoDigits(endDate.getHours()));
 	setFieldValue("scheduleEndMinute", makeTwoDigits(endDate.getMinutes()));
-	setFieldValue("scheduleEndDate", getISODateString(endDate));
+	setFieldValue("scheduleEndDate", endDate.toISOString());
 
 	if (!!checkConflicts && !!formikValues.captureAgent) {
 		checkConflicts(
@@ -405,8 +400,8 @@ const changeStartMultiple = (
 		endDate.setDate(startDate.getDate() + 1);
 	}
 
-	setFieldValue("scheduleEndDate", getISODateString(endDate));
-	setFieldValue("scheduleStartDate", getISODateString(startDate));
+	setFieldValue("scheduleEndDate", endDate.toISOString());
+	setFieldValue("scheduleStartDate", startDate.toISOString());
 
 	if (!!checkConflicts && !! formikValues.captureAgent) {
 		checkConflicts(
@@ -525,8 +520,8 @@ export const changeEndDateMultiple = async (
 		}
 	}
 
-	setFieldValue("scheduleEndDate", getISODateString(endDate));
-	setFieldValue("scheduleStartDate", getISODateString(startDate));
+	setFieldValue("scheduleEndDate", endDate.toISOString());
+	setFieldValue("scheduleStartDate", startDate.toISOString());
 
 	if (!!checkConflicts && !!formikValues.captureAgent) {
 		checkConflicts(
@@ -571,7 +566,7 @@ const changeEndMultiple = (
 
 	if (isEndBeforeStart(startDate, endDate)) {
 		endDate.setDate(startDate.getDate() + 1);
-	  setFieldValue("scheduleEndDate", getISODateString(endDate));
+	  setFieldValue("scheduleEndDate", endDate.toISOString());
 	}
 
 	if (!!checkConflicts && !!formikValues.captureAgent) {
@@ -668,7 +663,7 @@ const changeDurationMultiple = (
 
 	setFieldValue("scheduleEndHour", makeTwoDigits(endDate.getHours()));
 	setFieldValue("scheduleEndMinute", makeTwoDigits(endDate.getMinutes()));
-	setFieldValue("scheduleEndDate", getISODateString(endDate));
+	setFieldValue("scheduleEndDate", endDate.toISOString());
 
 	if (!!checkConflicts && !!formikValues.captureAgent) {
 		checkConflicts(


### PR DESCRIPTION
And hopefully all other timezones. The date for a new scheduled event should now always be correct, no matter what hour/minute is selected.

Aims at fixing #1062.


### How to test this

Can be tested as usual. Try scheduling events with many different dates, hours, minutes, durations and check if it works as intended. Switch timezones if possible.