### PR TITLE
Fix hiding tobira tab in series create modal

### DIFF
--- a/src/components/events/partials/wizards/NewSeriesWizard.tsx
+++ b/src/components/events/partials/wizards/NewSeriesWizard.tsx
@@ -23,6 +23,7 @@ import { UserInfoState } from "../../../../slices/userInfoSlice";
 import { TransformedAcl } from "../../../../slices/aclDetailsSlice";
 import { removeNotificationWizardForm } from "../../../../slices/notificationSlice";
 import NewMetadataCommonPage from "../ModalTabsAndPages/NewMetadataCommonPage";
+import { hasAccess } from "../../../../utils/utils";
 
 /**
  * This component manages the pages of the new series wizard and the submission of values
@@ -87,7 +88,7 @@ const NewSeriesWizard: React.FC<{
 		{
 			translation: "EVENTS.SERIES.NEW.TOBIRA.CAPTION",
 			name: "tobira",
-			hidden: !!(tobiraStatus === "failed" && tobiraError?.message?.includes("503")),
+			hidden: !hasAccess("ROLE_UI_SERIES_DETAILS_TOBIRA_EDIT", user) || !!(tobiraStatus === "failed" && tobiraError?.message?.includes("503")),
 		},
 		{
 			translation: "EVENTS.SERIES.NEW.SUMMARY.CAPTION",


### PR DESCRIPTION
In the series create modal, we query ´/admin-ng/series/new/tobira/page` to check if Tobira is available. However, if the user does not have the role required for that endpoint (ROLE_UI_SERIES_DETAILS_TOBIRA_EDIT), the endpoint will return an error html page which we are not expecting, causing the ui to crash.
This fixes the problem by checking if the user has the required role to make the request to the endpoint. If the user does not have the role, the tobira tab is then not shown.

### How to test this

Ideally test without but also with a configured Tobira, and with a user who has tobira roles and who does not have tobira roles.