### PR TITLE
Improve phrasing of warning when deleting files

### DIFF
--- a/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
@@ -259,7 +259,7 @@
 			}
 		},
 
-		"DELETE_EVENTS_WARNING_LINE1": "Once deleted, all event metadata, audio and video files will be deleted and be unrecoverable.",
+		"DELETE_EVENTS_WARNING_LINE1": "Once deleted, all event metadata, audio and video files are irrevocably gone.",
 		"DELETE_EVENTS_WARNING_LINE2": "",
 		"DELETE_SERIES_WARNING_LINE1": "Once deleted, all series metadata will be unrecoverable. Events in the series will not be deleted.",
 		"DELETE_SERIES_WARNING_LINE2": "",


### PR DESCRIPTION
The sentence “once deleted, [they] will be deleted […]” just sounds wrong.