### PR TITLE
Typecheck translation strings

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -10,6 +10,7 @@ import { setOffset } from "../slices/tableSlice";
 import NewResourceModal, { NewResource } from "./shared/NewResourceModal";
 import { useHotkeys } from "react-hotkeys-hook";
 import { ModalHandle } from "./shared/modals/Modal";
+import { ParseKeys } from "i18next";
 
 /**
  * Component that renders the nav bar
@@ -18,18 +19,18 @@ type LinkType = {
 	path: string
 	accessRole: string
 	loadFn: (dispatch: AppDispatch) => void
-	text: string
+	text: ParseKeys
 }
 
 type CreateType = {
 	accessRole: string
 	onShowModal?: () => Promise<void>
 	onHideModal?: () => void
-	text: string
+	text: ParseKeys
 	isDisplay?: boolean
 	resource: NewResource
 	hotkeySequence?: string[]
-	hotkeyDescription?: string
+	hotkeyDescription?: ParseKeys
 }
 
 const NavBar = ({
@@ -41,7 +42,7 @@ const NavBar = ({
 	create,
 } : {
 	children?: React.ReactNode
-	navAriaLabel?: string
+	navAriaLabel?: ParseKeys
 	displayNavigation: boolean
 	setNavigation: React.Dispatch<React.SetStateAction<boolean>>
 	links: LinkType[]
@@ -73,7 +74,7 @@ const NavBar = ({
 	useHotkeys(
 		(create && create.hotkeySequence) ?? [],
 		() => showNewResourceModal(),
-		{ description: t((create && create.hotkeyDescription) ?? "") ?? undefined },
+		{ description: create && create.hotkeyDescription ? t(create.hotkeyDescription) : undefined },
 		[showNewResourceModal]
 	);
 

--- a/src/components/configuration/partials/wizard/NewThemeWizard.tsx
+++ b/src/components/configuration/partials/wizard/NewThemeWizard.tsx
@@ -11,6 +11,7 @@ import { usePageFunctions } from "../../../../hooks/wizardHooks";
 import { NewThemeSchema } from "../../../../utils/validate";
 import { useAppDispatch } from "../../../../store";
 import { postNewTheme, ThemeDetailsInitialValues } from "../../../../slices/themeSlice";
+import { ParseKeys } from "i18next";
 
 /**
  * This component manages the pages of the new theme wizard and the submission of values
@@ -34,7 +35,10 @@ const NewThemeWizard: React.FC<{
 	 } = usePageFunctions(0, initialValues);
 
 	// Caption of steps used by Stepper
-	const steps = [
+	const steps: {
+		name: string
+		translation: ParseKeys
+	}[] = [
 		{
 			name: "generalForm",
 			translation: "CONFIGURATION.THEMES.DETAILS.GENERAL.CAPTION",

--- a/src/components/configuration/partials/wizard/ThemeDetails.tsx
+++ b/src/components/configuration/partials/wizard/ThemeDetails.tsx
@@ -15,6 +15,7 @@ import { useAppDispatch, useAppSelector } from "../../../../store";
 import { updateThemeDetails } from "../../../../slices/themeDetailsSlice";
 import WizardNavigationButtons from "../../../shared/wizard/WizardNavigationButtons";
 import { ThemeDetailsInitialValues } from "../../../../slices/themeSlice";
+import { ParseKeys } from "i18next";
 
 /**
  * This component manages the pages of the theme details
@@ -41,7 +42,12 @@ const ThemeDetails = ({
 	};
 
 	// information about tabs
-	const tabs = [
+	const tabs: {
+		name: string
+		tabTranslation: ParseKeys
+		translation: ParseKeys
+		accessRole: string
+	}[] = [
 		{
 			name: "generalForm",
 			tabTranslation: "CONFIGURATION.THEMES.DETAILS.GENERAL.CAPTION",

--- a/src/components/events/partials/EventsNavigation.tsx
+++ b/src/components/events/partials/EventsNavigation.tsx
@@ -1,3 +1,4 @@
+import { ParseKeys } from "i18next";
 import { fetchEvents } from "../../../slices/eventSlice";
 import { fetchSeries } from "../../../slices/seriesSlice";
 import { fetchStats } from "../../../slices/tableFilterSlice";
@@ -27,7 +28,12 @@ export const loadSeries = (dispatch: AppDispatch) => {
 	dispatch(loadSeriesIntoTable());
 };
 
-export const eventsLinks = [
+export const eventsLinks: {
+	path: string,
+	accessRole: string,
+	loadFn: (dispatch: AppDispatch) => void,
+	text: ParseKeys
+}[] = [
 	{
 		path: "/events/events",
 		accessRole: "ROLE_UI_EVENTS_VIEW",

--- a/src/components/events/partials/EventsStatusCell.tsx
+++ b/src/components/events/partials/EventsStatusCell.tsx
@@ -9,6 +9,7 @@ import {
 import { EventDetailsPage } from "./modals/EventDetails";
 import { hasScheduledStatus } from "../../../utils/eventDetailsUtils";
 import { IconButton } from "../../shared/IconButton";
+import { ParseKeys } from "i18next";
 
 /**
  * This component renders the status cells of events in the table view
@@ -46,7 +47,7 @@ const EventsStatusCell = ({
 			iconClassname={"crosslink"}
 			tooltipText={"EVENTS.EVENTS.TABLE.TOOLTIP.STATUS"}
 		>
-			{t(row.displayable_status)}
+			{t(row.displayable_status as ParseKeys)}
 		</IconButton>
 	);
 };

--- a/src/components/events/partials/ModalTabsAndPages/DetailsMetadataTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/DetailsMetadataTab.tsx
@@ -16,6 +16,7 @@ import { MetadataCatalog } from "../../../../slices/eventSlice";
 import { AsyncThunk } from "@reduxjs/toolkit";
 import RenderDate from "../../../shared/RenderDate";
 import WizardNavigationButtons from "../../../shared/wizard/WizardNavigationButtons";
+import { ParseKeys } from "i18next";
 
 /**
  * This component renders metadata details of a certain event or series
@@ -35,7 +36,7 @@ const DetailsMetadataTab = ({
 		catalog: MetadataCatalog;
 	}, any> //(id: string, values: { [key: string]: any }, catalog: MetadataCatalog) => void,
 	editAccessRole: string,
-	header?: string
+	header?: ParseKeys
 }) => {
 	const { t } = useTranslation();
 	const dispatch = useAppDispatch();
@@ -91,7 +92,7 @@ const DetailsMetadataTab = ({
 										/* Render table for each metadata catalog */
 										<div className="obj tbl-details" key={key}>
 											<header>
-												<span>{t(header ? header : catalog.title)}</span>
+												<span>{t(header ? header : catalog.title as ParseKeys)}</span>
 											</header>
 											<div className="obj-container">
 												<table className="main-tbl">
