### PR TITLE
Scheduling single event or multiple events times filed display wrong digits

### DIFF
--- a/src/utils/dropDownUtils.ts
+++ b/src/utils/dropDownUtils.ts
@@ -5,7 +5,7 @@ import { Role } from "../slices/aclSlice";
  * this file contains functions, which are needed for the searchable drop-down selections
  */
 
-export const formatTimeForDropdown = (times: {index: number, value: string}[]) => {
+export const formatTimeForDropdown = (times: {index: string, value: string}[]) => {
 	return times.map(({index, value}) => ({ label: value, value: index }));
 };
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -39,7 +39,7 @@ export const initArray = (numberOfElements: number) => {
 		result = [];
 	for (i = 0; i < numberOfElements; i++) {
 		result.push({
-			index: i,
+			index: makeTwoDigits(i),
 			value: makeTwoDigits(i),
 		});
 	}


### PR DESCRIPTION
Scheduling single event or multiple events times filed display wrong digits #1198


Screenshot after the fix:

![image](https://github.com/user-attachments/assets/13bf59ed-3699-4cba-9a42-f95471d0583e)

Summary Page:
![image](https://github.com/user-attachments/assets/e47c70c9-ce4a-43f6-b6b5-690c984c9cb8)
