### PR TITLE
Fix "Typing in date input ends early"

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsSchedulingTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsSchedulingTab.tsx
@@ -289,6 +289,7 @@ const EventDetailsSchedulingTab = ({
 																	className="datepicker-custom-input"
 																	portalId="root"
 																	locale={currentLanguage?.dateLocale}
+																	strictParsing
 																/>
 															) : (
 																<>

--- a/src/components/events/partials/ModalTabsAndPages/NewSourcePage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewSourcePage.tsx
@@ -429,6 +429,7 @@ const Schedule = <T extends {
 									className="datepicker-custom-input"
 									portalId="root"
 									locale={currentLanguage?.dateLocale}
+									strictParsing
 								/>
 							</td>
 						</tr>
@@ -459,6 +460,7 @@ const Schedule = <T extends {
 											className="datepicker-custom-input"
 											portalId="root"
 											locale={currentLanguage?.dateLocale}
+											strictParsing
 										/>
 									</td>
 								</tr>

--- a/src/components/shared/TableFilters.tsx
+++ b/src/components/shared/TableFilters.tsx
@@ -441,7 +441,7 @@ const FilterSwitch = ({
 						popperClassName="datepicker-custom"
 						className="datepicker-custom-input"
 						locale={getCurrentLanguageInformation()?.dateLocale}
-
+						strictParsing
 					/>
 				</div>
 			);

--- a/src/components/shared/wizard/RenderField.tsx
+++ b/src/components/shared/wizard/RenderField.tsx
@@ -195,6 +195,7 @@ const EditableDateValue = ({
 			className="datepicker-custom-input"
 			wrapperClassName="datepicker-custom-wrapper"
 			locale={getCurrentLanguageInformation()?.dateLocale}
+			strictParsing
 		/>
 	</div>
 ) : (
@@ -399,6 +400,7 @@ const EditableSingleValueTime = ({
 				className="datepicker-custom-input"
 				wrapperClassName="datepicker-custom-wrapper"
 				locale={getCurrentLanguageInformation()?.dateLocale}
+				strictParsing
 			/>
 		</div>
 	) : (


### PR DESCRIPTION
Trying to type in a date in for example the start date table filter is not working. The input is interpreted as a date immediately. For example, typing "1" will result in "01/01/2025", even if you wanted to type something completely different.

This patch fixes that by enabling strict parsing. Arguably not the best solution, but it works for now.