### PR TITLE
Fix cancel button in column selection modal

### DIFF
--- a/src/components/shared/EditTableViewModal.tsx
+++ b/src/components/shared/EditTableViewModal.tsx
@@ -106,7 +106,7 @@ const EditTableViewModalContent = ({
 	const clearData = () => {
 		setActiveColumns(originalActiveColumns);
 		setDeactivatedColumns(originalDeactivatedColumns);
-		close();
+		handleClose();
 	};
 
 	// Reset columns to how they were before the user made any changes ever


### PR DESCRIPTION
The cancel button in the modal where the user can select which columns should be displayed in a table was broken by 26d7417fbbd8f2e0c9dca10716378b63157055bc.
This patch fixes that.

### How to test this
Can be tested as usual. 