### PR TITLE
Remove bourbon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@reduxjs/toolkit": "^2.5.1",
         "array-move": "^4.0.0",
         "axios": "^1.7.9",
-        "bourbon": "^7.3.0",
         "classnames": "^2.5.1",
         "date-fns": "^3.6.0",
         "dompurify": "^3.2.3",
@@ -5514,11 +5513,6 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/bourbon": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/bourbon/-/bourbon-7.3.0.tgz",
-      "integrity": "sha512-u9ZUqmaX7K7nkarKODlFT4/XYfWafLRoadlv2Lye8hytrIA4Urg/50rav1eFdbdbO6o9GnK9a6qf7zwq808atA=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "@reduxjs/toolkit": "^2.5.1",
     "array-move": "^4.0.0",
     "axios": "^1.7.9",
-    "bourbon": "^7.3.0",
     "classnames": "^2.5.1",
     "date-fns": "^3.6.0",
     "dompurify": "^3.2.3",

--- a/src/styles/base/_variables.scss
+++ b/src/styles/base/_variables.scss
@@ -1,5 +1,4 @@
 @use "sass:color";
-@use "../../../node_modules/bourbon/core/bourbon/library/shade";
 
 /**
  * Licensed to The Apereo Foundation under one or more contributor license
@@ -211,22 +210,22 @@ $img-path:                      "/src/img/";
 // Success (Green)
 $state-success-text:             #3c763d;
 $state-success-bg:               #dff0d8;
-$state-success-border:           color.adjust(shade.shade($state-success-bg, 1%), $lightness: -3%);
+$state-success-border:           rgb(211.8267110656, 233.0538934426, 203.0861065574); //Old bourbon code that calculated these values: color.adjust(shade.shade($state-success-bg, 1%), $lightness: -3%);
 
 // Info (Blue)
 $state-info-text:                color.adjust(#31708f, $lightness: 5%);
 $state-info-bg:                  #d9edf7;
-$state-info-border:              color.adjust(shade.shade($state-info-bg, 1%), $lightness: -5%);
+$state-info-border:              rgb(194.6022156398, 224.3725947867, 239.2577843602); //Old bourbon code that calculated these values: color.adjust(shade.shade($state-info-bg, 1%), $lightness: -5%);
 
 // Warning (Yellow)
 $state-warning-text:             #8a6d3b;
 $state-warning-bg:               #fcf8e3;
-$state-warning-border:           color.adjust(shade.shade($state-warning-bg, 1%), $lightness: -5%);
+$state-warning-border:           rgb(245.5470578374, 238.7655993294, 203.1629421626); //Old bourbon code that calculated these values: color.adjust(shade.shade($state-warning-bg, 1%), $lightness: -5%);
 
 // Danger (Red)
 $state-danger-text:              #a94442;
 $state-danger-bg:                #f2dede;
-$state-danger-border:            color.adjust(shade.shade($state-danger-bg, 1%), $lightness: -3%);
+$state-danger-border:            rgb(234.9211137441, 209.1388862559, 209.1388862559); //Old bourbon code that calculated these values: color.adjust(shade.shade($state-danger-bg, 1%), $lightness: -3%);
 
 // Transition
 $alert-transition: color 300ms ease-in;

--- a/src/styles/components/_dropdowns.scss
+++ b/src/styles/components/_dropdowns.scss
@@ -1,5 +1,4 @@
 @use "sass:color";
-@use "../../../node_modules/bourbon/core/bourbon/library/border-radius";
 @use "../base/variables";
 @use "../base/fontawesome/fa-mixins";
 
@@ -89,7 +88,8 @@
         transition: all 200ms;
         background: variables.$off-white;
         list-style: none;
-        @include border-radius.border-bottom-radius(variables.$main-border-radius);
+        border-bottom-left-radius: variables.$main-border-radius;
+        border-bottom-right-radius: variables.$main-border-radius;
         border: variables.$thin-border-stroke variables.$main-border-color;
         opacity: 1;
         pointer-events: auto;
@@ -125,7 +125,8 @@
             }
 
             &:last-child a {
-                @include border-radius.border-bottom-radius(variables.$main-border-radius);
+                border-bottom-left-radius: variables.$main-border-radius;
+                border-bottom-right-radius: variables.$main-border-radius;
             }
         }
 
@@ -168,7 +169,8 @@
             transition: all 200ms;
             background: variables.$off-white;
             list-style: none;
-            @include border-radius.border-bottom-radius(variables.$main-border-radius);
+            border-bottom-left-radius: variables.$main-border-radius;
+            border-bottom-right-radius: variables.$main-border-radius;
             border: variables.$thin-border-stroke variables.$main-border-color;
             opacity: 1;
             pointer-events: auto;
@@ -214,7 +216,8 @@
                 }
 
                 &:last-child a {
-                    @include border-radius.border-bottom-radius(variables.$main-border-radius);
+                    border-bottom-left-radius: variables.$main-border-radius;
+                    border-bottom-right-radius: variables.$main-border-radius;
                 }
             }
         }
@@ -224,21 +227,26 @@
     &.flipped {
 
         &.active {
-            @include border-radius.border-top-radius(0);
-            @include border-radius.border-bottom-radius(variables.$main-border-radius);
+            border-top-left-radius: 0;
+            border-top-right-radius: 0;
+            border-bottom-left-radius: variables.$main-border-radius;
+            border-bottom-right-radius: variables.$main-border-radius;
         }
 
         > ul {
             top: auto;
             bottom: 100%;
-            @include border-radius.border-top-radius(variables.$main-border-radius);
-            @include border-radius.border-bottom-radius(0);
+            border-top-left-radius: variables.$main-border-radius;
+            border-top-right-radius: variables.$main-border-radius;
+            border-bottom-left-radius: 0;
+            border-bottom-right-radius: 0;
         }
     }
 
     // Active State
     &.active {
-        @include border-radius.border-bottom-radius(0);
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
 
         &:after {
             transform: rotate(180deg);

--- a/src/styles/components/_footer.scss
+++ b/src/styles/components/_footer.scss
@@ -1,5 +1,5 @@
 @use "sass:color";
-@use "../../../node_modules/bourbon/core/bourbon/library/clearfix";
+@use "../mixins/mixins-bourbon";
 @use "../base/variables";
 
 /**
@@ -48,7 +48,7 @@ $footer-background-color: color.adjust(variables.$body-background, $lightness: -
     border-top: 1px solid $footer-border-color;
 
     .feedback-btn {
-        @include clearfix.clearfix();
+        @include mixins-bourbon.clearfix;
         width: 90px;
         position: absolute;
         right: 0;

--- a/src/styles/components/_form.scss
+++ b/src/styles/components/_form.scss
@@ -1,4 +1,4 @@
-@use "../../../node_modules/bourbon/core/bourbon/library/clearfix";
+@use "../mixins/mixins-bourbon";
 @use "../base/variables";
 
 /**
@@ -24,7 +24,7 @@
 
 
 .form-container {
-    @include clearfix.clearfix();
+    @include mixins-bourbon.clearfix;
     max-width: 100%;
     padding: 0;
     margin: 15px 0;
@@ -60,7 +60,7 @@
     }
 
     .row {
-        @include clearfix.clearfix();
+        @include mixins-bourbon.clearfix;
         display: block;
         width: 100%;
         margin: 15px 0;

--- a/src/styles/components/_header.scss
+++ b/src/styles/components/_header.scss
@@ -1,6 +1,5 @@
 @use "sass:color";
-@use "../../../node_modules/bourbon/core/bourbon/library/border-radius";
-@use "../../../node_modules/bourbon/core/bourbon/library/clearfix";
+@use "../mixins/mixins-bourbon";
 @use "../base/fontawesome/fa-mixins";
 @use "../base/fontawesome/variables" as variables2;
 @use "../base/variables";
@@ -266,7 +265,8 @@
         width: 80px;
         height: 42px;
         background: #243e55;
-        @include border-radius.border-top-radius(4px);
+        border-top-left-radius: 4px;
+        border-top-right-radius: 4px;
         border: variables.$thin-border-stroke color.adjust(#1e364b, $lightness: -3%);
         border-bottom: none;
         margin: 0 variables.$side-margin;
@@ -438,7 +438,7 @@
 // Example: https://gist.github.com/mattmischuk/b4dcb1e245f00b21c6a6
 
 .page-nav-container {
-    @include clearfix.clearfix();
+    @include mixins-bourbon.clearfix;
     width: 100%;
 
     .page-nav-bar {

--- a/src/styles/components/_menu.scss
+++ b/src/styles/components/_menu.scss
@@ -1,4 +1,3 @@
-@use "../../../node_modules/bourbon/core/bourbon/library/border-radius";
 @use "../base/fontawesome/fa-mixins";
 @use "../base/fontawesome/variables" as variables2;
 @use "../base/variables";
@@ -33,7 +32,8 @@
     background: #fff;
     border: variables.$thin-border-stroke #c3cbd0;
     border-top: none;
-    @include border-radius.border-bottom-radius(4px);
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
     position: absolute;
     top: 1px;
     left: -1px;

--- a/src/styles/components/_multi-select.scss
+++ b/src/styles/components/_multi-select.scss
@@ -1,4 +1,4 @@
-@use "../../../node_modules/bourbon/core/bourbon/library/clearfix";
+@use "../mixins/mixins-bourbon";
 @use "../base/fontawesome/fa-mixins";
 @use "../base/fontawesome/variables" as variables2;
 @use "../base/variables";
@@ -27,7 +27,7 @@
 
 
 .multi-select-container {
-    @include clearfix.clearfix();
+    @include mixins-bourbon.clearfix;
 
     select[multiple] {
         margin-top: 10px;

--- a/src/styles/components/_simple-box.scss
+++ b/src/styles/components/_simple-box.scss
@@ -1,5 +1,4 @@
 @use "sass:color";
-@use "../../../node_modules/bourbon/core/bourbon/library/border-radius";
 @use "../base/variables";
 
 /**
@@ -40,7 +39,8 @@
         display: inline-block;
         background: color.adjust(variables.$body-background, $lightness: -1%);
         border: variables.$thin-border-stroke variables.$main-border-color;
-        @include border-radius.border-top-radius(variables.$main-border-radius);
+        border-top-left-radius: variables.$main-border-radius;
+        border-top-right-radius: variables.$main-border-radius;
         font-size: 13px;
 
         &.active {

--- a/src/styles/components/_tables.scss
+++ b/src/styles/components/_tables.scss
@@ -1,5 +1,4 @@
 @use "sass:color";
-@use "../../../node_modules/bourbon/core/bourbon/library/border-radius";
 @use "../base/fontawesome/fa-mixins";
 @use "../base/fontawesome/variables" as variables2;
 @use "../base/variables";
@@ -529,7 +528,8 @@
 
             .sub-tbl tr:last-child > td {
                 border-bottom: 1px solid variables.$main-border-color;
-                @include border-radius.border-bottom-radius(0);
+                border-bottom-left-radius: 0;
+                border-bottom-right-radius: 0;
             }
         }
 

--- a/src/styles/components/data-filter/_base.scss
+++ b/src/styles/components/data-filter/_base.scss
@@ -1,4 +1,4 @@
-@use "../../../../node_modules/bourbon/core/bourbon/library/clearfix";
+@use "../../mixins/mixins-bourbon";
 
 /**
  * Licensed to The Apereo Foundation under one or more contributor license
@@ -35,5 +35,5 @@ $df-height: 42px;
 // ----------------------------------------
 
 .df-container {
-    @include clearfix.clearfix;
+    @include mixins-bourbon.clearfix;
 }

--- a/src/styles/components/data-filter/_filter-profiles.scss
+++ b/src/styles/components/data-filter/_filter-profiles.scss
@@ -1,5 +1,4 @@
 @use "sass:color";
-@use "../../../../node_modules/bourbon/core/bourbon/library/border-radius";
 @use "../../base/fontawesome/fa-mixins";
 @use "../../base/fontawesome/variables" as variables2;
 @use "../../base/variables";
@@ -219,7 +218,8 @@
             width: 100%;
             float: right;
             padding: 5px;
-            @include border-radius.border-bottom-radius(variables.$main-border-radius);
+            border-bottom-left-radius: variables.$main-border-radius;
+            border-bottom-right-radius: variables.$main-border-radius;
             background: color.adjust(variables.$body-background, $lightness: -3%);
             border-top: 1px solid variables.$main-border-color;
         }

--- a/src/styles/components/modals/_footer.scss
+++ b/src/styles/components/modals/_footer.scss
@@ -1,5 +1,4 @@
 @use "sass:color";
-@use "../../../../node_modules/bourbon/core/bourbon/library/border-radius";
 @use "../../base/variables";
 @use "../../mixins/button";
 
@@ -28,7 +27,8 @@
 .modal footer {
     width: 100%;
     height: 60px;
-    @include border-radius.border-bottom-radius(variables.$main-border-radius);
+    border-bottom-left-radius: variables.$main-border-radius;
+    border-bottom-right-radius: variables.$main-border-radius;
     background: color.adjust(variables.$body-background, $lightness: -3%);
     border-top: 1px solid variables.$main-border-color;
 

--- a/src/styles/components/modals/_header.scss
+++ b/src/styles/components/modals/_header.scss
@@ -1,4 +1,3 @@
-@use "../../../../node_modules/bourbon/core/bourbon/library/border-radius";
 @use "../../base/variables";
 
 /**
@@ -32,7 +31,8 @@
     line-height: 40px;
     background: linear-gradient(to bottom, #fbfbfb, #e8e8e8);
     border-bottom: 1px solid variables.$main-border-color;
-    @include border-radius.border-top-radius(variables.$main-border-radius);
+    border-bottom-left-radius: variables.$main-border-radius;
+    border-bottom-right-radius: variables.$main-border-radius;
     padding: 0 20px;
 
     > h2 {

--- a/src/styles/components/modals/_modal-alerts.scss
+++ b/src/styles/components/modals/_modal-alerts.scss
@@ -1,4 +1,4 @@
-@use "../../../../node_modules/bourbon/core/bourbon/library/clearfix";
+@use "../../mixins/mixins-bourbon";
 @use "../../base/fontawesome/fa-variables";
 @use "../../base/variables";
 @use "../alerts";
@@ -39,7 +39,7 @@
 }
 
 .modal-alert {
-    @include clearfix.clearfix();
+    @include mixins-bourbon.clearfix;
     display: block;
     padding: 15px 25px;
     

--- a/src/styles/components/modals/_modal-components.scss
+++ b/src/styles/components/modals/_modal-components.scss
@@ -1,10 +1,9 @@
 @use "sass:color";
-@use "../../../../node_modules/bourbon/core/bourbon/library/border-radius";
-@use "../../../../node_modules/bourbon/core/bourbon/library/clearfix";
 @use "../../base/fontawesome/fa-mixins";
 @use "../../base/fontawesome/variables" as variables2;
 @use "../../base/variables";
 @use "../../mixins/button";
+@use "../../mixins/mixins-bourbon";
 
 /**
  * Licensed to The Apereo Foundation under one or more contributor license
@@ -140,7 +139,8 @@
         .add-comment {
             background: variables.$off-white;
             border-top: variables.$thin-border-stroke #e9e9e9;
-            @include border-radius.border-bottom-radius(variables.$main-border-radius);
+            border-bottom-left-radius: variables.$main-border-radius;
+            border-bottom-right-radius: variables.$main-border-radius;
             height: 191px;
             padding: 3%;
             display: flex;
@@ -341,11 +341,11 @@
     // ----------------------------------------
 
     .file-upload {
-        @include clearfix.clearfix();
+        @include mixins-bourbon.clearfix;
     }
 
     .upload-file-info {
-        @include clearfix.clearfix();
+        @include mixins-bourbon.clearfix;
         color: variables.$medium-prim-color;
         font-size: 10px;
         font-weight: variables.$weight-semibold;
@@ -462,7 +462,7 @@
     }
 
     .list-row {
-        @include clearfix.clearfix();
+        @include mixins-bourbon.clearfix;
         padding: 15px 0;
         border-bottom: 1px solid variables.$main-border-color;
 
@@ -481,7 +481,7 @@
     }
 
     .list-sub-row {
-        @include clearfix.clearfix();
+        @include mixins-bourbon.clearfix;
         padding: 5px 0;
 
         &:last-child {
@@ -512,7 +512,7 @@
     // ----------------------------------------
 
     .video-container {
-        @include clearfix.clearfix();
+        @include mixins-bourbon.clearfix;
         position: relative;
 
         .video-wrapper {

--- a/src/styles/extensions/components/_tables.scss
+++ b/src/styles/extensions/components/_tables.scss
@@ -1,5 +1,5 @@
 @use "sass:color";
-@use "../../../../node_modules/bourbon/core/bourbon/library/clearfix";
+@use "../../mixins/mixins-bourbon";
 @use "../../base/fontawesome/fa-mixins";
 @use "../../base/fontawesome/variables" as variables2;
 @use "../../base/variables";
@@ -45,7 +45,7 @@
 }
 
 .action-bar {
-    @include clearfix.clearfix();
+    @include mixins-bourbon.clearfix;
     border: 1px solid variables.$main-border-color;
     border-bottom: none;
     border-top-left-radius: variables.$main-border-radius;

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -27,7 +27,6 @@ $disable-warnings: true !default; // disables deprecation warnings
 
 // Imports
 @use "sass:meta";
-@use "../../node_modules/bourbon/core/bourbon";
 
 // Foundation
 // ----------------------------------------
@@ -37,6 +36,7 @@ $disable-warnings: true !default; // disables deprecation warnings
 
 // Mixins
 @use "mixins/_mixins-config";
+@use "mixins/mixins-bourbon";
 
 // Components
 @use "components/components-config";
@@ -46,7 +46,6 @@ $disable-warnings: true !default; // disables deprecation warnings
 
 // Extensions
 @use "extensions/extensions-config";
-@use "../../node_modules/bourbon/core/bourbon/library/clearfix";
 @use "base/fontawesome/fa-mixins";
 @use "base/fontawesome/variables" as variables2;
 @use "base/variables";
@@ -612,7 +611,7 @@ tr.info {
 }
 
 .video-player {
-  @include clearfix.clearfix();
+  @include mixins-bourbon.clearfix;
   width: 100%;
   margin: 0 auto;
   background: #1e1e1e;

--- a/src/styles/mixins/_mixins-bourbon.scss
+++ b/src/styles/mixins/_mixins-bourbon.scss
@@ -1,0 +1,9 @@
+// Bourbon leftovers
+
+@mixin clearfix {
+  .element::after {
+      clear: both;
+      content: "";
+      display: block;
+    }
+}

--- a/src/styles/mixins/_mixins-config.scss
+++ b/src/styles/mixins/_mixins-config.scss
@@ -23,7 +23,6 @@
 @use "sass:color";
 @use "button";
 @use "triangle-point";
-@use "../../../node_modules/bourbon/core/bourbon/library/border-radius";
 @use "../base/fontawesome/fa-mixins";
 @use "../base/fontawesome/variables" as variables2;
 @use "../base/variables";
@@ -57,7 +56,8 @@
     line-height: $height;
     background: linear-gradient(to bottom, #fff, #f3f5f6);
     border-bottom: 1px solid variables.$main-border-color;
-    @include border-radius.border-top-radius(variables.$main-border-radius);
+    border-top-left-radius: variables.$main-border-radius;
+    border-top-right-radius: variables.$main-border-radius;
     margin: 0;
     width: 100%;
     padding-left: 10px;
@@ -102,7 +102,8 @@
 
     header {
         background: linear-gradient(variables.$white, #f7f7f7);
-        @include border-radius.border-top-radius(variables.$main-border-radius);
+        border-top-left-radius: variables.$main-border-radius;
+        border-top-right-radius: variables.$main-border-radius;
         border-bottom: variables.$thin-border-stroke variables.$main-border-color;
         height: 30px;
 
@@ -115,7 +116,8 @@
     .footer-btn {
         background: linear-gradient(variables.$off-white, #f0f2f5);
         border-top: variables.$thin-border-stroke color.adjust(#f0f2f5, $lightness: -10%);
-        @include border-radius.border-bottom-radius(variables.$main-border-radius);
+        border-bottom-left-radius: variables.$main-border-radius;
+        border-bottom-right-radius: variables.$main-border-radius;
         display: block;
         line-height: 30px;
         text-align: center;

--- a/src/styles/views/_core.scss
+++ b/src/styles/views/_core.scss
@@ -1,5 +1,5 @@
 @use "sass:color";
-@use "../../../node_modules/bourbon/core/bourbon/library/clearfix";
+@use "../mixins/mixins-bourbon";
 @use "../base/fontawesome/fa-mixins";
 @use "../base/fontawesome/variables" as variables2;
 @use "../base/variables";
@@ -99,7 +99,7 @@ body {
         // ## (End)
 
         .filters-container {
-            @include clearfix.clearfix();
+            @include mixins-bourbon.clearfix;
             float: right;
             position: relative;
 

--- a/src/styles/views/_statistics.scss
+++ b/src/styles/views/_statistics.scss
@@ -1,4 +1,3 @@
-@use "../../../node_modules/bourbon/core/bourbon/library/border-radius";
 @use "../base/variables";
 
 .statistics header {
@@ -8,7 +7,8 @@
     line-height: 40px;
     background: linear-gradient(to bottom, #fbfbfb, #e8e8e8);
     border-bottom: 1px solid variables.$main-border-color;
-    @include border-radius.border-top-radius(variables.$main-border-radius);
+    border-top-left-radius: variables.$main-border-radius;
+    border-top-right-radius: variables.$main-border-radius;
     padding: 0 20px;
 }
 

--- a/src/styles/views/modals/_event-series.scss
+++ b/src/styles/views/modals/_event-series.scss
@@ -1,4 +1,3 @@
-@use "../../../../node_modules/bourbon/core/bourbon/library/border-radius";
 @use "../../base/variables";
 @use "../../components/alerts";
 @use "../../mixins/button";
@@ -92,7 +91,8 @@
             .main-tbl {
                 border-top: 1px solid variables.$main-border-color;
                 margin-top: 0;
-                @include border-radius.border-top-radius(0);
+                border-top-left-radius: 0;
+                border-top-right-radius: 0;
             }
 
             .add-remove-container {


### PR DESCRIPTION
bourbon is no longer maintained (see https://github.com/thoughtbot/bourbon). Furthermore, bourbon is using deprecated  SASS that will cause issues sooner rather then later. Therefore this patch removes bourbon entirely and replaces it with native CSS.

Fixes #1040.

### How to test this.

Can be tested as usual. Look for any stylistic changes, particularly concerning any borders and notifications.