### PR TITLE
Fix visual errors and path validation in Tobira tab

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/DetailsTobiraTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/DetailsTobiraTab.tsx
@@ -12,7 +12,6 @@ import NewTobiraPage, { TobiraFormProps } from "./NewTobiraPage";
 import { fetchSeriesDetailsTobira, removeSeriesTobiraPath, setTobiraTabHierarchy, TobiraData, updateSeriesTobiraPath } from "../../../../slices/seriesDetailsSlice";
 import { fetchSeriesDetailsTobiraNew, TobiraPage } from "../../../../slices/seriesSlice";
 import ConfirmModal from "../../../shared/ConfirmModal";
-import { Tooltip } from "../../../shared/Tooltip";
 import ButtonLikeAnchor from "../../../shared/ButtonLikeAnchor";
 import { ModalHandle } from "../../../shared/modals/Modal";
 import { fetchEventDetailsTobira } from "../../../../slices/eventDetailsSlice";
@@ -213,13 +212,12 @@ const TobiraTable = ({ tobiraData, i18nKey, openSubTab, handleDelete }: TobiraTa
 				{tobiraData.hostPages.length === 0 && <tr>
 					<td className="tobira-not-mounted">
 						{t(`EVENTS.${i18nKey}.DETAILS.TOBIRA.NOT_MOUNTED`)}
-						{i18nKey === "SERIES" && <Tooltip title={t("EVENTS.SERIES.DETAILS.TOBIRA.MOUNT_SERIES")}>
-							<ButtonLikeAnchor
-								style={{ margin: 5 }}
-								extraClassName="edit fa fa-pencil-square pull-right"
-								onClick={() => openSubTab("edit-path")}
-								/>
-						</Tooltip>}
+						{i18nKey === "SERIES" && <ButtonLikeAnchor
+							style={{ margin: 5 }}
+							extraClassName="edit fa fa-pencil-square pull-right"
+							onClick={() => openSubTab("edit-path")}
+							tooltipText="EVENTS.SERIES.DETAILS.TOBIRA.MOUNT_SERIES"
+						/>}
 					</td>
 				</tr>}
 				{tobiraData.hostPages.map(hostPage => <tr key={hostPage.path}>

--- a/src/components/events/partials/ModalTabsAndPages/NewTobiraPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewTobiraPage.tsx
@@ -364,14 +364,14 @@ const NewTobiraPage = <T extends TobiraFormProps>({
 					</p>
 					{!mode.edit && <p style={{ fontSize: 12 }}>{t("EVENTS.SERIES.NEW.TOBIRA.DIRECT_LINK")}</p>}
 				</>}
-			{/* Render buttons for saving or resetting updated path */}
-			{mode.edit && <SaveEditFooter
-				active={formik.values.selectedPage !== undefined}
-				reset={() => formik.setFieldValue("selectedPage", undefined)}
-				submit={() => formik.handleSubmit()}
-				{...{ isValid }}
-			/>}
 		</ModalContent>
+		{/* Render buttons for saving or resetting updated path */}
+		{mode.edit && <SaveEditFooter
+			active={formik.values.selectedPage !== undefined}
+			reset={() => formik.setFieldValue("selectedPage", undefined)}
+			submit={() => formik.handleSubmit()}
+			{...{ isValid }}
+		/>}
 
 		{/* Button for navigation to next page and previous page */}
 		{!mode.edit && <WizardNavigationButtons

--- a/src/components/events/partials/ModalTabsAndPages/NewTobiraPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewTobiraPage.tsx
@@ -174,7 +174,6 @@ const NewTobiraPage = <T extends TobiraFormProps>({
 			segment: "",
 		};
 		dispatch(setTobiraPage({ ...currentPage, children: [...currentPage.children, newPage]}));
-		select(newPage);
 	};
 
 	const setPage = (


### PR DESCRIPTION
This restores the previous styling of the "edit path" button as well as the footer containing the "save path" button (for screenshots of the broken state, see the linked issue).

Also fixes a small error with the path validation that I overlooked before.

Resolves #1170 
