### PR TITLE
Fix event/series modal not wide enough

### DIFF
--- a/src/components/events/partials/modals/EventDetailsModal.tsx
+++ b/src/components/events/partials/modals/EventDetailsModal.tsx
@@ -44,7 +44,7 @@ const EventDetailsModal = () => {
 			open
 			closeCallback={close}
 			header={t("EVENTS.EVENTS.DETAILS.HEADER", { name: event.title })}
-			classId="event-details-modal"
+			classId="details-modal"
 			ref={modalRef}
 		>
 			<EventDetails

--- a/src/components/events/partials/modals/SeriesDetailsModal.tsx
+++ b/src/components/events/partials/modals/SeriesDetailsModal.tsx
@@ -40,7 +40,7 @@ const SeriesDetailsModal = ({
 		<Modal
 			closeCallback={close}
 			header={t("EVENTS.SERIES.DETAILS.HEADER", { name: seriesTitle })}
-			classId="series-details-modal"
+			classId="details-modal"
 			ref={modalRef}
 		>
 			<SeriesDetails


### PR DESCRIPTION
The tabs in the event/series details modals were wrapping around in case there were too many of them, due to the of the container being too small. This fixes that by applying the correct class id for those modals again, which was lost due to multiple PRs.

Arguably the fixed widths here are the true problem and we should look into making our modal css more dynamic, but that's a task for another PR.

Screenshot of the bug:
![Unbenannt](https://github.com/user-attachments/assets/330ad50c-2b98-4238-b57a-3a76fbbfec6c)

### How to test this
Cause as many tabs to appear in the event details as possible by
- Schedule the event
- Configure Extended Metadata
- Configure Tobira