### PR TITLE
Fix "Events" not bold on page load.

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -96,7 +96,7 @@ const NavBar = ({
 					{return (hasAccess(link.accessRole, user) && (
 						<Link
 							to={link.path}
-							className={cn({ active: location.pathname === link.path })}
+							className={cn({ active: location.pathname === link.path || (location.pathname === "/" && link.path === "/events/events") })}
 							onClick={() => {
 								if (location.pathname !== link.path) {
 									// Reset the current page to first page


### PR DESCRIPTION
Fixes #1110.

Makes the "Events" header on page load bold white again.

### How to test this

Can be tested as usual.