### PR TITLE
Fix notes column loading slowly sometimes

### DIFF
--- a/src/slices/eventSlice.ts
+++ b/src/slices/eventSlice.ts
@@ -234,7 +234,7 @@ export const fetchEvents = createAppAsyncThunk('events/fetchEvents', async (_, {
 	let params: ReturnType<typeof getURLParams> & { getComments?: boolean } = getURLParams(state);
 
 	// Only if the notes column is enabled, fetch comment information for events
-	if (state.table.columns.find(column => column.label === "EVENTS.EVENTS.TABLE.ADMINUI_NOTES" && !column.deactivated)) {
+	if (state.events.columns.find(column => column.label === "EVENTS.EVENTS.TABLE.ADMINUI_NOTES" && !column.deactivated)) {
 		params = {
 			...params,
 			getComments: true


### PR DESCRIPTION
The textareas in the notes column in the events table would sometimes take several seconds to load. This patch ensures that they load as fast as any other information in the events table.

### How to test this

Enable the notes column if not already enabled by going to "Edit" in the top right corner of the events table. Reload the page or switch between series and events tab a couple of times to observe the error/fix.