### PR TITLE
Fix create modal strings

### DIFF
--- a/src/components/shared/NewResourceModal.tsx
+++ b/src/components/shared/NewResourceModal.tsx
@@ -32,10 +32,10 @@ const NewResourceModal = ({
 		switch(resource) {
 			case "events": return t("EVENTS.EVENTS.NEW.CAPTION");
 			case "series": return t("EVENTS.SERIES.NEW.CAPTION");
-			case "themes": return t("CONFIGURATION.THEMES.NEW.CAPTION");
+			case "themes": return t("CONFIGURATION.THEMES.DETAILS.NEWCAPTION");
 			case "acl": return t("USERS.ACLS.NEW.CAPTION");
 			case "group": return t("USERS.GROUPS.NEW.CAPTION");
-			case "user": return t("USERS.USERS.NEW.CAPTION");
+			case "user": return t("USERS.USERS.DETAILS.NEWCAPTION");
 		}
 	}
 


### PR DESCRIPTION
Fixes the translation string for the header of the create modals for themes and users.

### How to test this.
Themes need to be enabled in your Opencast in etc/org.opencastproject.organization-mh_default_org.cfg.