### PR TITLE
Enforce event ordering

### DIFF
--- a/src/slices/eventSlice.ts
+++ b/src/slices/eventSlice.ts
@@ -232,6 +232,13 @@ export const fetchEvents = createAppAsyncThunk('events/fetchEvents', async (_, {
 	const state = getState();
 	let params: ReturnType<typeof getURLParams> & { getComments?: boolean } = getURLParams(state);
 
+	// Add a secondary filter to enforce order of events
+	// (Elasticsearch does not guarantee ordering)
+	params = {
+		...params,
+		sort: params.sort ? params.sort + ",uid:asc" : "uid:asc"
+	}
+
 	// Only if the notes column is enabled, fetch comment information for events
 	if (state.table.columns.find(column => column.label === "EVENTS.EVENTS.TABLE.ADMINUI_NOTES" && !column.deactivated)) {
 		params = {


### PR DESCRIPTION
**WILL BREAK THE UI WITHOUT THE REQUIRED BACKEND CHANGES:** https://github.com/opencast/opencast/pull/6461

The events table is sorted by a sort parameter. By default, this is the start date. If there are multiple events with the same start date, the sorting for those is left to the elasticseach index in the backend. Elasticsearch however does not guarantee any ordering. This may result in the order of events changing unexpectedly like in #1102.

This patch aims to solve this by adding a secondary sort parameter to the events query. The primary parameter still takes priority. For the secondary parameter, `uid` was chosen as it is the only field guaranteed to be unique.

More sorting parameters can lead to increased query times. If someone with an Opencast with *many* events could test the impact of these changes on the `events.json` request times, that would be great.

### How to test this

Requires an Opencast with the PR https://github.com/opencast/opencast/pull/6461 installed.
- Sort the events table by different parameters and check if the resulting sorting make sense.
- Compare the response times in the network tab of the developer tools.
- Check if #1102 is still reproducible or not.