### PR TITLE
Fix unique key error in NavBar

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -92,9 +92,10 @@ const NavBar = ({
 			<MainNav isOpen={displayNavigation} toggleMenu={toggleNavigation} />
 
 			<nav aria-label={navAriaLabel && t(navAriaLabel)}>
-				{links.map((link) =>
+				{links.map((link, index) =>
 					{return (hasAccess(link.accessRole, user) && (
 						<Link
+							key={index}
 							to={link.path}
 							className={cn({ active: location.pathname === link.path })}
 							onClick={() => {


### PR DESCRIPTION
NavBar did not correctly key its links. This patch fixes that.

### How to test this

Can be tested as usual. Observe if the unique key error in the webconsole disappears. 