### PR TITLE
Remove filter selection if no value is selected

### DIFF
--- a/src/components/shared/TableFilters.tsx
+++ b/src/components/shared/TableFilters.tsx
@@ -141,6 +141,12 @@ const TableFilters = ({
 	};
 
 	useEffect(() => {
+		// Reset filter selection to ensure filter selection is closed on mount/reload
+		dispatch(removeSelectedFilter());
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
+	useEffect(() => {
 		// Call to apply filter changes with 500MS debounce!
 		let applyFilterChangesDebouncedTimeoutId = setTimeout(applyFilterChangesDebounced, 500);
 


### PR DESCRIPTION
When a filter was selected, but no value was chosen, the filter dropdown or datepicker was unexpectedly opening on a page reload.

This fixes this issue including #1079
