### PR TITLE
Split presenters at ";"

### DIFF
--- a/src/components/shared/wizard/RenderMultiField.tsx
+++ b/src/components/shared/wizard/RenderMultiField.tsx
@@ -53,23 +53,26 @@ const RenderMultiField = ({
 		}
 
 		if (newInputValue !== "") {
-			// Flag if only values of collection are allowed or any value
-			if (onlyCollectionValues) {
-				// add input to formik field value if not already added and input in collection of possible values
-				if (
-					!fieldValue.find((e) => e === newInputValue) &&
-					fieldInfo.collection?.find((e) => e.value === newInputValue)
-				) {
-					fieldValue[fieldValue.length] = newInputValue;
-					form.setFieldValue(field.name, fieldValue);
-				}
-			} else {
-				// add input to formik field value if not already added
-				if (!fieldValue.find((e) => e === newInputValue)) {
-					fieldValue[fieldValue.length] = newInputValue;
-					form.setFieldValue(field.name, fieldValue);
-				}
+			const splitArray = newInputValue.split(";").map(item => item.trim()).filter(Boolean);
+			for (const newInput of splitArray) {
+				// Flag if only values of collection are allowed or any value
+				if (onlyCollectionValues) {
+					// add input to formik field value if not already added and input in collection of possible values
+					if (
+						!fieldValue.find((e) => e === newInput) &&
+						fieldInfo.collection?.find((e) => e.value === newInput)
+					) {
+						fieldValue[fieldValue.length] = newInput;
+						form.setFieldValue(field.name, fieldValue);
+					}
+				} else {
+					// add input to formik field value if not already added
+					if (!fieldValue.find((e) => e === newInput)) {
+						fieldValue[fieldValue.length] = newInput;
+						form.setFieldValue(field.name, fieldValue);
+					}
 			}
+		}
 
 			// reset inputValue
 			setInputValue("");


### PR DESCRIPTION
It was brought to my attention that this was a feature in the previous admin ui, so this patch adds it back in.

When adding multiple presenters to an event in the metadata tab, you can now add multiple presenters at the same time by delimiting them with a ";". For example, writing "Pacman; Duck Hunt" would result in both "Pacman" and "Duck Hunt" being added as presenters. Will also work for other metadata fields that work the same way, e.g. contributers.

### How to test this

Can be tested as usual. 