### PR TITLE
Fix nested buttons in dropdown warning

### DIFF
--- a/src/components/shared/Table.tsx
+++ b/src/components/shared/Table.tsx
@@ -37,7 +37,7 @@ import { useAppDispatch, useAppSelector } from "../../store";
 import { TableColumn } from "../../configs/tableConfigs/aclsTableConfig";
 import { ModalHandle } from "./modals/Modal";
 
-const containerPageSize = React.createRef<HTMLButtonElement>();
+const containerPageSize = React.createRef<HTMLDivElement>();
 
 type TemplateMap = {
 	[key: string]: ({ row }: { row: any }) => JSX.Element | JSX.Element[]
@@ -289,10 +289,12 @@ const Table = ({
 
 			{/* Selection of page size */}
 			<div id="tbl-view-controls-container">
-				<button
+				<div
 					className="drop-down-container small flipped"
 					onClick={() => setShowPageSizes(!showPageSizes)}
 					ref={containerPageSize}
+					role="button"
+					tabIndex={0}
 				>
 					<span>{pagination.limit}</span>
 					{/* Drop down menu for selection of page size */}
@@ -310,7 +312,7 @@ const Table = ({
 							))}
 						</ul>
 					)}
-				</button>
+				</div>
 
 				{/* Pagination and navigation trough pages */}
 				<div className="pagination">


### PR DESCRIPTION
Fixes #1156.

Fixes a console warning for the table size dropdown and the bottom right of most pages. Also slightly fixes the CSS
to avoid overlapping of elements.

Warning this fixes:
![Bildschirmfoto vom 2025-03-18 10-00-58](https://github.com/user-attachments/assets/5abbb63e-e83f-408b-805e-ce6b5c247302)

Before:
![Bildschirmfoto vom 2025-03-18 09-59-53](https://github.com/user-attachments/assets/4e99e64e-678b-40f9-917a-9d7dbc1179fb)

After:
![Bildschirmfoto vom 2025-03-18 09-59-44](https://github.com/user-attachments/assets/2c78eecb-c7fa-4df4-86e7-24a5f55b04e3)

### How to test this
Can be tested as usual.