### PR TITLE
Fix error when changing date in bulk edit metadata

### DIFF
--- a/src/components/shared/wizard/RenderField.tsx
+++ b/src/components/shared/wizard/RenderField.tsx
@@ -178,11 +178,12 @@ const EditableDateValue = ({
 	setEditMode: (e: boolean) => void
 	showCheck?: boolean,
 	handleKeyDown: (event: React.KeyboardEvent, type: string) => void
-}) => editMode ? (
+}) => 
+	editMode ? (
 	<div>
 		<DatePicker
 			autoFocus
-			selected={typeof field.value === "string" ? parseISO(field.value) : field.value}
+			selected={!isNaN(Date.parse(field.value)) ? new Date(field.value) : null}
 			onChange={(value) => setFieldValue(field.name, value)}
 			onClickOutside={() => setEditMode(false)}
 			showTimeInput


### PR DESCRIPTION
Fixes #1099.

Trying to change the start date for two or more events at the same time would cause the app to crash (See #1099). This fixes that.

### How to test this

Can be tested as usual. "Bulk edit metadata" can be found in the "Actions" dropdown in the events table. Make sure to select at least two events via the checkmarks on the left side of the table.