### PR TITLE
Limit concurrency for deploy and remove test page

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -6,6 +6,10 @@ on:
       - opened
       - synchronize
 
+concurrency:
+  group: pull-request-page
+  cancel-in-progress: false
+
 jobs:
   main:
     runs-on: ubuntu-latest

--- a/.github/workflows/remove-test.yml
+++ b/.github/workflows/remove-test.yml
@@ -5,6 +5,10 @@ on:
     types:
       - closed
 
+concurrency:
+  group: pull-request-page
+  cancel-in-progress: false
+
 env:
   PR_NUMBER: ${{ github.event.pull_request.number }}
 


### PR DESCRIPTION
If the test page repository is processed simultaneously, the fastest pushed wins. To prevent this, parallel processing is restricted. The processing order is not guaranteed; thus, a page could be removed before deployment.

https://github.com/opencast/opencast-admin-interface/actions/runs/13932498328/job/38992836228