### PR TITLE
Improve word wrapping in tables

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/StartTaskGeneralPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/StartTaskGeneralPage.tsx
@@ -87,7 +87,7 @@ const StartTaskGeneralPage = <T extends RequiredFormProps>({
 												onChange={(e) => onChangeAllSelected(e)}
 											/>
 										</th>
-										<th className="full-width">
+										<th>
 											{t("EVENTS.EVENTS.TABLE.TITLE")}
 										</th>
 										<th className="nowrap">
@@ -105,7 +105,7 @@ const StartTaskGeneralPage = <T extends RequiredFormProps>({
 											key={key}
 											className={cn({ error: !isStartable(event) })}
 										>
-											<td>
+											<td className="small">
 												<input
 													name="events"
 													type="checkbox"
@@ -114,10 +114,10 @@ const StartTaskGeneralPage = <T extends RequiredFormProps>({
 												/>
 											</td>
 											<td>{event.title}</td>
-											<td className="nowrap">
+											<td>
 												{event.series ? event.series.title : ""}
 											</td>
-											<td className="nowrap">{t(event.event_status as ParseKeys)}</td>
+											<td>{t(event.event_status as ParseKeys)}</td>
 										</tr>
 									))}
 								</tbody>

--- a/src/styles/components/modals/_modal-components.scss
+++ b/src/styles/components/modals/_modal-components.scss
@@ -244,7 +244,7 @@
     &.tbl-list table td {
 
         &:first-child {
-            width: 150px;
+            max-width: 150px;
         }
 
         &:last-child {

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -568,7 +568,6 @@ table.main-tbl {
 
   td {
     max-width: 800px;
-    word-wrap: anywhere;
   }
 
   td {


### PR DESCRIPTION
Many tables in the admin interface cannot handle events or series with longer texts, either wrapping them at weird places or even breaking the user interface completely.

This patch tries to improve the situation and allow for better wrapping of table content.

Before:
![Screenshot from 2025-04-29 21-50-59](https://github.com/user-attachments/assets/26209a11-30fb-49c3-930e-c9be9f853199)

After:
![Screenshot from 2025-04-29 21-49-52](https://github.com/user-attachments/assets/0acc0b2b-9ae0-4c24-afed-cde15cc88dfd)


