### PR TITLE
Properly clean up pull requests

### DIFF
--- a/.github/workflows/remove-test.yml
+++ b/.github/workflows/remove-test.yml
@@ -1,7 +1,7 @@
 name: Remove Pull Request Page
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
 


### PR DESCRIPTION
This PR follow #1133, changing the event type that the workflow operates on from `pull_request` to `pull_request_target`.  The former does *not* have proper access to the `DEPLOY_KEY_TEST` secret required to successfully clone the test repository, failing the workflow after the merge.
