### PR TITLE
Restore table checkboxes on load

### DIFF
--- a/src/slices/tableSlice.ts
+++ b/src/slices/tableSlice.ts
@@ -70,7 +70,7 @@ export function isSeries(row: Row | Event | Series | Recording | Server | Job | 
 // TODO: Improve row typing. While this somewhat correctly reflects the current state of our code, it is rather annoying to work with.
 export type Row = { selected: boolean } & ( Event | Series | Recording | Server | Job | Service | User | Group | AclResult | ThemeDetailsType )
 
-export type Resource = "events" | "series" | "recordings" | "jobs" | "servers" | "services" | "users" | "groups" | "acls" | "themes"
+export type Resource = "" | "events" | "series" | "recordings" | "jobs" | "servers" | "services" | "users" | "groups" | "acls" | "themes"
 
 export type TableState = {
 	status: 'uninitialized' | 'loading' | 'succeeded' | 'failed',
@@ -92,7 +92,7 @@ const initialState: TableState = {
 	status: 'uninitialized',
 	error: null,
 	multiSelect: false,
-	resource: "events",
+	resource: "",
 	pages: [],
 	columns: [],
 	sortBy: {


### PR DESCRIPTION
Fixes #1136.
Table checkboxes were not rendered upon initial load. This patch fixes that.

### How to test this

Can be tested as usual. Tables should again always render the selection checkboxes (if applicable for that table). The reset button in the edit table view modal should also continue to work.