### PR TITLE
Reset workflow info on error

### DIFF
--- a/src/slices/eventDetailsSlice.ts
+++ b/src/slices/eventDetailsSlice.ts
@@ -2298,6 +2298,18 @@ const eventDetailsSlice = createSlice({
 			})
 			.addCase(fetchWorkflows.rejected, (state, action) => {
 				state.statusWorkflows = 'failed';
+				state.workflows = {
+					scheduling: false,
+					entries: [],
+					workflow: {
+						workflowId: "",
+						description: "",
+					},
+				};
+				state.workflowConfiguration = {
+					workflowId: "",
+					description: "",
+				};
 				state.errorWorkflows = action.error;
 				console.error(action.error);
 			})


### PR DESCRIPTION
Should fix #908.
Make sure that in case of an error when fetching workflows for an event, we clear out workflow data in redux just in case there is some data left in there for whatever reason.