@@ -101,7 +102,7 @@ const DetailsMetadataTab = ({
 															catalog.fields.map((field, index) => (
 																<tr key={index}>
 																	<td>
-																		<span>{t(field.label)}</span>
+																		<span>{t(field.label as ParseKeys)}</span>
 																		{field.required && (
 																			<i className="required">*</i>
 																		)}

--- a/src/components/events/partials/ModalTabsAndPages/EditScheduledEventsEditPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EditScheduledEventsEditPage.tsx
@@ -243,7 +243,7 @@ const EditScheduledEventsEditPage = <T extends RequiredFormProps>({
 										{
 											reduceGroupEvents(Object.values(groupBy(formik.values.editedEvents, i => i.weekday))).map((groupedEvent, key) => (
 												<div className="obj tbl-details">
-													<header>{t("EVENTS.EVENTS.NEW.WEEKDAYSLONG." + groupedEvent.weekday)
+													<header>{t(`EVENTS.EVENTS.NEW.WEEKDAYSLONG.${groupedEvent.weekday}`)
 														+ " ("
 														+ t("BULK_ACTIONS.EDIT_EVENTS.EDIT.EVENTS")
 														+ " "
@@ -272,7 +272,7 @@ const EditScheduledEventsEditPage = <T extends RequiredFormProps>({
 																			disabled={false}
 																			title={"EVENTS.EVENTS.DETAILS.SOURCE.DATE_TIME.START_TIME"}
 																			hourPlaceholder={"EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.HOUR"}
-																			minutePlaceholder={"EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.MINUTES"}
+																			minutePlaceholder={"EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.MINUTE"}
 																			callbackHour={(value: string) => {
 																				for (const [i, entry] of formik.values.editedEvents.entries()) {
 																					if (entry.weekday === groupedEvent.weekday ) {
@@ -300,7 +300,7 @@ const EditScheduledEventsEditPage = <T extends RequiredFormProps>({
 																			disabled={false}
 																			title={"EVENTS.EVENTS.DETAILS.SOURCE.DATE_TIME.END_TIME"}
 																			hourPlaceholder={"EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.HOUR"}
-																			minutePlaceholder={"EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.MINUTES"}
+																			minutePlaceholder={"EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.MINUTE"}
 																			callbackHour={(value: string) => {
 																				for (const [i, entry] of formik.values.editedEvents.entries()) {
 																					if (entry.weekday === groupedEvent.weekday ) {
@@ -329,9 +329,7 @@ const EditScheduledEventsEditPage = <T extends RequiredFormProps>({
 																			inputDevices={inputDevices}
 																			disabled={false}
 																			title={"EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.LOCATION"}
-																			placeholder={`-- ${t(
-																						"SELECT_NO_OPTION_SELECTED"
-																					)} --`}
+																			placeholder={"SELECT_NO_OPTION_SELECTED"}
 																			callback={(value: string) => {
 																				for (const [i, entry] of formik.values.editedEvents.entries()) {
 																					if (entry.weekday === groupedEvent.weekday ) {

--- a/src/components/events/partials/ModalTabsAndPages/EditScheduledEventsGeneralPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EditScheduledEventsGeneralPage.tsx
@@ -15,6 +15,7 @@ import { useAppSelector } from "../../../../store";
 import { FormikProps } from "formik";
 import { Event } from "../../../../slices/eventSlice";
 import WizardNavigationButtons from "../../../shared/wizard/WizardNavigationButtons";
+import { ParseKeys } from "i18next";
 
 /**
  * This component renders the table overview of selected events in edit scheduled events bulk action
@@ -119,7 +120,7 @@ const EditScheduledEventsGeneralPage = <T extends RequiredFormProps>({
 												<td className="nowrap">
 													{event.series ? event.series.title : ""}
 												</td>
-												<td className="nowrap">{t(event.event_status)}</td>
+												<td className="nowrap">{t(event.event_status as ParseKeys)}</td>
 											</tr>
 										))}
 									</tbody>

--- a/src/components/events/partials/ModalTabsAndPages/EditScheduledEventsSummaryPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EditScheduledEventsSummaryPage.tsx
@@ -6,6 +6,7 @@ import { getSchedulingSeriesOptions } from "../../../../selectors/eventSelectors
 import { useAppSelector } from "../../../../store";
 import { FormikProps } from "formik";
 import { EditedEvents } from "../../../../slices/eventSlice";
+import { ParseKeys } from "i18next";
 
 /**
  * This component renders the summary page of the edit scheduled bulk action
@@ -13,6 +14,16 @@ import { EditedEvents } from "../../../../slices/eventSlice";
 interface RequiredFormProps {
 	editedEvents: EditedEvents[],
 	changedEvents: string[],
+}
+
+type Change = {
+	eventId: string,
+	title: string,
+	changes: {
+		type: ParseKeys,
+		previous: string,
+		next: string
+	}[]
 }
 
 const EditScheduledEventsSummaryPage = <T extends RequiredFormProps>({
@@ -25,7 +36,7 @@ const EditScheduledEventsSummaryPage = <T extends RequiredFormProps>({
 	const { t } = useTranslation();
 
 	// Changes applied to events
-	const [changes, setChanges] = useState<{eventId: string, title: string, changes: { type: string, previous: string, next: string }[]}[]>([]);
+	const [changes, setChanges] = useState<Change[]>([]);
 
 	const seriesOptions = useAppSelector(state => getSchedulingSeriesOptions(state));
 
@@ -36,11 +47,11 @@ const EditScheduledEventsSummaryPage = <T extends RequiredFormProps>({
 	}, []);
 
 	const checkForChanges = () => {
-		let changed: {eventId: string, title: string, changes: { type: string, previous: string, next: string }[]}[] = [];
+		let changed: Change[] = [];
 
 		// Loop through each event selected for editing and compare original values and changed values
 		for (const event of formik.values.editedEvents) {
-			let eventChanges : {eventId: string, title: string, changes: { type: string, previous: string, next: string }[]}= {
+			let eventChanges: Change = {
 				eventId: event.eventId,
 				title: event.title,
 				changes: [],
@@ -110,8 +121,8 @@ const EditScheduledEventsSummaryPage = <T extends RequiredFormProps>({
 			if (isChanged(event.weekday, event.changedWeekday)) {
 				eventChanges.changes.push({
 					type: "EVENTS.EVENTS.TABLE.WEEKDAY",
-					previous: t("EVENTS.EVENTS.NEW.WEEKDAYSLONG." + event.weekday),
-					next: t("EVENTS.EVENTS.NEW.WEEKDAYSLONG." + event.changedWeekday),
+					previous: t(`EVENTS.EVENTS.NEW.WEEKDAYSLONG.${event.weekday}`),
+					next: t(`EVENTS.EVENTS.NEW.WEEKDAYSLONG.${event.changedWeekday}`),
 				});
 			}
 

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsAccessPolicyTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsAccessPolicyTab.tsx
@@ -8,6 +8,7 @@ import {
 	saveAccessPolicies,
 } from "../../../../slices/eventDetailsSlice";
 import { useTranslation } from "react-i18next";
+import { ParseKeys } from "i18next";
 
 /**
  * This component manages the access policy tab of the event details modal
@@ -19,7 +20,7 @@ const EventDetailsAccessPolicyTab = ({
 	setPolicyChanged,
 }: {
 	eventId: string,
-	header: string,
+	header: ParseKeys,
 	policyChanged: boolean,
 	setPolicyChanged: (value: boolean) => void,
 }) => {

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetsTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetsTab.tsx
@@ -31,6 +31,7 @@ import EventDetailsAssetMedia from "./EventDetailsAssetMedia";
 import EventDetailsAssetMediaDetails from "./EventDetailsAssetMediaDetails";
 import EventDetailsAssetPublications from "./EventDetailsAssetPublications";
 import EventDetailsAssetPublicationDetails from "./EventDetailsAssetPublicationDetails";
+import { ParseKeys } from "i18next";
 
 /**
  * This component manages the main assets tab of event details modal
@@ -51,7 +52,11 @@ const EventDetailsAssetsTab = ({
 	const transactionsReadOnly = useAppSelector(state => isTransactionReadOnly(state));
 	const isFetchingAssetUploadOptions = useAppSelector(state => getIsFetchingAssetUploadOptions(state));
 
-	const assetsTabs = [
+	const assetsTabs: {
+		tabNameTranslation: ParseKeys
+		tabHierarchies: string[]
+		open: () => void
+	}[] = [
 		{
 			tabNameTranslation: "EVENTS.EVENTS.DETAILS.ASSETS.ATTACHMENTS.TITLE",
 			tabHierarchies: ["asset-attachments", "attachment-details"],

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsCommentsTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsCommentsTab.tsx
@@ -21,6 +21,7 @@ import {
 } from "../../../../slices/eventDetailsSlice";
 import { renderValidDate } from "../../../../utils/dateUtils";
 import { useTranslation } from "react-i18next";
+import { ParseKeys } from "i18next";
 
 /**
  * This component manages the comment tab of the event details modal
@@ -30,7 +31,7 @@ const EventDetailsCommentsTab = ({
 	header,
 }: {
 	eventId: string,
-	header: string,
+	header: ParseKeys,
 }) => {
 	const { t } = useTranslation();
 	const dispatch = useAppDispatch();
@@ -140,7 +141,7 @@ const EventDetailsCommentsTab = ({
 												<strong>
 													{t("EVENTS.EVENTS.DETAILS.COMMENTS.REASON")}
 												</strong>
-												:{" " + t(comment.reason) || ""}
+												:{" " + t(comment.reason as ParseKeys) || ""}
 											</span>
 
 											{/* comment text */}
@@ -195,7 +196,7 @@ const EventDetailsCommentsTab = ({
 															<strong>
 																{t("EVENTS.EVENTS.DETAILS.COMMENTS.REASON")}
 															</strong>
-															:{" " + t(comment.reason) || ""}
+															:{" " + t(comment.reason as ParseKeys) || ""}
 														</span>
 														<p>
 															<span>@{comment.author.name}</span> {reply.text}
@@ -245,7 +246,7 @@ const EventDetailsCommentsTab = ({
 										<div className="editable">
 											<DropDown
 												value={commentReason}
-												text={t(commentReason)}
+												text={t(commentReason as ParseKeys)}
 												options={Object.entries(commentReasons).map(([key, value]) => ({ label: value, value: key }))}
 												required={true}
 												handleChange={(element) => {

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsPublicationTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsPublicationTab.tsx
@@ -4,6 +4,7 @@ import Notifications from "../../../shared/Notifications";
 import { getPublications } from "../../../../selectors/eventDetailsSelectors";
 import { useAppDispatch, useAppSelector } from "../../../../store";
 import { fetchEventPublications } from "../../../../slices/eventDetailsSlice";
+import { ParseKeys } from "i18next";
 
 const EventDetailsPublicationTab = ({
 	eventId,
@@ -61,7 +62,7 @@ const EventDetailsPublicationTab = ({
 															)}
 														</span>
 														<div>
-															<span>{publication.label ? t(publication.label) : t(publication.name)}</span>
+															<span>{publication.label ? t(publication.label as ParseKeys) : t(publication.name as ParseKeys)}</span>
 															{publication.description && (
 																<p className="description">
 																	{publication.description}

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsSchedulingTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsSchedulingTab.tsx
@@ -51,6 +51,7 @@ import SchedulingEndDateDisplay from "../wizards/scheduling/SchedulingEndDateDis
 import SchedulingLocation from "../wizards/scheduling/SchedulingLocation";
 import SchedulingInputs from "../wizards/scheduling/SchedulingInputs";
 import SchedulingConflicts from "../wizards/scheduling/SchedulingConflicts";
+import { ParseKeys } from "i18next";
 
 /**../wizards/scheduling/SchedulingTime
  * This component manages the main assets tab of event details modal
@@ -119,6 +120,12 @@ const EventDetailsSchedulingTab = ({
 			return [];
 		}
 	};
+
+	const getInputForAgent = (deviceId: Recording["id"], input: string) => {
+		const inputs = getInputs(deviceId);
+		const value = inputs.find((agent) => agent.id === input)?.value;
+		return value ? t(value as ParseKeys) : "";
+	}
 
 	// changes the inputs in the formik
 	const changeInputs = (deviceId: Recording["id"], setFieldValue: (field: string, value: any) => Promise<void | FormikErrors<any>>) => {
@@ -309,7 +316,7 @@ const EventDetailsSchedulingTab = ({
 															disabled={!accessAllowed(formik.values.captureAgent)}
 															title={"EVENTS.EVENTS.DETAILS.SOURCE.DATE_TIME.START_TIME"}
 															hourPlaceholder={"EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.HOUR"}
-															minutePlaceholder={"EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.MINUTES"}
+															minutePlaceholder={"EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.MINUTE"}
 															callbackHour={(value: string) => {
 																changeStartHour(
 																	value,
@@ -492,11 +499,7 @@ const EventDetailsSchedulingTab = ({
 																		/>
 																	: formik.values.inputs.map((input, key) => (
 																			<span key={key}>
-																				{t(
-																					getInputs(formik.values.captureAgent).find(
-																						(agent) => agent.id === input
-																					)?.value ?? ""
-																				)}
+																				{getInputForAgent(formik.values.captureAgent, input)}
 																				<br />
 																			</span>
 																		)))}

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsStatisticsTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsStatisticsTab.tsx
@@ -8,6 +8,7 @@ import { useAppSelector } from "../../../../store";
 import { fetchEventStatisticsValueUpdate } from "../../../../slices/eventDetailsSlice";
 import { useTranslation } from "react-i18next";
 import { createChartOptions } from "../../../../utils/statisticsUtils";
+import { ParseKeys } from "i18next";
 
 /**
  * This component manages the statistics tab of the event details modal
@@ -17,7 +18,7 @@ const EventDetailsStatisticsTab = ({
 	header,
 }: {
 	eventId: string,
-	header: string,
+	header: ParseKeys,
 }) => {
 	const { t } = useTranslation();
 
@@ -49,14 +50,14 @@ const EventDetailsStatisticsTab = ({
 						statistics.map((stat, key) => (
 							<div className="obj" key={key}>
 								{/* title of statistic */}
-								<header className="no-expand">{t(stat.title)}</header>
+								<header className="no-expand">{t(stat.title as ParseKeys)}</header>
 
 								{stat.providerType === "timeSeries" ? (
 									/* visualization of statistic for time series data */
 									<div className="obj-container">
 										<TimeSeriesStatistics
 											resourceId={eventId}
-											statTitle={t(stat.title)}
+											statTitle={t(stat.title as ParseKeys)}
 											providerId={stat.providerId}
 											fromDate={stat.from}
 											toDate={stat.to}

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsTabHierarchyNavigation.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsTabHierarchyNavigation.tsx
@@ -5,6 +5,7 @@ import {
 	style_nav_hierarchy,
 	style_nav_hierarchy_inactive,
 } from "../../../../utils/eventDetailsUtils";
+import { ParseKeys } from "i18next";
 
 /**
  * This component renders the navigation hierarchy for the workflow details sub-tabs of event details modal
@@ -12,20 +13,20 @@ import {
 const EventDetailsTabHierarchyNavigation = <T,>({
 	openSubTab,
 	hierarchyDepth,
-	translationKey0 = "",
+	translationKey0,
 	subTabArgument0,
-	translationKey1 = "",
+	translationKey1,
 	subTabArgument1,
-	translationKey2 = "",
+	translationKey2,
 	subTabArgument2,
 }: {
 	openSubTab: (tabType: T) => void,
 	hierarchyDepth: number,
-	translationKey0: string,
+	translationKey0: ParseKeys,
 	subTabArgument0: T,
-	translationKey1?: string,
+	translationKey1?: ParseKeys,
 	subTabArgument1?: T,
-	translationKey2?: string,
+	translationKey2?: ParseKeys,
 	subTabArgument2?: T,
 }) => {
 	const { t } = useTranslation();
@@ -57,7 +58,7 @@ const EventDetailsTabHierarchyNavigation = <T,>({
 					}
 					onClick={() => openSubTab(subTabArgument1)}
 				>
-					{t(translationKey1)}
+					{translationKey1 && t(translationKey1)}
 					{hierarchyDepth > 1 && (
 						<span style={style_nav_hierarchy_inactive}> </span>
 					)}
@@ -69,7 +70,7 @@ const EventDetailsTabHierarchyNavigation = <T,>({
 					style={style_nav_hierarchy}
 					onClick={() => openSubTab(subTabArgument2)}
 				>
-					{t(translationKey2)}
+					{translationKey2 && t(translationKey2)}
 				</button>
 			)}
 		</nav>

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowDetails.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowDetails.tsx
@@ -17,6 +17,7 @@ import { removeNotificationWizardForm } from "../../../../slices/notificationSli
 import { renderValidDate } from "../../../../utils/dateUtils";
 import { WorkflowTabHierarchy } from "../modals/EventDetails";
 import { useTranslation } from "react-i18next";
+import { ParseKeys } from "i18next";
 
 /**
  * This component manages the workflow details for the workflows tab of the event details modal
@@ -135,7 +136,7 @@ const EventDetailsWorkflowDetails = ({
 														) /* Status */
 													}
 												</td>
-												<td>{t(workflowData.status)}</td>
+												<td>{t(workflowData.status as ParseKeys)}</td>
 											</tr>
 											{workflowData.status !==
 												"EVENTS.EVENTS.DETAILS.WORKFLOWS.OPERATION_STATUS.RUNNING" && (

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowOperationDetails.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowOperationDetails.tsx
@@ -11,6 +11,7 @@ import { renderValidDate } from "../../../../utils/dateUtils";
 import { useTranslation } from "react-i18next";
 import { setModalWorkflowTabHierarchy } from "../../../../slices/eventDetailsSlice";
 import { WorkflowTabHierarchy } from "../modals/EventDetails";
+import { ParseKeys } from "i18next";
 
 /**
  * This component manages the workflow operation details for the workflows tab of the event details modal
@@ -87,7 +88,7 @@ const EventDetailsWorkflowOperationDetails = () => {
 													) /* State */
 												}
 											</td>
-											<td>{t(operationDetails.state)}</td>
+											<td>{t(operationDetails.state as ParseKeys)}</td>
 										</tr>
 										<tr>
 											<td>

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowOperations.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowOperations.tsx
@@ -11,6 +11,7 @@ import {
 } from "../../../../slices/eventDetailsSlice";
 import { useTranslation } from "react-i18next";
 import { WorkflowTabHierarchy } from "../modals/EventDetails";
+import { ParseKeys } from "i18next";
 
 /**
  * This component manages the workflow operations for the workflows tab of the event details modal
@@ -111,7 +112,7 @@ const EventDetailsWorkflowOperations = ({
 									{/* workflow operation details */}
 									{operations.entries.map((item, key) => (
 										<tr key={key}>
-											<td>{t(item.status)}</td>
+											<td>{t(item.status as ParseKeys)}</td>
 											<td>{item.title}</td>
 											<td>{item.description}</td>
 

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowTab.tsx
@@ -30,6 +30,7 @@ import { Tooltip } from "../../../shared/Tooltip";
 import { WorkflowTabHierarchy } from "../modals/EventDetails";
 import { useTranslation } from "react-i18next";
 import { formatWorkflowsForDropdown } from "../../../../utils/dropDownUtils";
+import { ParseKeys } from "i18next";
 
 /**
  * This component manages the workflows tab of the event details modal
@@ -197,7 +198,7 @@ const EventDetailsWorkflowTab = ({
 																	dateTime: renderValidDate(item.submitted),
 																})}
 															</td>
-															<td>{t(item.status)}</td>
+															<td>{t(item.status as ParseKeys)}</td>
 															{isRoleWorkflowEdit && (
 																<td>
 																	{item.status ===

--- a/src/components/events/partials/ModalTabsAndPages/NewMetadataCommonPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewMetadataCommonPage.tsx
@@ -3,6 +3,7 @@ import { FormikProps } from "formik";
 import WizardNavigationButtons from "../../../shared/wizard/WizardNavigationButtons";
 import { MetadataCatalog } from "../../../../slices/eventSlice";
 import NewMetadataPage from "./NewMetadataPage";
+import { ParseKeys } from "i18next";
 
 /**
  * This component renders the metadata page for new events and series in the wizards.
@@ -16,7 +17,7 @@ const NewMetadataCommonPage = <T,>({
 	formik: FormikProps<T>,
 	nextPage: (values: T) => void,
 	metadataFields: MetadataCatalog,
-	header: string
+	header: ParseKeys
 }) => {
 
 	return (

--- a/src/components/events/partials/ModalTabsAndPages/NewMetadataPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewMetadataPage.tsx
@@ -5,6 +5,7 @@ import RenderField from "../../../shared/wizard/RenderField";
 import RenderMultiField from "../../../shared/wizard/RenderMultiField";
 import { MetadataCatalog } from "../../../../slices/eventSlice";
 import { getMetadataCollectionFieldName } from "../../../../utils/resourceUtils";
+import { ParseKeys } from "i18next";
 
 /**
  * This component renders the metadata page for new events and series in the wizards.
@@ -14,7 +15,7 @@ const NewMetadataPage = ({
 	header
 }: {
 	metadataCatalogs: MetadataCatalog [],
-	header?: string
+	header?: ParseKeys
 }) => {
 	const { t } = useTranslation();
 
@@ -30,7 +31,7 @@ const NewMetadataPage = ({
 								<div className="obj tbl-list">
 									{/* <header className="no-expand">{t(header)}</header> */}
 									<header>
-										<span>{t(header ? header : catalog.title)}</span>
+										<span>{t(header ? header : catalog.title as ParseKeys)}</span>
 									</header>
 									{/* Table view containing input fields for metadata */}
 									<div className="obj-container">
@@ -41,7 +42,7 @@ const NewMetadataPage = ({
 													catalog.fields.map((field, key) => (
 														<tr key={key}>
 															<td>
-																<span>{t(field.label)}</span>
+																<span>{t(field.label as ParseKeys)}</span>
 																{field.required && (
 																	<i className="required">*</i>
 																)}

--- a/src/components/events/partials/ModalTabsAndPages/NewSourcePage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewSourcePage.tsx
@@ -46,6 +46,7 @@ import SchedulingEndDateDisplay from "../wizards/scheduling/SchedulingEndDateDis
 import SchedulingLocation from "../wizards/scheduling/SchedulingLocation";
 import SchedulingInputs from "../wizards/scheduling/SchedulingInputs";
 import SchedulingConflicts from "../wizards/scheduling/SchedulingConflicts";
+import { ParseKeys } from "i18next";
 
 /**
  * This component renders the source page for new events in the new event wizard.
@@ -325,7 +326,7 @@ const Upload = <T extends RequiredFormPropsUpload>({
 							{sourceMetadata.UPLOAD && sourceMetadata.UPLOAD.metadata.map((field, key) => (
 								<tr key={key}>
 									<td>
-										<span>{t(field.label)}</span>
+										<span>{t(field.label as ParseKeys)}</span>
 										{field.required && <i className="required">*</i>}
 									</td>
 									<td className="editable">
@@ -492,7 +493,7 @@ const Schedule = <T extends {
 							disabled={false}
 							title={"EVENTS.EVENTS.NEW.SOURCE.DATE_TIME.START_TIME"}
 							hourPlaceholder={"EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.HOUR"}
-							minutePlaceholder={"EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.MINUTES"}
+							minutePlaceholder={"EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.MINUTE"}
 							callbackHour={(value: string) => {
 								if (formik.values.sourceMode === "SCHEDULE_MULTIPLE") {
 									changeStartHourMultiple(
@@ -531,7 +532,7 @@ const Schedule = <T extends {
 							disabled={false}
 							title={"EVENTS.EVENTS.NEW.SOURCE.DATE_TIME.DURATION"}
 							hourPlaceholder={"EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.HOUR"}
-							minutePlaceholder={"EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.MINUTES"}
+							minutePlaceholder={"EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.MINUTE"}
 							callbackHour={(value: string) => {
 								if (formik.values.sourceMode === "SCHEDULE_MULTIPLE") {
 									changeDurationHourMultiple(
@@ -570,7 +571,7 @@ const Schedule = <T extends {
 							disabled={false}
 							title={"EVENTS.EVENTS.NEW.SOURCE.DATE_TIME.END_TIME"}
 							hourPlaceholder={"EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.HOUR"}
-							minutePlaceholder={"EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.MINUTES"}
+							minutePlaceholder={"EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.MINUTE"}
 							callbackHour={(value: string) => {
 								if (formik.values.sourceMode === "SCHEDULE_MULTIPLE") {
 									changeEndHourMultiple(

--- a/src/components/events/partials/ModalTabsAndPages/SeriesDetailsAccessTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/SeriesDetailsAccessTab.tsx
@@ -8,6 +8,7 @@ import {
 } from "../../../../slices/seriesDetailsSlice";
 import { removeNotificationWizardForm } from "../../../../slices/notificationSlice";
 import { useAppDispatch, useAppSelector } from "../../../../store";
+import { ParseKeys } from "i18next";
 
 /**
  * This component manages the access policy tab of the series details modal
@@ -19,7 +20,7 @@ const SeriesDetailsAccessTab = ({
 	setPolicyChanged,
 }: {
 	seriesId: string,
-	header: string,
+	header: ParseKeys,
 	policyChanged: boolean,
 	setPolicyChanged: (value: boolean) => void,
 }) => {

--- a/src/components/events/partials/ModalTabsAndPages/SeriesDetailsStatisticTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/SeriesDetailsStatisticTab.tsx
@@ -8,13 +8,14 @@ import { fetchSeriesStatisticsValueUpdate } from "../../../../slices/seriesDetai
 import TimeSeriesStatistics from "../../../shared/TimeSeriesStatistics";
 import { useAppSelector } from "../../../../store";
 import { createChartOptions } from "../../../../utils/statisticsUtils";
+import { ParseKeys } from "i18next";
 
 const SeriesDetailsStatisticTab = ({
 	seriesId,
 	header,
 }: {
 	seriesId: string,
-	header: string,
+	header: ParseKeys,
 }) => {
 	const { t } = useTranslation();
 
@@ -46,14 +47,14 @@ const SeriesDetailsStatisticTab = ({
 						statistics.map((stat, key) => (
 							<div className="obj" key={key}>
 								{/* title of statistic */}
-								<header className="no-expand">{t(stat.title)}</header>
+								<header className="no-expand">{t(stat.title as ParseKeys)}</header>
 
 								{stat.providerType === "timeSeries" ? (
 									/* visualization of statistic for time series data */
 									<div className="obj-container">
 										<TimeSeriesStatistics
 											resourceId={seriesId}
-											statTitle={t(stat.title)}
+											statTitle={t(stat.title as ParseKeys)}
 											providerId={stat.providerId}
 											fromDate={stat.from}
 											toDate={stat.to}

--- a/src/components/events/partials/ModalTabsAndPages/StartTaskGeneralPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/StartTaskGeneralPage.tsx
@@ -15,6 +15,7 @@ import {
 } from "../../../../slices/eventSlice";
 import { useAppSelector } from "../../../../store";
 import WizardNavigationButtons from "../../../shared/wizard/WizardNavigationButtons";
+import { ParseKeys } from "i18next";
 
 /**
  * This component renders the table overview of selected events in start task bulk action
@@ -116,7 +117,7 @@ const StartTaskGeneralPage = <T extends RequiredFormProps>({
 												<td className="nowrap">
 													{event.series ? event.series.title : ""}
 												</td>
-												<td className="nowrap">{t(event.event_status)}</td>
+												<td className="nowrap">{t(event.event_status as ParseKeys)}</td>
 											</tr>
 										))}
 									</tbody>

--- a/src/components/events/partials/PublishedCell.tsx
+++ b/src/components/events/partials/PublishedCell.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Event } from "../../../slices/eventSlice";
 import { Tooltip } from "../../shared/Tooltip";
+import { ParseKeys } from "i18next";
 
 // References for detecting a click outside of the container of the popup listing publications of an event
 const containerPublications = React.createRef<HTMLDivElement>();
@@ -75,11 +76,11 @@ const PublishCell = ({
 												rel='noreferrer'
 												key={key}
 											>
-												<span>{publication.label ? t(publication.label) : t(publication.name)}</span>
+												<span>{publication.label? t(publication.label as ParseKeys) : t(publication.name as ParseKeys)}</span>
 											</a>
 										) : (
 											<button key={key} className="button-like-anchor popover__list-item">
-												<span>{publication.label ? t(publication.label) : t(publication.name)}</span>
+												<span>{publication.label ? t(publication.label as ParseKeys) : t(publication.name as ParseKeys)}</span>
 											</button>
 										)
 									) : null

--- a/src/components/events/partials/modals/EditMetadataEventsModal.tsx
+++ b/src/components/events/partials/modals/EditMetadataEventsModal.tsx
@@ -19,6 +19,7 @@ import {
 import { unwrapResult } from "@reduxjs/toolkit";
 import { isEvent } from "../../../../slices/tableSlice";
 import WizardNavigationButtons from "../../../shared/wizard/WizardNavigationButtons";
+import { ParseKeys } from "i18next";
 
 /**
  * This component manges the edit metadata bulk action
@@ -243,7 +244,7 @@ const EditMetadataEventsModal = ({
 																			/>
 																		</td>
 																		<td>
-																			<span>{t(metadata.label)}</span>
+																			<span>{t(metadata.label as ParseKeys)}</span>
 																			{metadata.required && (
 																				<i className="required">*</i>
 																			)}

--- a/src/components/events/partials/modals/EditScheduledEventsModal.tsx
+++ b/src/components/events/partials/modals/EditScheduledEventsModal.tsx
@@ -21,6 +21,7 @@ import {
 } from "../../../../slices/eventSlice";
 import { fetchRecordings } from "../../../../slices/recordingSlice";
 import { Event } from "../../../../slices/eventSlice";
+import { ParseKeys } from "i18next";
 
 /**
  * This component manages the pages of the edit scheduled bulk action
@@ -57,7 +58,10 @@ const EditScheduledEventsModal = ({
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
-	const steps = [
+	const steps: {
+		translation: ParseKeys
+		name: string
+	}[] = [
 		{
 			translation: "BULK_ACTIONS.EDIT_EVENTS.GENERAL.CAPTION",
 			name: "general",

--- a/src/components/events/partials/modals/EventDetails.tsx
+++ b/src/components/events/partials/modals/EventDetails.tsx
@@ -47,6 +47,7 @@ import { addNotification, removeNotificationByKey, removeNotificationWizardForm,
 import DetailsTobiraTab from "../ModalTabsAndPages/DetailsTobiraTab";
 import { NOTIFICATION_CONTEXT } from "../../../../configs/modalConfig";
 import { unwrapResult } from "@reduxjs/toolkit";
+import { ParseKeys } from "i18next";
 
 export enum EventDetailsPage {
 	Metadata,
@@ -132,7 +133,14 @@ const EventDetails = ({
 	const tobiraStatus = useAppSelector(state => getEventDetailsTobiraStatus(state));
 	const tobiraError = useAppSelector(state => getEventDetailsTobiraDataError(state));
 
-	const tabs = [
+	const tabs: {
+		tabNameTranslation: ParseKeys,
+		bodyHeaderTranslation?: ParseKeys,
+		accessRole: string,
+		name: string,
+		page: EventDetailsPage,
+		hidden?: boolean,
+	}[] = [
 		{
 			tabNameTranslation: "EVENTS.EVENTS.DETAILS.TABS.METADATA",
 			bodyHeaderTranslation: "EVENTS.EVENTS.DETAILS.METADATA.CAPTION",
@@ -234,7 +242,7 @@ const EventDetails = ({
 						metadata={[metadata]}
 						updateResource={updateMetadata}
 						editAccessRole="ROLE_UI_EVENTS_DETAILS_METADATA_EDIT"
-						header={tabs[page].bodyHeaderTranslation ?? ""}
+						header={tabs[page].bodyHeaderTranslation}
 					/>
 				)}
 				{page === EventDetailsPage.ExtendedMetadata && !isLoadingMetadata && (
@@ -284,7 +292,7 @@ const EventDetails = ({
 				{page === EventDetailsPage.AccessPolicy && (
 					<EventDetailsAccessPolicyTab
 						eventId={eventId}
-						header={tabs[page].bodyHeaderTranslation ?? ""}
+						header={tabs[page].bodyHeaderTranslation ?? "EVENTS.EVENTS.DETAILS.TABS.ACCESS"}
 						policyChanged={policyChanged}
 						setPolicyChanged={setPolicyChanged}
 					/>
@@ -292,7 +300,7 @@ const EventDetails = ({
 				{page === EventDetailsPage.Comments && (
 					<EventDetailsCommentsTab
 						eventId={eventId}
-						header={tabs[page].bodyHeaderTranslation ?? ""}
+						header={tabs[page].bodyHeaderTranslation ?? "EVENTS.EVENTS.DETAILS.COMMENTS.CAPTION"}
 					/>
 				)}
 				{page === EventDetailsPage.Tobira && (
@@ -304,7 +312,7 @@ const EventDetails = ({
 				{page === EventDetailsPage.Statistics && !isLoadingStatistics && (
 					<EventDetailsStatisticsTab
 						eventId={eventId}
-						header={tabs[page].bodyHeaderTranslation ?? ""}
+						header={tabs[page].bodyHeaderTranslation ?? "EVENTS.EVENTS.DETAILS.STATISTICS.CAPTION"}
 					/>
 				)}
 			</div>

--- a/src/components/events/partials/modals/SeriesDetails.tsx
+++ b/src/components/events/partials/modals/SeriesDetails.tsx
@@ -26,6 +26,7 @@ import {
 } from "../../../../slices/seriesDetailsSlice";
 import DetailsTobiraTab from "../ModalTabsAndPages/DetailsTobiraTab";
 import { removeNotificationWizardTobira } from "../../../../slices/notificationSlice";
+import { ParseKeys } from "i18next";
 
 /**
  * This component manages the tabs of the series details modal
@@ -65,7 +66,12 @@ const SeriesDetails = ({
 	const themesEnabled = (orgProperties['admin.themes.enabled'] || 'false').toLowerCase() === 'true';
 
 	// information about each tab
-	const tabs = [
+	const tabs: {
+		tabNameTranslation: ParseKeys,
+		accessRole: string,
+		name: string,
+		hidden?: boolean,
+	}[] = [
 		{
 			tabNameTranslation: "EVENTS.SERIES.DETAILS.TABS.METADATA",
 			accessRole: "ROLE_UI_SERIES_DETAILS_METADATA_VIEW",

--- a/src/components/events/partials/modals/StartTaskModal.tsx
+++ b/src/components/events/partials/modals/StartTaskModal.tsx
@@ -11,6 +11,7 @@ import { usePageFunctions } from "../../../../hooks/wizardHooks";
 import { checkValidityStartTaskEventSelection } from "../../../../utils/bulkActionUtils";
 import { useAppDispatch } from "../../../../store";
 import { Event } from "../../../../slices/eventSlice";
+import { ParseKeys } from "i18next";
 
 /**
  * This component manages the pages of the task start bulk action
@@ -34,7 +35,10 @@ const StartTaskModal = ({
 		setPageCompleted,
 	} = usePageFunctions(0, initialValues);
 
-	const steps = [
+	const steps: {
+		translation: ParseKeys
+		name: string
+	}[] = [
 		{
 			translation: "BULK_ACTIONS.SCHEDULE_TASK.GENERAL.CAPTION",
 			name: "general",

--- a/src/components/events/partials/wizards/NewEventSummary.tsx
+++ b/src/components/events/partials/wizards/NewEventSummary.tsx
@@ -14,6 +14,7 @@ import { useAppSelector } from "../../../../store";
 import { FormikProps } from "formik";
 import { TransformedAcl } from "../../../../slices/aclDetailsSlice";
 import { renderValidDate } from "../../../../utils/dateUtils";
+import { ParseKeys } from "i18next";
 
 /**
  * This component renders the summary page for new events in the new event wizard.
@@ -31,7 +32,7 @@ interface RequiredFormProps {
 	scheduleEndMinute: string
 	scheduleDurationHours: string
 	scheduleDurationMinutes: string
-	repeatOn: string[]
+	repeatOn: ("MO" | "TU" | "WE" | "TH" | "FR" | "SA" | "SU")[]
 	deviceInputs?: string[]
 	configuration: { [key: string]: string }
 	acls: TransformedAcl[]
@@ -70,7 +71,7 @@ const NewEventSummary = <T extends RequiredFormProps>({
 	for (let i = 0; uploadAssetsOptionsNonTrack.length > i; i++) {
 		let fieldValue = formik.values[uploadAssetsOptionsNonTrack[i].id];
 		if (!!fieldValue) {
-			const displayOverride = uploadAssetsOptionsNonTrack[i].displayOverride
+			const displayOverride = uploadAssetsOptionsNonTrack[i].displayOverride as ParseKeys
 			uploadAssetsNonTrack = uploadAssetsNonTrack.concat({
 				name: uploadAssetsOptionsNonTrack[i].id,
 				translate: !!displayOverride
@@ -231,7 +232,7 @@ const NewEventSummary = <T extends RequiredFormProps>({
 													<td>
 														{formik.values.repeatOn
 															.map((day) =>
-																t("EVENTS.EVENTS.NEW.WEEKDAYSLONG." + day)
+																t(`EVENTS.EVENTS.NEW.WEEKDAYSLONG.${day}`)
 															)
 															.join(", ")}
 													</td>

--- a/src/components/events/partials/wizards/NewEventWizard.tsx
+++ b/src/components/events/partials/wizards/NewEventWizard.tsx
@@ -22,6 +22,7 @@ import { UserInfoState } from "../../../../slices/userInfoSlice";
 import { removeNotificationWizardForm } from "../../../../slices/notificationSlice";
 import NewMetadataCommonPage from "../ModalTabsAndPages/NewMetadataCommonPage";
 import WizardStepper from "../../../shared/wizard/WizardStepper";
+import { ParseKeys } from "i18next";
 
 /**
  * This component manages the pages of the new event wizard and the submission of values
@@ -64,7 +65,11 @@ const NewEventWizard: React.FC<{
 	const [pageCompleted, setPageCompleted] = useState<{ [key: number]: boolean }>({});
 
 	// Caption of steps used by Stepper
-	const steps = [
+	const steps: {
+		translation: ParseKeys,
+		name: string,
+		hidden: boolean,
+	}[] = [
 		{
 			translation: "EVENTS.EVENTS.NEW.METADATA.CAPTION",
 			name: "metadata",

--- a/src/components/events/partials/wizards/NewSeriesWizard.tsx
+++ b/src/components/events/partials/wizards/NewSeriesWizard.tsx
@@ -24,6 +24,7 @@ import { TransformedAcl } from "../../../../slices/aclDetailsSlice";
 import { removeNotificationWizardForm } from "../../../../slices/notificationSlice";
 import NewMetadataCommonPage from "../ModalTabsAndPages/NewMetadataCommonPage";
 import { hasAccess } from "../../../../utils/utils";
+import { ParseKeys } from "i18next";
 
 /**
  * This component manages the pages of the new series wizard and the submission of values
@@ -64,7 +65,11 @@ const NewSeriesWizard: React.FC<{
 	}, []);
 
 	// Caption of steps used by Stepper
-	const steps = [
+	const steps: {
+		translation: ParseKeys,
+		name: string,
+		hidden: boolean,
+	}[] = [
 		{
 			translation: "EVENTS.SERIES.NEW.METADATA.CAPTION",
 			name: "metadata",

--- a/src/components/events/partials/wizards/scheduling/SchedulingInputs.tsx
+++ b/src/components/events/partials/wizards/scheduling/SchedulingInputs.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { Field } from "formik";
+import { ParseKeys } from "i18next";
 
 const SchedulingInputs = ({
 	inputs
@@ -22,7 +23,7 @@ const SchedulingInputs = ({
 							type="checkbox"
 							value={input.id}
 						/>
-						{t(input.value)}
+						{t(input.value as ParseKeys)}
 					</label>
 				)
 			)}

--- a/src/components/events/partials/wizards/scheduling/SchedulingLocation.tsx
+++ b/src/components/events/partials/wizards/scheduling/SchedulingLocation.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import DropDown from "../../../../shared/DropDown";
 import { Recording } from "../../../../../slices/recordingSlice";
 import { formatCaptureAgentForDropdown } from "../../../../../utils/dropDownUtils";
+import { ParseKeys } from "i18next";
 
 const SchedulingLocation = ({
 	location,
@@ -15,8 +16,8 @@ const SchedulingLocation = ({
 	location: string,
 	inputDevices: Recording[]
 	disabled: boolean
-	title: string
-	placeholder: string
+	title: ParseKeys
+	placeholder: ParseKeys
 	callback: (value: string) => void
 }) => {
 	const { t } = useTranslation();

--- a/src/components/events/partials/wizards/scheduling/SchedulingTime.tsx
+++ b/src/components/events/partials/wizards/scheduling/SchedulingTime.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import DropDown from "../../../../shared/DropDown";
 import { hours, minutes } from "../../../../../configs/modalConfig";
 import { formatTimeForDropdown } from "../../../../../utils/dropDownUtils";
+import { ParseKeys } from "i18next";
 
 const SchedulingTime = ({
 	hour,
@@ -17,9 +18,9 @@ const SchedulingTime = ({
 	hour: string,
 	minute: string,
 	disabled: boolean
-	title: string
-	hourPlaceholder: string
-	minutePlaceholder: string
+	title: ParseKeys
+	hourPlaceholder: ParseKeys
+	minutePlaceholder: ParseKeys
 	callbackHour: (value: string) => void
 	callbackMinute: (value: string) => void
 }) => {

--- a/src/components/events/partials/wizards/summaryTables/AccessSummaryTable.tsx
+++ b/src/components/events/partials/wizards/summaryTables/AccessSummaryTable.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { TransformedAcl } from "../../../../../slices/aclDetailsSlice";
+import { ParseKeys } from "i18next";
 
 /**
  * This component renders the access table containing access rules provided by user before in wizard summary pages
@@ -10,7 +11,7 @@ const AccessSummaryTable = ({
 	header
 }: {
 	policies: TransformedAcl[]
-	header: string
+	header: ParseKeys
 }) => {
 	const { t } = useTranslation();
 

--- a/src/components/events/partials/wizards/summaryTables/MetadataSummaryTable.tsx
+++ b/src/components/events/partials/wizards/summaryTables/MetadataSummaryTable.tsx
@@ -4,6 +4,7 @@ import { getMetadataCollectionFieldName } from "../../../../../utils/resourceUti
 import { MetadataCatalog } from "../../../../../slices/eventSlice";
 import { isEmpty } from "lodash";
 import { isEmptyArray } from "formik";
+import { ParseKeys } from "i18next";
 
 /**
  * This component renders the metadata table containing access rules provided by user before in wizard summary pages
@@ -15,7 +16,7 @@ const MetadataSummaryTable = ({
 }: {
 	metadataCatalogs: MetadataCatalog[],
 	formikValues: { [key: string]: string | string[] | boolean },
-	header: string,
+	header: ParseKeys,
 }) => {
 	const { t } = useTranslation();
 
@@ -74,7 +75,7 @@ const MetadataSummaryTable = ({
 							{/*Insert row for each metadata entry user has provided*/}
 							{catalog.map((entry, key) => (
 								<tr key={key}>
-									<td>{t(entry.label)}</td>
+									<td>{t(entry.label as ParseKeys)}</td>
 									<td>
 										{Array.isArray(entry.value)
 											? entry.value.join(", ")

--- a/src/components/recordings/partials/RecordingsStatusCell.tsx
+++ b/src/components/recordings/partials/RecordingsStatusCell.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { Recording } from "../../../slices/recordingSlice";
+import { ParseKeys } from "i18next";
 
 /**
  * This component renders the status cells of recordings in the table view
@@ -12,7 +13,7 @@ const RecordingsStatusCell = ({
 }) => {
 	const { t } = useTranslation();
 
-	return <span data-status={row.status}>{t(row.status)}</span>;
+	return <span data-status={row.status}>{t(row.status as ParseKeys)}</span>;
 };
 
 export default RecordingsStatusCell;

--- a/src/components/recordings/partials/modal/RecordingsDetails.tsx
+++ b/src/components/recordings/partials/modal/RecordingsDetails.tsx
@@ -5,6 +5,7 @@ import CapabilitiesDetailsTab from "../wizards/CapabilitiesDetailsTab";
 import { getRecordingDetails } from "../../../../selectors/recordingDetailsSelectors";
 import ModalNavigation from "../../../shared/modals/ModalNavigation";
 import { useAppSelector } from "../../../../store";
+import { ParseKeys } from "i18next";
 
 /**
  * This component manages the pages of the recording details
@@ -15,7 +16,11 @@ const RecordingsDetails: React.FC = () => {
 	const agent = useAppSelector(state => getRecordingDetails(state));
 
 	// information about tabs
-	const tabs = [
+	const tabs: {
+		tabTranslation: ParseKeys
+		accessRole: string
+		name: string
+	}[] = [
 		{
 			tabTranslation: "RECORDINGS.RECORDINGS.DETAILS.TAB.GENERAL",
 			accessRole: "ROLE_UI_LOCATIONS_DETAILS_GENERAL_VIEW",

--- a/src/components/recordings/partials/wizards/GeneralDetailsTab.tsx
+++ b/src/components/recordings/partials/wizards/GeneralDetailsTab.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { RecordingDetails } from "../../../../slices/recordingDetailsSlice";
+import { ParseKeys } from "i18next";
 
 /**
  * This component renders details about a recording/capture agent
@@ -38,7 +39,7 @@ const GeneralDetailsTab: React.FC<{
 									</tr>
 									<tr>
 										<td>{t("RECORDINGS.RECORDINGS.DETAILS.GENERAL.STATUS")}</td>
-										<td>{t(agent.status)}</td>
+										<td>{t(agent.status as ParseKeys)}</td>
 									</tr>
 									<tr>
 										<td>{t("RECORDINGS.RECORDINGS.DETAILS.GENERAL.UPDATE")}</td>

--- a/src/components/shared/ActionCellDelete.tsx
+++ b/src/components/shared/ActionCellDelete.tsx
@@ -2,6 +2,7 @@ import ConfirmModal, { ResourceType } from "./ConfirmModal";
 import { useRef } from "react";
 import { IconButton } from "./IconButton";
 import { ModalHandle } from "./modals/Modal";
+import { ParseKeys } from "i18next";
 
 export const ActionCellDelete = <T,>({
 	editAccessRole,
@@ -16,15 +17,15 @@ export const ActionCellDelete = <T,>({
 	deleteWithCautionMessage,
 }: {
 	editAccessRole: string
-	tooltipText: string
+	tooltipText: ParseKeys
 	resourceId: T
 	resourceName: string
 	resourceType: ResourceType
 	deleteMethod: (id: T) => void
 	deleteAllowed?: boolean,
 	showCautionMessage?: boolean,
-	deleteNotAllowedMessage?: string,
-	deleteWithCautionMessage?: string,
+	deleteNotAllowedMessage?: ParseKeys,
+	deleteWithCautionMessage?: ParseKeys,
 }) => {
 	const deleteConfirmationModalRef = useRef<ModalHandle>(null);
 

--- a/src/components/shared/ConfirmModal.tsx
+++ b/src/components/shared/ConfirmModal.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { Modal, ModalHandle } from "./modals/Modal";
+import { ParseKeys } from "i18next";
 
 export type ResourceType = "EVENT" | "SERIES" | "LOCATION" | "USER" | "GROUP" | "ACL" | "THEME" | "TOBIRA_PATH";
 
@@ -12,8 +13,8 @@ const ConfirmModal = <T,>({
 	deleteMethod,
 	deleteAllowed = true,
 	showCautionMessage = false,
-	deleteNotAllowedMessage = "",
-	deleteWithCautionMessage = "",
+	deleteNotAllowedMessage,
+	deleteWithCautionMessage,
 	modalRef,
 }: {
 	close: () => void,
@@ -23,8 +24,8 @@ const ConfirmModal = <T,>({
 	deleteMethod: (id: T) => void,
 	deleteAllowed?: boolean,
 	showCautionMessage?: boolean,
-	deleteNotAllowedMessage?: string,
-	deleteWithCautionMessage?: string,
+	deleteNotAllowedMessage?: ParseKeys,
+	deleteWithCautionMessage?: ParseKeys,
 	modalRef: React.RefObject<ModalHandle | null>
 }) => {
 	const { t } = useTranslation();
@@ -48,14 +49,14 @@ const ConfirmModal = <T,>({
 				<div>
 					{showCautionMessage && (
 						<div className="modal-alert warning">
-							<p>{t(deleteWithCautionMessage)}</p>
+							<p>{deleteWithCautionMessage ? t(deleteWithCautionMessage) : undefined}</p>
 						</div>
 					)}
 
 					<div>
 						<p>
 							<span style={{ padding: "0px 4px"}}>
-								{t("CONFIRMATIONS.METADATA.NOTICE." + resourceType)}
+								{t(`CONFIRMATIONS.METADATA.NOTICE.${resourceType}`)}
 							</span>
 						</p>
 						<p className="delete">{resourceName}</p>
@@ -85,7 +86,7 @@ const ConfirmModal = <T,>({
 			) : (
 				<div>
 					<div className="modal-alert danger">
-						<p>{t(deleteNotAllowedMessage)}</p>
+						<p>{deleteNotAllowedMessage ? t(deleteNotAllowedMessage) : undefined}</p>
 					</div>
 					<div className="btn-container">
 						<button

--- a/src/components/shared/DropDown.tsx
+++ b/src/components/shared/DropDown.tsx
@@ -7,6 +7,7 @@ import {
 import Select, { GroupBase, Props, SelectInstance } from "react-select";
 import CreatableSelect from "react-select/creatable";
 import { isJson } from "../../utils/utils";
+import { ParseKeys } from "i18next";
 
 export type DropDownOption = {
 	label: string,
@@ -81,7 +82,7 @@ const DropDown = <T,>({
 		required: boolean,
 	) => {
 		// Translate?
-		unformattedOptions = unformattedOptions.map(option => ({...option, label: t(option.label)}))
+		unformattedOptions = unformattedOptions.map(option => ({...option, label: t(option.label as ParseKeys)}))
 
 		// Filter
 		filterText = filterText.toLowerCase();

--- a/src/components/shared/EditTableViewModal.tsx
+++ b/src/components/shared/EditTableViewModal.tsx
@@ -20,6 +20,8 @@ import { usersTableConfig } from "../../configs/tableConfigs/usersTableConfig";
 import { groupsTableConfig } from "../../configs/tableConfigs/groupsTableConfig";
 import { themesTableConfig } from "../../configs/tableConfigs/themesTableConfig";
 import { Modal, ModalHandle } from "./modals/Modal";
+import { Resource } from "../../slices/tableSlice";
+import { ParseKeys } from "i18next";
 
 /**
  * This component renders the modal for editing which columns are shown in the table
@@ -116,7 +118,7 @@ const EditTableViewModalContent = ({
 		setDeactivatedColumns(initialConfig?.columns.filter((column) => column.deactivated) ?? []);
 	}
 
-	const getConfigByResource = (resource: string) => {
+	const getConfigByResource = (resource: Resource) => {
 		switch (resource) {
 			case "events": return eventsTableConfig;
 			case "series": return seriesTableConfig;
@@ -146,24 +148,23 @@ const EditTableViewModalContent = ({
 		setActiveColumns((columns) => arrayMoveImmutable(columns, result.source.index, destination.index));
 	}
 
-	const getTranslationForSubheading = (resource: string) => {
-		const resourceLC = resource.toLowerCase();
-		if (resourceLC === "events" || resourceLC === "series") {
-			return "EVENTS." + resource.toUpperCase() + ".TABLE.CAPTION"
+	const getTranslationForSubheading = (resource: Resource): ParseKeys | undefined => {
+		const resourceUC: Uppercase<Resource> = resource.toUpperCase() as Uppercase<Resource>;
+		if (resourceUC === "EVENTS" || resourceUC === "SERIES") {
+			return `EVENTS.${resourceUC}.TABLE.CAPTION`
 		}
-		if (resourceLC === "recordings") {
-			return resource.toUpperCase() + "." + resource.toUpperCase() + ".TABLE.CAPTION"
+		if (resourceUC === "RECORDINGS") {
+			return `${resourceUC}.${resourceUC}.TABLE.CAPTION`
 		}
-		if (resourceLC === "jobs" || resourceLC === "servers" || resourceLC === "services") {
-			return "SYSTEMS." + resource.toUpperCase() + ".TABLE.CAPTION"
+		if (resourceUC === "JOBS" || resourceUC === "SERVERS" || resourceUC === "SERVICES") {
+			return `SYSTEMS.${resourceUC}.TABLE.CAPTION`
 		}
-		if (resourceLC === "users" || resourceLC === "groups" || resourceLC === "acls") {
-			return "USERS." + resource.toUpperCase() + ".TABLE.CAPTION"
+		if (resourceUC === "USERS" || resourceUC === "GROUPS" || resourceUC === "ACLS") {
+			return `USERS.${resourceUC}.TABLE.CAPTION`
 		}
-		if (resourceLC === "themes") {
-			return "CONFIGURATION." + resource.toUpperCase() + ".TABLE.CAPTION"
+		if (resourceUC === "THEMES") {
+			return `CONFIGURATION.${resourceUC}.TABLE.CAPTION`
 		}
-		return ""
 	}
 
 	return (
@@ -173,7 +174,7 @@ const EditTableViewModalContent = ({
 					<div className="tab-description for-header">
 						<p>
 							{t("PREFERENCES.TABLE.SUBHEADING", {
-								tableName: t(getTranslationForSubheading(resource)),
+								tableName: t(getTranslationForSubheading(resource)!),
 							})}
 						</p>
 					</div>

--- a/src/components/shared/HotKeyCheatSheet.tsx
+++ b/src/components/shared/HotKeyCheatSheet.tsx
@@ -4,6 +4,7 @@ import { availableHotkeys } from "../../configs/hotkeysConfig";
 import { useHotkeysContext } from "react-hotkeys-hook";
 import { Hotkey } from "react-hotkeys-hook/dist/types";
 import { Modal, ModalHandle } from "./modals/Modal";
+import { ParseKeys } from "i18next";
 
 /**
  * This component renders the hotkey cheat sheet showing all available hotkeys
@@ -42,7 +43,7 @@ const HotKeyCheatSheet = ({
 						{Object.keys(availableHotkeys).map((hotkeyGroup, key) => (
 							<div className="obj tbl-list" key={key}>
 								<header>
-									{t("HOTKEYS.GROUPS." + hotkeyGroup.toUpperCase())}
+									{t(`HOTKEYS.GROUPS.${hotkeyGroup.toUpperCase()}` as ParseKeys)}
 								</header>
 								<table className="main-tbl">
 									<tbody>

--- a/src/components/shared/IconButton.tsx
+++ b/src/components/shared/IconButton.tsx
@@ -4,6 +4,7 @@ import { useAppSelector } from "../../store";
 import { hasAccess } from "../../utils/utils"
 import { Tooltip } from "./Tooltip";
 import React from "react";
+import { ParseKeys } from "i18next";
 
 export const IconButton = ({
 	callback,
@@ -15,7 +16,7 @@ export const IconButton = ({
 	callback: () => void
 	iconClassname: string
 	editAccessRole?: string
-	tooltipText?: string
+	tooltipText?: ParseKeys
 	children?: React.ReactNode
 }) => {
 	const { t } = useTranslation();

--- a/src/components/shared/NavigationButtons.tsx
+++ b/src/components/shared/NavigationButtons.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import cn from "classnames";
+import { ParseKeys } from "i18next";
 
 const NavigationButtons = ({
 	isFirst,
@@ -18,8 +19,8 @@ const NavigationButtons = ({
 	submitClassName?: string,
 	nextPage?: () => unknown,
 	previousPage?: () => unknown,
-	nextTranslationString?: string,
-	previousTranslationString?: string,
+	nextTranslationString?: ParseKeys,
+	previousTranslationString?: ParseKeys,
 }) => {
 
 	const { t } = useTranslation();

--- a/src/components/shared/NewResourceModal.tsx
+++ b/src/components/shared/NewResourceModal.tsx
@@ -32,10 +32,10 @@ const NewResourceModal = ({
 		switch(resource) {
 			case "events": return t("EVENTS.EVENTS.NEW.CAPTION");
 			case "series": return t("EVENTS.SERIES.NEW.CAPTION");
-			case "themes": return t("CONFIGURATION.THEMES.NEW.CAPTION");
+			case "themes": return t("CONFIGURATION.THEMES.DETAILS.NEWCAPTION");
 			case "acl": return t("USERS.ACLS.NEW.CAPTION");
 			case "group": return t("USERS.GROUPS.NEW.CAPTION");
-			case "user": return t("USERS.USERS.NEW.CAPTION");
+			case "user": return t("USERS.USERS.DETAILS.NEWCAPTION");
 		}
 	}
 

--- a/src/components/shared/RegistrationModal.tsx
+++ b/src/components/shared/RegistrationModal.tsx
@@ -14,6 +14,7 @@ import {
 	postRegistration,
 } from "../../utils/adopterRegistrationUtils";
 import { Modal, ModalHandle } from "./modals/Modal";
+import { ParseKeys } from "i18next";
 
 /**
  * This component renders the adopter registration modal. This modal has various states.
@@ -706,7 +707,7 @@ const RegistrationModalContent = () => {
 										onClick={() => formik.handleSubmit()}
 										className={cn("submit")}
 									>
-										{t(states[state].buttons.submitButtonText)}
+										{t(states[state].buttons.submitButtonText as ParseKeys)}
 									</button>
 								: state === "form" ?
 									<button
@@ -722,7 +723,7 @@ const RegistrationModalContent = () => {
 											),
 										})}
 									>
-										{t(states[state].buttons.submitButtonText)}
+										{t(states[state].buttons.submitButtonText as ParseKeys)}
 									</button>
 								:
 									// continue button or confirm button (depending on state)
@@ -730,7 +731,7 @@ const RegistrationModalContent = () => {
 										className="continue-registration"
 										onClick={() => onClickContinue()}
 									>
-										{t(states[state].buttons.submitButtonText)}
+										{t(states[state].buttons.submitButtonText as ParseKeys)}
 									</button>
 								}
 							</div>

--- a/src/components/shared/Stats.tsx
+++ b/src/components/shared/Stats.tsx
@@ -12,6 +12,7 @@ import {
 import { loadEventsIntoTable } from "../../thunks/tableThunks";
 import { useAppDispatch, useAppSelector } from "../../store";
 import { fetchEvents } from "../../slices/eventSlice";
+import { ParseKeys } from "i18next";
 
 /**
  * This component renders the status bar of the event view and filters depending on these
@@ -66,11 +67,11 @@ const Stats = () => {
 							{/* Show the description of the status, if defined,
 								else show name of filter and its value*/}
 							{!!st.description ? (
-								<span>{t(st.description)}</span>
+								<span>{t(st.description as ParseKeys)}</span>
 							) : (
 								st.filters.map((filter, key) => (
 									<span key={key}>
-										{t(filter.filter)}: {t(filter.value)}
+										{t(filter.filter as ParseKeys)}: {t(filter.value as ParseKeys)}
 									</span>
 								))
 							)}

--- a/src/components/shared/Table.tsx
+++ b/src/components/shared/Table.tsx
@@ -35,6 +35,7 @@ import Notifications from "./Notifications";
 import { useAppDispatch, useAppSelector } from "../../store";
 import { TableColumn } from "../../configs/tableConfigs/aclsTableConfig";
 import { ModalHandle } from "./modals/Modal";
+import { ParseKeys } from "i18next";
 
 const containerPageSize = React.createRef<HTMLButtonElement>();
 
@@ -264,7 +265,7 @@ const Table = ({
 									  column.translate &&
 									  !column.deactivated ? (
 										//Show only if column not template, translate, not deactivated
-										<td key={key}>{t(tryToGetValueForKeyFromRowAsString(row, column.name))}</td>
+										<td key={key}>{t(tryToGetValueForKeyFromRowAsString(row, column.name) as ParseKeys)}</td>
 									) : !!column.template &&
 									  !column.deactivated &&
 									  !!templateMap[column.template] ? (

--- a/src/components/shared/TableFilters.tsx
+++ b/src/components/shared/TableFilters.tsx
@@ -30,6 +30,7 @@ import { getCurrentLanguageInformation } from "../../utils/utils";
 import { Tooltip } from "./Tooltip";
 import DropDown from "./DropDown";
 import { AsyncThunk } from "@reduxjs/toolkit";
+import { ParseKeys } from "i18next";
 
 /**
  * This component renders the table filters in the upper right corner of the table
@@ -212,14 +213,14 @@ const TableFilters = ({
 			?.label || filter.value;
 		return (
 			<span className="table-filter-blue-box">
-				{t(filter.label)}:
-				{filter.translatable? t(valueLabel) : valueLabel}
+				{t(filter.label as ParseKeys)}:
+				{filter.translatable? t(valueLabel as ParseKeys) : valueLabel}
 			</span>
 		);
 	};
 
 	const getSelectedFilterText = () => {
-		return filter?.label ? t(filter.label) : selectedFilter;
+		return filter?.label ? t(filter.label as ParseKeys) : selectedFilter;
 	}
 
 	return (
@@ -259,11 +260,11 @@ const TableFilters = ({
 											? filterMap.filter(
 													(filter) => filter.name !== "presentersBibliographic"
 												)
-												.sort((a, b) => t(a.label).localeCompare(t(b.label))) // Sort alphabetically
+												.sort((a, b) => t(a.label as ParseKeys).localeCompare(t(b.label as ParseKeys))) // Sort alphabetically
 												.map(filter => {
 													return {
 														value: filter.name,
-														label: t(filter.label).substr(0, 40),
+														label: t(filter.label as ParseKeys).substr(0, 40),
 													};
 												})
 											: []
@@ -312,7 +313,7 @@ const TableFilters = ({
 											// Use different representation of name and value depending on type of filter
 											filter.type === "period" ? (
 												<span className="table-filter-blue-box">
-													{t(filter.label)}:
+													{t(filter.label as ParseKeys)}:
 													{t("dateFormats.date.short", {
 														date: renderValidDate(filter.value.split("/")[0]),
 													})}
@@ -419,7 +420,7 @@ const FilterSwitch = ({
 									} else {
 										return {
 											...option,
-											label: t(option.label).substr(0, 40),
+											label: t(option.label as ParseKeys).substr(0, 40),
 										}
 									}
 								})

--- a/src/components/shared/TimeSeriesStatistics.tsx
+++ b/src/components/shared/TimeSeriesStatistics.tsx
@@ -18,6 +18,7 @@ import type { ChartOptions } from 'chart.js';
 import { AsyncThunk } from "@reduxjs/toolkit";
 import { useAppDispatch } from "../../store";
 import { DataResolution, TimeMode } from "../../slices/statisticsSlice";
+import { ParseKeys } from "i18next";
 
 
 /**
@@ -252,7 +253,7 @@ const TimeSeriesStatistics = ({
 										)
 									}
 								/>
-								{t("STATISTICS.TIME_MODES." + mode.translation)}
+								{t(`STATISTICS.TIME_MODES.${mode.translation}` as ParseKeys)}
 							</label>
 						))}
 					</div>
@@ -377,7 +378,7 @@ const TimeSeriesStatistics = ({
 										<option value="" hidden />
 										{availableCustomDataResolutions.map((option, key) => (
 											<option value={option.value} key={key}>
-												{t("STATISTICS.TIME_GRANULARITIES." + option.label)}
+												{t(`STATISTICS.TIME_GRANULARITIES.${option.label}` as ParseKeys)}
 											</option>
 										))}
 									</Field>
@@ -395,7 +396,7 @@ const TimeSeriesStatistics = ({
 					/>
 
 					{/* statistic description */}
-					<p>{t(statDescription)}</p>
+					<p>{t(statDescription as ParseKeys)}</p>
 				</div>
 			)}
 		</Formik>

--- a/src/components/shared/modals/DetailsModal.tsx
+++ b/src/components/shared/modals/DetailsModal.tsx
@@ -2,6 +2,7 @@ import React, { PropsWithChildren } from "react";
 import { useTranslation } from "react-i18next";
 import { useHotkeys } from "react-hotkeys-hook";
 import { availableHotkeys } from "../../../configs/hotkeysConfig";
+import { ParseKeys } from "i18next";
 
 /**
  * This component renders the modal for displaying series details
@@ -13,7 +14,7 @@ const DetailsModal = ({
 	children
 }: PropsWithChildren<{
 	handleClose: () => void
-	prefix: string
+	prefix: ParseKeys
 	title: string
 }>) => {
 	const { t } = useTranslation();

--- a/src/components/shared/modals/ModalNavigation.tsx
+++ b/src/components/shared/modals/ModalNavigation.tsx
@@ -4,6 +4,7 @@ import cn from "classnames";
 import { getUserInformation } from "../../../selectors/userInfoSelectors";
 import { hasAccess } from "../../../utils/utils";
 import { useAppSelector } from "../../../store";
+import { ParseKeys } from "i18next";
 
 /**
  * This component renders the navigation in details modals
@@ -15,7 +16,7 @@ const ModalNavigation = ({
 }: {
 	tabInformation: {
 		accessRole: string,
-		tabTranslation: string
+		tabTranslation: ParseKeys
 	}[],
 	page: number,
 	openTab: (key: number) => unknown,

--- a/src/components/shared/modals/ResourceDetailsAccessPolicyTab.tsx
+++ b/src/components/shared/modals/ResourceDetailsAccessPolicyTab.tsx
@@ -28,6 +28,7 @@ import { TransformedAcl } from "../../../slices/aclDetailsSlice";
 import { AsyncThunk, unwrapResult } from "@reduxjs/toolkit";
 import { SaveEditFooter } from "../SaveEditFooter";
 import { formatAclRolesForDropdown, formatAclTemplatesForDropdown } from "../../../utils/dropDownUtils";
+import { ParseKeys } from "i18next";
 
 
 /**
@@ -47,13 +48,13 @@ const ResourceDetailsAccessPolicyTab = ({
 	setPolicyChanged,
 }: {
 	resourceId: string,
-	header: string,
+	header: ParseKeys,
 	policies: TransformedAcl[],
 	fetchHasActiveTransactions?: AsyncThunk<any, string, any>
 	fetchAccessPolicies: AsyncThunk<TransformedAcl[], string, any>,
 	saveNewAccessPolicies:  AsyncThunk<boolean, { id: string, policies: { acl: Acl } }, any>
 	descriptionText: string,
-	buttonText: string,
+	buttonText: ParseKeys,
 	editAccessRole: string,
 	policyChanged: boolean,
 	setPolicyChanged: (value: boolean) => void,

--- a/src/components/shared/wizard/FileUpload.tsx
+++ b/src/components/shared/wizard/FileUpload.tsx
@@ -5,6 +5,7 @@ import { NOTIFICATION_CONTEXT } from "../../../configs/modalConfig";
 import { useAppDispatch } from "../../../store";
 import { addNotification } from "../../../slices/notificationSlice";
 import { FormikProps } from "formik";
+import { ParseKeys } from "i18next";
 
 /**
  * This component renders a custom file upload button in wizards.
@@ -23,9 +24,9 @@ const FileUpload = <T extends RequiredFormProps>({
 	formik,
 	isEdit,
 }: {
-	descriptionKey?: string,
-	labelKey: string,
-	buttonKey: string,
+	descriptionKey?: ParseKeys,
+	labelKey: ParseKeys,
+	buttonKey: ParseKeys,
 	acceptableTypes: string,
 	fileId: string,
 	fileName: string,

--- a/src/components/shared/wizard/SelectContainer.tsx
+++ b/src/components/shared/wizard/SelectContainer.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import cn from "classnames";
 import { useField } from "formik";
+import { ParseKeys } from "i18next";
 
 type Item = {
 	name: string
@@ -186,7 +187,7 @@ const SelectContainer = ({
 				<div className="multi-select-col">
 					<div className="row">
 						<label>
-							{t(resource.label + ".LEFT")}
+							{t(`${resource.label}.LEFT` as ParseKeys)}
 							<i className="required" />
 						</label>
 						{/*Search*/}
@@ -230,7 +231,7 @@ const SelectContainer = ({
 								})}
 								onClick={() => handleClickAdd()}
 							>
-								{t(resource.label + ".ADD")}
+								{t(`${resource.label}.ADD` as ParseKeys)}
 							</button>
 						</div>
 					</div>
@@ -241,7 +242,7 @@ const SelectContainer = ({
 				{/*Select with options chosen by user*/}
 				<div className="multi-select-col">
 					<div className="row">
-						<label>{t(resource.label + ".RIGHT")}</label>
+						<label>{t(`${resource.label}.RIGHT` as ParseKeys)}</label>
 						<select
 							multiple
 							className="selected"
@@ -266,7 +267,7 @@ const SelectContainer = ({
 								})}
 								onClick={() => handleClickRemove()}
 							>
-								{t(resource.label + ".REMOVE")}
+								{t(`${resource.label}.REMOVE` as ParseKeys)}
 							</button>
 						</div>
 					</div>

--- a/src/components/shared/wizard/WizardNavigationButtons.tsx
+++ b/src/components/shared/wizard/WizardNavigationButtons.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { FormikProps } from "formik";
 import NavigationButtons from "../NavigationButtons";
+import { ParseKeys } from "i18next";
 
 const WizardNavigationButtons = <T,>({
 	isFirst,
@@ -22,8 +23,8 @@ const WizardNavigationButtons = <T,>({
 	nextPage?: (values: T) => void,
 	previousPage?: (values: T) => void,
 	submitPage?: () => void,
-	createTranslationString?: string,
-	cancelTranslationString?: string,
+	createTranslationString?: ParseKeys,
+	cancelTranslationString?: ParseKeys,
 }) => {
 
 	const disabled = noValidation

--- a/src/components/shared/wizard/WizardStepper.tsx
+++ b/src/components/shared/wizard/WizardStepper.tsx
@@ -11,6 +11,7 @@ import CustomStepIcon from "./CustomStepIcon";
 import { checkAcls } from "../../../slices/aclSlice";
 import { useAppDispatch } from "../../../store";
 import { FormikProps } from "formik/dist/types";
+import { ParseKeys } from "i18next";
 
 /**
  * This components renders the stepper navigation of new resource wizards
@@ -26,7 +27,7 @@ const WizardStepper = ({
 }: {
 	steps: {
 		name: string,
-		translation: string,
+		translation: ParseKeys,
 		hidden?: boolean,
 	}[],
 	page: number,

--- a/src/components/statistics/Statistics.tsx
+++ b/src/components/statistics/Statistics.tsx
@@ -21,6 +21,7 @@ import {
 	fetchStatisticsPageStatisticsValueUpdate,
 } from "../../slices/statisticsSlice";
 import { createChartOptions } from "../../utils/statisticsUtils";
+import { ParseKeys } from "i18next";
 
 const Statistics: React.FC = () => {
 	const { t } = useTranslation();
@@ -98,14 +99,14 @@ const Statistics: React.FC = () => {
 							statistics.map((stat, key) => (
 								<div className="obj" key={key}>
 									{/* title of statistic */}
-									<header className="no-expand">{t(stat.title)}</header>
+									<header className="no-expand">{t(stat.title as ParseKeys)}</header>
 
 									{stat.providerType === "timeSeries" ? (
 										/* visualization of statistic for time series data */
 										<div className="obj-container">
 											<TimeSeriesStatistics
 												resourceId={organizationId}
-												statTitle={t(stat.title)}
+												statTitle={t(stat.title as ParseKeys)}
 												providerId={stat.providerId}
 												fromDate={stat.from}
 												toDate={stat.to}

--- a/src/components/systems/partials/SystemsNavigation.tsx
+++ b/src/components/systems/partials/SystemsNavigation.tsx
@@ -1,3 +1,4 @@
+import { ParseKeys } from "i18next";
 import { fetchJobs } from "../../../slices/jobSlice";
 import { fetchServers } from "../../../slices/serverSlice";
 import { fetchServices } from "../../../slices/serviceSlice";
@@ -32,7 +33,12 @@ export const loadServices = async (dispatch: AppDispatch) => {
 	dispatch(loadServicesIntoTable());
 };
 
-export const systemsLinks = [
+export const systemsLinks: {
+	path: string
+	accessRole: string
+	loadFn: (dispatch: AppDispatch) => Promise<void>
+	text: ParseKeys
+}[] = [
 	{
 		path: "/systems/jobs",
 		accessRole: "ROLE_UI_JOBS_VIEW",

--- a/src/components/users/partials/UsersNavigation.tsx
+++ b/src/components/users/partials/UsersNavigation.tsx
@@ -1,3 +1,4 @@
+import { ParseKeys } from "i18next";
 import { fetchAcls } from "../../../slices/aclSlice";
 import { fetchGroups } from "../../../slices/groupSlice";
 import { fetchUsers } from "../../../slices/userSlice";
@@ -32,7 +33,12 @@ export const loadGroups = async (dispatch: AppDispatch) => {
 	dispatch(loadGroupsIntoTable());
 };
 
-export const usersLinks = [
+export const usersLinks: {
+	path: string
+	accessRole: string
+	loadFn: (dispatch: AppDispatch) => Promise<void>
+	text: ParseKeys
+}[] = [
 	{
 		path: "/users/users",
 		accessRole: "ROLE_UI_USERS_VIEW",

--- a/src/components/users/partials/modal/AclDetails.tsx
+++ b/src/components/users/partials/modal/AclDetails.tsx
@@ -9,6 +9,7 @@ import { checkAcls } from "../../../../slices/aclSlice";
 import { useAppDispatch, useAppSelector } from "../../../../store";
 import { TransformedAcl, updateAclDetails } from "../../../../slices/aclDetailsSlice";
 import WizardNavigationButtons from "../../../shared/wizard/WizardNavigationButtons";
+import { ParseKeys } from "i18next";
 
 /**
  * This component manages the pages of the acl details modal
@@ -32,7 +33,11 @@ const AclDetails = ({
 	};
 
 	// information about tabs
-	const tabs = [
+	const tabs: {
+		tabTranslation: ParseKeys,
+		accessRole: string,
+		name: string,
+	}[] = [
 		{
 			tabTranslation: "USERS.ACLS.DETAILS.TABS.METADATA",
 			accessRole: "ROLE_UI_ACLS_EDIT",

--- a/src/components/users/partials/modal/GroupDetails.tsx
+++ b/src/components/users/partials/modal/GroupDetails.tsx
@@ -9,6 +9,7 @@ import ModalNavigation from "../../../shared/modals/ModalNavigation";
 import { useAppDispatch, useAppSelector } from "../../../../store";
 import { UpdateGroupDetailsState, updateGroupDetails } from "../../../../slices/groupDetailsSlice";
 import WizardNavigationButtons from "../../../shared/wizard/WizardNavigationButtons";
+import { ParseKeys } from "i18next";
 
 /**
  * This component manages the pages of the group details
@@ -40,7 +41,11 @@ const GroupDetails: React.FC<{
 	};
 
 	// information about tabs
-	const tabs = [
+	const tabs: {
+		tabTranslation: ParseKeys
+		accessRole: string
+		name: string
+	}[] = [
 		{
 			tabTranslation: "USERS.GROUPS.DETAILS.TABS.GROUP",
 			accessRole: "ROLE_UI_GROUPS_EDIT",

--- a/src/components/users/partials/modal/UserDetails.tsx
+++ b/src/components/users/partials/modal/UserDetails.tsx
@@ -9,6 +9,7 @@ import ModalNavigation from "../../../shared/modals/ModalNavigation";
 import { useAppDispatch, useAppSelector } from "../../../../store";
 import { UpdateUser, updateUserDetails } from "../../../../slices/userDetailsSlice";
 import WizardNavigationButtons from "../../../shared/wizard/WizardNavigationButtons";
+import { ParseKeys } from "i18next";
 
 /**
  * This component manages the pages of the user details
@@ -31,7 +32,11 @@ const UserDetails: React.FC<{
 	};
 
 	// information about tabs
-	const tabs = [
+	const tabs: {
+		tabTranslation: ParseKeys
+		accessRole: string
+		name: string
+	}[] = [
 		{
 			tabTranslation: "USERS.USERS.DETAILS.TABS.USER",
 			accessRole: "ROLE_UI_USERS_EDIT",

--- a/src/components/users/partials/wizard/AclAccessPage.tsx
+++ b/src/components/users/partials/wizard/AclAccessPage.tsx
@@ -161,7 +161,7 @@ const AclAccessPage = <T extends RequiredFormProps>({
 
 											<div className="obj-container">
 												<div className="obj tbl-list">
-													<header>{t("")}</header>
+													<header>{""}</header>
 													<div className="obj-container">
 														<table className="main-tbl">
 															<thead>

--- a/src/components/users/partials/wizard/NewAclSummaryPage.tsx
+++ b/src/components/users/partials/wizard/NewAclSummaryPage.tsx
@@ -26,7 +26,7 @@ const NewAclSummaryPage = <T extends RequiredFormProps>({
 					<div className="full-col">
 						<Notifications context={"other"}/>
 						<div className="obj tbl-list">
-							<header className="no-expand">{t("")}</header>
+							<header className="no-expand">{""}</header>
 							<div className="obj-container">
 								<table className="main-tbl">
 									<tr>

--- a/src/components/users/partials/wizard/NewAclWizard.tsx
+++ b/src/components/users/partials/wizard/NewAclWizard.tsx
@@ -9,6 +9,7 @@ import { usePageFunctions } from "../../../../hooks/wizardHooks";
 import { NewAclSchema } from "../../../../utils/validate";
 import AclAccessPage from "./AclAccessPage";
 import { useAppDispatch } from "../../../../store";
+import { ParseKeys } from "i18next";
 
 /**
  * This component manages the pages of the new ACL wizard
@@ -35,7 +36,10 @@ const NewAclWizard = ({
 		setPageCompleted,
 	} = usePageFunctions(0, initialValues);
 
-	const steps = [
+	const steps: {
+		name: string
+		translation: ParseKeys
+	}[] = [
 		{
 			name: "metadata",
 			translation: "USERS.ACLS.NEW.TABS.METADATA",

--- a/src/components/users/partials/wizard/NewGroupWizard.tsx
+++ b/src/components/users/partials/wizard/NewGroupWizard.tsx
@@ -10,6 +10,7 @@ import { usePageFunctions } from "../../../../hooks/wizardHooks";
 import { NewGroupSchema } from "../../../../utils/validate";
 import { useAppDispatch } from "../../../../store";
 import { postNewGroup } from "../../../../slices/groupSlice";
+import { ParseKeys } from "i18next";
 
 /**
  * This component renders the new group wizard
@@ -34,7 +35,10 @@ const NewGroupWizard: React.FC<{
 	} = usePageFunctions(0, initialValues);
 
 	// Caption of steps used by Stepper
-	const steps = [
+	const steps: {
+		translation: ParseKeys
+		name: string
+	}[] = [
 		{
 			translation: "USERS.GROUPS.DETAILS.TABS.METADATA",
 			name: "metadata",

--- a/src/components/users/partials/wizard/NewUserGeneralTab.tsx
+++ b/src/components/users/partials/wizard/NewUserGeneralTab.tsx
@@ -4,6 +4,7 @@ import { FormikProps } from "formik";
 import Notifications from "../../../shared/Notifications";
 import { useTranslation } from "react-i18next";
 import cn from "classnames";
+import { ParseKeys } from "i18next";
 
 /**
  * This component renders the general user information tab for new users in the new users wizard.
@@ -157,7 +158,7 @@ const PasswordStrengthIndicator = ({
 		return Math.round(strength);
 	}
 
-	const setProgBar = (strength: number) => {
+	const setProgBar = (strength: number): [string | undefined, ParseKeys | undefined] => {
 		if (strength >= 90) {
 			return ["green", "USERS.USERS.DETAILS.STRENGTH.VERYSTRONG"]
 		}
@@ -177,7 +178,7 @@ const PasswordStrengthIndicator = ({
 			return ["white", "USERS.USERS.DETAILS.STRENGTH.BAD"]
 		}
 
-		return ["", ""];
+		return [undefined, undefined];
 	}
 
 	const strength = calcStrength(password);
@@ -193,7 +194,7 @@ const PasswordStrengthIndicator = ({
 			<div className="progress pw-strength">
 				<div id="bar" className="progress-bar" style={progressBarStyle}></div>
 			</div>
-			<label id="pw" style={{textAlign: "left"}}>{t(barText)}</label>
+			<label id="pw" style={{textAlign: "left"}}>{barText ? t(barText) : undefined}</label>
 		</div>
 	);
 }

--- a/src/configs/adopterRegistrationConfig.ts
+++ b/src/configs/adopterRegistrationConfig.ts
@@ -1,5 +1,19 @@
+import { ParseKeys } from "i18next";
+
 // states contains the different states and their configurations of the adapter registration modal
-export const states = {
+export const states: {
+	[key in "information" | "form" | "save" | "update" | "delete_submit" | "delete" | "summary" | "thank_you" | "error" | "skip" | "legal_info"]: {
+		nextState: { [key: number]: string }
+		buttons: {
+			submit: boolean,
+			back: boolean,
+			skip: boolean,
+			close: boolean,
+			delete?: boolean,
+			submitButtonText?: ParseKeys
+		}
+	}
+} = {
 	information: {
 		nextState: {
 			0: "close",
@@ -42,7 +56,6 @@ export const states = {
 			back: false,
 			skip: false,
 			close: false,
-			submitButtonText: "",
 		},
 	},
 	update: {
@@ -55,7 +68,6 @@ export const states = {
 			back: false,
 			skip: false,
 			close: false,
-			submitButtonText: "",
 		},
 	},
 	delete_submit: {
@@ -82,7 +94,6 @@ export const states = {
 			back: false,
 			skip: false,
 			close: false,
-			submitButtonText: "",
 		},
 	},
 	summary: {
@@ -109,7 +120,6 @@ export const states = {
 			back: false,
 			skip: false,
 			close: true,
-			submitButtonText: "",
 		},
 	},
 	error: {
@@ -122,7 +132,6 @@ export const states = {
 			back: false,
 			skip: false,
 			close: true,
-			submitButtonText: "",
 		},
 	},
 	skip: {
@@ -135,7 +144,6 @@ export const states = {
 			back: false,
 			skip: false,
 			close: true,
-			submitButtonText: "",
 		},
 	},
 	legal_info: {
@@ -149,12 +157,14 @@ export const states = {
 			back: true,
 			skip: false,
 			close: true,
-			submitButtonText: "",
 		},
 	},
 };
 
-export const systemTypes = [
+export const systemTypes: {
+	value: string,
+	name: ParseKeys,
+}[] = [
 	{
 		value: "production",
 		name: "ADOPTER_REGISTRATION.MODAL.FORM_STATE.SYSTEM_TYPE_PRODUCTION",

--- a/src/configs/hotkeysConfig.ts
+++ b/src/configs/hotkeysConfig.ts
@@ -1,9 +1,11 @@
+import { ParseKeys } from "i18next";
+
 // keymap containing information about available hotkeys
 type HotkeyMapType = {
 	[key: string]: {
 		[key: string]: {
 			name: string,
-			description: string,
+			description: ParseKeys,
 			sequence: string[],
 		}
 	}

--- a/src/configs/modalConfig.ts
+++ b/src/configs/modalConfig.ts
@@ -5,6 +5,7 @@ import { TobiraPage } from "../slices/seriesSlice";
 import { initArray } from "../utils/utils";
 import { EditedEvents, Event, UploadAssetsTrack } from "../slices/eventSlice";
 import { Role } from "../slices/aclSlice";
+import { ParseKeys } from "i18next";
 
 // Context for notifications shown in modals
 export const NOTIFICATION_CONTEXT = "modal-form";
@@ -25,7 +26,7 @@ export const initialFormValuesNewEvents: {
 	scheduleDurationMinutes: string,
 	scheduleEndHour: string,
 	scheduleEndMinute: string,
-	repeatOn: string[],
+	repeatOn: ("MO" | "TU" | "WE" | "TH" | "FR" | "SA" | "SU")[],
 	location: string,
 	processingWorkflow: string,
 	configuration: { [key: string]: string },
@@ -57,7 +58,10 @@ export const hours = initArray(24);
 export const minutes = initArray(60);
 
 // sorted weekdays and their translation key
-export const weekdays = [
+export const weekdays: {
+	name: "MO" | "TU" | "WE" | "TH" | "FR" | "SA" | "SU"
+	label: ParseKeys
+}[] = [
 	{
 		name: "MO",
 		label: "EVENTS.EVENTS.NEW.WEEKDAYS.MO",

--- a/src/configs/tableConfigs/aclsTableConfig.ts
+++ b/src/configs/tableConfigs/aclsTableConfig.ts
@@ -1,3 +1,5 @@
+import { ParseKeys } from "i18next";
+
 export type TableConfig = {
 	columns: TableColumn[],
 	caption: string,
@@ -8,7 +10,7 @@ export type TableConfig = {
 
 export type TableColumn = {
 	name: string,
-	label: string,
+	label: ParseKeys,
 	template?: string,
 	sortable?: boolean,
 	translate?: boolean,

--- a/src/i18n/i18next.d.ts
+++ b/src/i18n/i18next.d.ts
@@ -1,0 +1,13 @@
+// import the original type declarations
+import 'i18next';
+
+// import all namespaces (for the default language, only)
+import translation from './org/opencastproject/adminui/languages/lang-en_US.json';
+
+declare module 'i18next' {
+  interface CustomTypeOptions {
+    resources: {
+      translation: typeof translation;
+    };
+  }
+}

--- a/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
@@ -19,6 +19,7 @@
 	"LOGOUT": "Logout",
 	"RESET": "Reset",
 	"SELECT_NO_OPTION_SELECTED": "No option selected",
+	"SELECT_NO_OPTION_SELECTED_DASHED": "-- No option selected --",
 	"SELECT_NO_OPTIONS_AVAILABLE": "No options available",
 	"SELECT_NO_MATCHING_RESULTS": "No matching results.",
 	"YES": "Yes",

--- a/src/slices/eventSlice.ts
+++ b/src/slices/eventSlice.ts
@@ -122,7 +122,7 @@ export type EditedEvents = {
 	changedStartTimeHour: string,
 	changedStartTimeMinutes: string,
 	changedTitle: string,
-	changedWeekday: string,
+	changedWeekday: "MO" | "TU" | "WE" | "TH" | "FR" | "SA" | "SU",
 	deviceInputs: string,
 	endTimeHour: string,
 	endTimeMinutes: string,
@@ -132,7 +132,7 @@ export type EditedEvents = {
 	startTimeHour: string,
 	startTimeMinutes: string,
 	title: string,
-	weekday: string,
+	weekday: "MO" | "TU" | "WE" | "TH" | "FR" | "SA" | "SU",
 }
 
 export type UploadAssetOption = {

--- a/src/slices/notificationSlice.ts
+++ b/src/slices/notificationSlice.ts
@@ -12,13 +12,14 @@ import {
 } from "../configs/generalConfig";
 import { getLastAddedNotification } from '../selectors/notificationSelector';
 import { createAppAsyncThunk } from '../createAsyncThunkWithTypes';
+import { ParseKeys } from 'i18next';
 
 /**
  * This file contains redux reducer for actions affecting the state of table
  */
 // Calling this "OurNotification" because "Notification" is reserved by the Notifications Web API
 export type OurNotification = {
-	message: string,
+	message: ParseKeys,
 	id: number,
 	hidden: boolean,
 	duration: number,  // in milliseconds. -1 means stay forever
@@ -97,7 +98,7 @@ export const addNotification = createAppAsyncThunk('notifications/addNotificatio
 		id: 0,  // value does not matter, id is set in action
 		type: type,
 		key: key,
-		message: "NOTIFICATIONS." + key,
+		message: "NOTIFICATIONS." + key as ParseKeys,
 		parameter: parameter,
 		duration: duration,
 		hidden: false,

--- a/src/utils/resourceUtils.ts
+++ b/src/utils/resourceUtils.ts
@@ -15,7 +15,7 @@ import { RootState } from "../store";
 import { MetadataCatalog, MetadataField } from "../slices/eventSlice";
 import { initialFormValuesNewGroup } from '../configs/modalConfig';
 import { UpdateUser } from '../slices/userDetailsSlice';
-import { TFunction } from 'i18next';
+import { ParseKeys, TFunction } from 'i18next';
 import { TableState } from "../slices/tableSlice";
 
 /**
@@ -256,7 +256,7 @@ export const getMetadataCollectionFieldName = (metadataField: { collection?: { [
 				return t(JSON.parse(collectionField.name as string).label);
 			}
 
-			return collectionField ? t(collectionField.name as string) : "";
+			return collectionField ? t(collectionField.name as ParseKeys) : "";
 		}
 
 		return "";

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,6 +1,6 @@
 import languages from "../i18n/languages";
 import i18n from "../i18n/i18n";
-import { TFunction } from "i18next";
+import { ParseKeys, TFunction } from "i18next";
 import { UserInfoState } from "../slices/userInfoSlice";
 import { UploadAssetOption } from "../slices/eventSlice";
 
@@ -133,7 +133,7 @@ export const translateOverrideFallback = (asset: UploadAssetOption, t: TFunction
 		result = asset[`displayOverride${sub}` as const];
 
 	} else if (i18n.exists(translatable)) {
-		result = t(translatable);
+		result = t(translatable as ParseKeys);
 
 	} else if (asset[`displayFallback${sub}` as const]) {
 		result = asset[`displayFallback${sub}` as const];


### PR DESCRIPTION
If we attempt to translate a string which does not exist in our translations JSON, we now get a build error to warn us of that. This is intended to help avoid mistakes like in #1145, where a translation string was simply misspelled.
We do so by leveraging the typescript capabilities of i18n.

![Bildschirmfoto vom 2025-03-13 09-58-38](https://github.com/user-attachments/assets/27a0d9b1-50cf-425b-895d-7547e4e5d369)

Unfortunately, we also get a bunch of strings from the backend which can be translation strings, any other string or possibly either! Which is why you will see a lot "as ParseKeys" typecasts. We could theoretically check those stringsat runtime (if we somehow knew that they must be translation strings) and render some default message, but I personally think it is better to then render a "wrong" translation string, because it may still contain valuable information, even if that information is not rendered nicely. For example, "EVENTS.STATUS.COMPLETED" can still signal that event processing has finished, even if it is a bit hard to read and requires english skills.

### How to test this
Can be tested as usual, although I expect the main focus here to be code review.