### PR TITLE
Remove unspecified filter on clear

### DIFF
--- a/src/components/shared/TableFilters.tsx
+++ b/src/components/shared/TableFilters.tsx
@@ -68,6 +68,7 @@ const TableFilters = ({
 		// Clear state
 		setStartDate(undefined);
 		setEndDate(undefined);
+		setFilterSelector(false);
 
 		dispatch(removeTextFilter());
 		dispatch(removeSelectedFilter());


### PR DESCRIPTION
The clear button clears the table filter field of all selected filters. It will however not remove an unspecified filter, meaning the dropdown menu. This patch makes is so that so that those are cleared as well, making sure the filter area is really clear.

![Bildschirmfoto vom 2025-01-16 08-53-36](https://github.com/user-attachments/assets/24cbad8d-98d4-4032-a7e6-2debe0f41f61)


### How to test this

Can be tested as usual.