### PR TITLE
Fix event summary page crashing for dates

### DIFF
--- a/src/components/events/partials/wizards/summaryTables/MetadataSummaryTable.tsx
+++ b/src/components/events/partials/wizards/summaryTables/MetadataSummaryTable.tsx
@@ -14,7 +14,7 @@ const MetadataSummaryTable = ({
 	header
 }: {
 	metadataCatalogs: MetadataCatalog[],
-	formikValues: { [key: string]: string | string[] | boolean },
+	formikValues: { [key: string]: string | string[] | boolean | Date },
 	header: string,
 }) => {
 	const { t } = useTranslation();
@@ -52,6 +52,10 @@ const MetadataSummaryTable = ({
 						},
 						t
 					)
+				}
+
+				if (fieldValue instanceof Date) {
+					fieldValue = t("dateFormats.dateTime.short", { dateTime: fieldValue })
 				}
 
 				metadata = metadata.concat({


### PR DESCRIPTION
If you specify a date in the metadata when creating a new event (which you do not do with the default metadata catalog), the event summary page will crash the app. This patch should fix that.

Kind of fixes #937. Not the exact error described in the issue, which I could not reproduce, but the general problem of being unable to create a new event with date property in extended metadata.

### How to test this
One way to test this is to create an extended metadata catalog in your Opencast (see https://docs.opencast.org/develop/admin/#configuration/metadata/#extended-metadata) and add a field of type "date" to it.