### PR TITLE
Show service online status

### DIFF
--- a/src/configs/tableConfigs/serversTableConfig.ts
+++ b/src/configs/tableConfigs/serversTableConfig.ts
@@ -16,7 +16,6 @@ export const serversTableConfig: TableConfig = {
 			template: "ServersStatusCell",
 			name: "online",
 			label: "SYSTEMS.SERVERS.TABLE.STATUS",
-			sortable: true,
 		},
 		{
 			name: "hostname",

--- a/src/configs/tableConfigs/servicesTableConfig.ts
+++ b/src/configs/tableConfigs/servicesTableConfig.ts
@@ -13,6 +13,11 @@ import { TableConfig } from "./aclsTableConfig";
 export const servicesTableConfig: TableConfig = {
 	columns: [
 		{
+			template: "ServersStatusCell",
+			name: "online",
+			label: "SYSTEMS.SERVICES.TABLE.ONLINE",
+		},
+		{
 			name: "status",
 			label: "SYSTEMS.SERVICES.TABLE.STATUS",
 			translate: true,

--- a/src/configs/tableConfigs/servicesTableMap.ts
+++ b/src/configs/tableConfigs/servicesTableMap.ts
@@ -1,6 +1,7 @@
 import MeanRunTimeCell from "../../components/systems/partials/MeanRunTimeCell";
 import MeanQueueTimeCell from "../../components/systems/partials/MeanQueueTimeCell";
 import ServicesActionCell from "../../components/systems/partials/ServicesActionsCell";
+import ServersStatusCell from "../../components/systems/partials/ServersStatusCell";
 
 /**
  * This map contains the mapping between the template strings above and the corresponding react component.
@@ -8,6 +9,7 @@ import ServicesActionCell from "../../components/systems/partials/ServicesAction
  * uses template map.
  */
 export const servicesTemplateMap = {
+	ServersStatusCell: ServersStatusCell,
 	MeanRunTimeCell: MeanRunTimeCell,
 	MeanQueueTimeCell: MeanQueueTimeCell,
 	ServicesActionsCell: ServicesActionCell,

--- a/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
@@ -1707,6 +1707,7 @@
 		"SERVICES": {
 			"TABLE": {
 				"CAPTION": "Services",
+				"ONLINE": "Online",
 				"STATUS": "Status",
 				"NAME": "Service name",
 				"HOST_NAME": "Host name",

--- a/src/slices/serviceSlice.ts
+++ b/src/slices/serviceSlice.ts
@@ -18,6 +18,8 @@ export type Service = {
 	queued: number,
 	running: number,
 	status: string,
+	online: boolean,
+	maintenance: boolean,
 }
 
 type ServiceState = {


### PR DESCRIPTION
**Requires https://github.com/opencast/opencast/pull/6632 to function.**

Fixes #1166.

Adds a column to the services table that displays the online status of a service using traffic lights, much like the respective column in the servers table.
This change should make it easier to reason about why certain jobs may not able to be dispatched.

Notably, an offline service does not necessarily mean that there is an error or even a problem. Therefore this patch does not add a notification about services being offline.

![Bildschirmfoto vom 2025-04-08 12-04-43](https://github.com/user-attachments/assets/394c9f3e-1fd1-40df-9428-aaa1803f44f4)


### How to test this

- Have an Opencast 17 or newer with https://github.com/opencast/opencast/pull/6632 installed. Ideally have a distributed setup as well (no AllInOne).
- Force services to be offline or in maintenance somehow. The latter can be achieved through the servers page in the ui.
