### PR TITLE
Remove "completed" column from servers table

### DIFF
--- a/src/configs/tableConfigs/serversTableConfig.ts
+++ b/src/configs/tableConfigs/serversTableConfig.ts
@@ -34,11 +34,6 @@ export const serversTableConfig: TableConfig = {
 			sortable: true,
 		},
 		{
-			name: "completed",
-			label: "SYSTEMS.SERVERS.TABLE.COMPLETED",
-			sortable: true,
-		},
-		{
 			name: "running",
 			label: "SYSTEMS.SERVERS.TABLE.RUNNING",
 			sortable: true,

--- a/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
@@ -1696,7 +1696,6 @@
 				"HOST_NAME": "Host name",
 				"NODE_NAME": "Node name",
 				"CORES": "Cores",
-				"COMPLETED": "Jobs completed",
 				"RUNNING": "Jobs running",
 				"QUEUED": "Jobs queued",
 				"MAINTENANCE": "Maintenance",


### PR DESCRIPTION
The column "jobs completed" had already been removed from the servers table in the old admin ui. The backend is not even offering any data for this column anymore.
Therefore, this patch gets rid of it.

Fixes #1155.

### How to test this
Can be tested as usual, but may require clearing browser cache. Check that nothing of this column remains.