### PR TITLE
Fix notes cannot be edited in notes column

### DIFF
--- a/src/slices/eventDetailsSlice.ts
+++ b/src/slices/eventDetailsSlice.ts
@@ -1805,7 +1805,7 @@ export const updateComment = createAppAsyncThunk('eventDetails/updateComment', a
 	data.append("text", commentText);
 	data.append("reason", commentReason);
 
-	const commentUpdated = await axios.post(
+	const commentUpdated = await axios.put(
 		`/admin-ng/event/${eventId}/comment/${commentId}`,
 		data.toString(),
 		headers


### PR DESCRIPTION
In the events table there is a "Notes" column (disabled by default). If there is a note, it currently cannot be changed (changes are lost on page refresh). This patch should fix that.

### How to test this

Can be tested as usual.
- To enable the notes column, go to the "events" table, then click on "Edit" in the top right corner of the table. There you can add the notes column to the other columns. 
- Write a note on an event. Reload the page.
- Change the note you just wrote. Reload the page.
- Check if the changes persisted or not.