### PR TITLE
Fix being unable to step back in event modal

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/NewAssetUploadPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewAssetUploadPage.tsx
@@ -33,12 +33,6 @@ const NewAssetUploadPage = <T extends RequiredFormProps>({
 		(asset) => asset.type !== "track"
 	);
 
-	// if user not chose upload in step before, the skip this step
-	if (formik.values.sourceMode !== "UPLOAD") {
-		nextPage(formik.values);
-		return null;
-	}
-
 	const handleChange = (e: React.ChangeEvent<HTMLInputElement>, assetId: string) => {
 		if (e.target.files) {
 			if (e.target.files.length === 0) {

--- a/src/components/events/partials/wizards/NewEventWizard.tsx
+++ b/src/components/events/partials/wizards/NewEventWizard.tsx
@@ -123,6 +123,10 @@ const NewEventWizard: React.FC<{
 		let newPage = page;
 		do {
 			newPage = newPage + 1;
+			// Skip asset upload step when scheduling
+			if (steps[newPage].name === "upload-asset" && values.sourceMode !== "UPLOAD") {
+				newPage = newPage + 1;
+			}
 		} while(steps[newPage] && steps[newPage].hidden);
 		if (steps[newPage]) {
 			setPage(newPage)
@@ -135,6 +139,10 @@ const NewEventWizard: React.FC<{
 		let newPage = page;
 		do {
 			newPage = newPage - 1;
+			// Skip asset upload step when scheduling
+			if (steps[newPage].name === "upload-asset" && values.sourceMode !== "UPLOAD") {
+				newPage = newPage - 1;
+			}
 		} while(steps[newPage] && steps[newPage].hidden);
 		if (steps[newPage]) {
 			setPage(newPage)


### PR DESCRIPTION
Fixes a bug occurring in the create event modal. When scheduling an event, going back from the "proccesing" step to the "source" step was not possible if the "asset upload" step was also configured.

![Bildschirmfoto_2025-03-14_um_04 48 57](https://github.com/user-attachments/assets/c122f89c-3a2f-4a20-886b-4839d1bed69f)


### How to test this
You will need an Opencast with asset upload options configured (see also https://docs.opencast.org/develop/admin/#configuration/admin-ui/asset-upload/).
Or cheat by checking out the code and setting `hidden` in line https://github.com/opencast/opencast-admin-interface/blob/57e21b1a7f3d272df09a68e19f1345055dcab2e5/src/components/events/partials/wizards/NewEventWizard.tsx#L86 to false.