### PR TITLE
Fix wrong notes being displayed in notes column

### DIFF
--- a/src/components/events/partials/EventsNotesCell.tsx
+++ b/src/components/events/partials/EventsNotesCell.tsx
@@ -65,7 +65,7 @@ const EventsNotesCell = ({
 				</textarea>
 			}
 			{comments.map((comment, key) => (
-				<div className="comment" key={key}>
+				<div className="comment" key={row.id + key}>
 					<hr />
 					<textarea
 						className="textarea"

--- a/src/components/events/partials/EventsNotesCell.tsx
+++ b/src/components/events/partials/EventsNotesCell.tsx
@@ -56,7 +56,7 @@ const EventsNotesCell = ({
 	}
 
 	return (
-		<div className="comment-container">
+		<div className="comment-container" key={row.id}>
 			{comments.length === 0 &&
 				<textarea
 					className="textarea"


### PR DESCRIPTION
When filtering events or switching between pages, sometimes notes from the wrong events would be displayed in the notes column. This patch should fix that.

### How to test this

Can be tested as usual.
- To enable the notes column, go to the "events" table, then click on "Edit" in the top right corner of the table. There you can add the notes column to the other columns. 
- Have at least two pages worth of events.
- Write a note on the topmost event on the first page. Write a different note on the topmost event on the second page.
- Reload the page.
- Switch between pages. Observe what is displayed in the note for the topmost event on each page.