### PR TITLE
Fix table action delete modal not opening

### DIFF
--- a/src/components/events/Events.tsx
+++ b/src/components/events/Events.tsx
@@ -157,7 +157,6 @@ const Events = () => {
 				<Modal
 					header={t("BULK_ACTIONS.DELETE.EVENTS.CAPTION")}
 					classId="delete-events-status-modal"
-					className="modal active modal-open"
 					ref={deleteModalRef}
 				>
 					<DeleteEventsModal close={hideDeleteModal} />

--- a/src/components/events/Series.tsx
+++ b/src/components/events/Series.tsx
@@ -129,7 +129,6 @@ const Series = () => {
 				<Modal
 					header={t("BULK_ACTIONS.DELETE.SERIES.CAPTION")}
 					classId="delete-series-status-modal"
-					className="modal active modal-open"
 					ref={deleteModalRef}
 				>
 					<DeleteSeriesModal close={hideDeleteModal} />


### PR DESCRIPTION
When trying to delete one or multiple events/series via the action dropdown above the table, the delete modal does not show. This patch fixes that.

### How to test this

Can be tested as usual.