### PR TITLE
Allow stats to set textfilter

### DIFF
--- a/src/components/shared/Stats.tsx
+++ b/src/components/shared/Stats.tsx
@@ -7,6 +7,7 @@ import {
 	fetchStats,
 	Stats as StatsType,
 	editTextFilter,
+	removeTextFilter,
 } from "../../slices/tableFilterSlice";
 import { loadEventsIntoTable } from "../../thunks/tableThunks";
 import { useAppDispatch, useAppSelector } from "../../store";
@@ -28,8 +29,10 @@ const Stats = () => {
 		let filterValue;
 		await stats.filters.forEach((f) => {
 			if (f.name.toLowerCase() === "textfilter") {
-				dispatch(editTextFilter(f.value))
+				dispatch(editTextFilter(f.value));
 				return;
+			} else {
+				dispatch(removeTextFilter());
 			}
 			let filter = filterMap.find(({ name }) => name === f.name);
 			filterValue = f.value;

--- a/src/components/shared/Stats.tsx
+++ b/src/components/shared/Stats.tsx
@@ -6,6 +6,7 @@ import {
 	resetFilterValues,
 	fetchStats,
 	Stats as StatsType,
+	editTextFilter,
 } from "../../slices/tableFilterSlice";
 import { loadEventsIntoTable } from "../../thunks/tableThunks";
 import { useAppDispatch, useAppSelector } from "../../store";
@@ -26,6 +27,10 @@ const Stats = () => {
 		dispatch(resetFilterValues());
 		let filterValue;
 		await stats.filters.forEach((f) => {
+			if (f.name.toLowerCase() === "textfilter") {
+				dispatch(editTextFilter(f.value))
+				return;
+			}
 			let filter = filterMap.find(({ name }) => name === f.name);
 			filterValue = f.value;
 			if (!!filter) {


### PR DESCRIPTION
The stats over the events table (Today, Running etc.) can set filters for the events table if clicked on. However, it was not possible to use this to set a textfilter (text in the search field). This patch fixes that.

### How to test this

Requires configuring the listprovider `etc/listproviders/admiminui.stats.properties` in Opencast. One example configuration would be:

```
FINISHED_WITH_COMMENTS=\
  {"filters": [{"name": "comments", "filter": "FILTERS.EVENTS.COMMENTS.LABEL", "value": "OPEN"},\
               {"name": "status", "filter": "FILTERS.EVENTS.STATUS.LABEL", "value": "EVENTS.EVENTS.STATUS.PROCESSED"},\
               {"name": "textFilter", "value": "-oaipmh"}],\
  "description": "DASHBOARD.FINISHED_WITH_COMMENTS",\
  "order":11}
```