### PR TITLE
Remove test deployment if PR is closed

### DIFF
--- a/.github/workflows/remove-test.yml
+++ b/.github/workflows/remove-test.yml
@@ -1,0 +1,63 @@
+name: Remove Pull Request Page
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  delete_directory:
+    runs-on: ubuntu-latest
+    steps:
+      - name: prepare git
+        run: |
+          git config --global user.name "Admin Interface Deployment Bot"
+          git config --global user.email "cloud@opencast.org"
+
+      - name: prepare GitHub SSH key
+        env:
+          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY_TEST }}
+        run: |
+          install -dm 700 ~/.ssh/
+          echo "${DEPLOY_KEY}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+      - name: clone repository
+        run: |
+          git clone "git@github.com:opencast/opencast-admin-interface-test.git" admin-interface-test
+
+      - name: switch to gh-pages branch
+        working-directory: admin-interface-test
+        run: |
+          git checkout gh-pages
+
+      - name: delete build
+        working-directory: admin-interface-test
+        run: |
+          if [ -d "${PR_NUMBER}" ]; then
+            rm -rf "${PR_NUMBER}"
+            echo "Directory ${PR_NUMBER} deleted successfully."
+          else
+            echo "Directory ${PR_NUMBER} does not exist. Skipping deletion."
+          fi
+
+      - name: clean index.html
+        working-directory: admin-interface-test
+        run: |
+          echo '<html><body><ul>' > index.html
+          find . -maxdepth 2 -name '*_*' -type d \
+            | sort -r \
+            | sed 's/^\(.*\)$/<li><a href=\1>\1<\/a><\/li>/' >> index.html
+          echo '</ul></body></html>' >> index.html
+
+      - name: commit new version
+        working-directory: admin-interface-test
+        run: |
+          git add .
+          git commit -m "Remove deployment ${PR_NUMBER} due to PR closure"
+
+      - name: push updates
+        working-directory: admin-interface-test
+        run: |
+          git push origin gh-pages


### PR DESCRIPTION
This workflow automatically removes test deployment directories when a pull request is closed. It ensures that obsolete test environments are cleaned up, preventing unnecessary storage usage.