### PR TITLE
Fix rendering of mean times

### DIFF
--- a/src/components/systems/partials/MeanQueueTimeCell.tsx
+++ b/src/components/systems/partials/MeanQueueTimeCell.tsx
@@ -1,7 +1,6 @@
 import React from "react";
-import { useTranslation } from "react-i18next";
-import { renderValidDate } from "../../../utils/dateUtils";
 import { Service } from "../../../slices/serviceSlice";
+import moment from "moment";
 
 /**
  * This component renders the mean queue time cells of systems in the table view
@@ -11,11 +10,10 @@ const MeanQueueTimeCell = ({
 }: {
 	row: Service
 }) => {
-	const { t } = useTranslation();
 
 	return (
 		<span>
-			{t("dateFormats.time.medium", { time: renderValidDate(row.meanQueueTime.toString()) })}
+			{ moment.utc(moment.duration(row.meanQueueTime* 1000).asMilliseconds()).format("HH:mm:ss") }
 		</span>
 	);
 };

--- a/src/components/systems/partials/MeanRunTimeCell.tsx
+++ b/src/components/systems/partials/MeanRunTimeCell.tsx
@@ -1,7 +1,6 @@
 import React from "react";
-import { useTranslation } from "react-i18next";
-import { renderValidDate } from "../../../utils/dateUtils";
 import { Service } from "../../../slices/serviceSlice";
+import moment from "moment";
 
 /**
  * This component renders the mean run time cells of systems in the table view
@@ -11,11 +10,10 @@ const MeanRunTimeCell = ({
 }: {
 	row: Service
 }) => {
-	const { t } = useTranslation();
 
 	return (
 		<span>
-			{t("dateFormats.time.medium", { time: renderValidDate(row.meanRunTime.toString()) })}
+			{ moment.utc(moment.duration(row.meanRunTime * 1000).asMilliseconds()).format("HH:mm:ss") }
 		</span>
 	);
 };


### PR DESCRIPTION
Fixes #923.

The "mean run time" and the "mean queue time" in the services table could show as timestamps instead of durations. This patch should fix that.

### How to test this

Can be tested as usual, ideally on a server where not all mean times are 0. The issue occurs for at least "English (US)" and does not occur for "Deutsch".