### PR TITLE
Username not displayed correctly in user details modal #1202

### DIFF
--- a/src/components/users/partials/UsersActionsCell.tsx
+++ b/src/components/users/partials/UsersActionsCell.tsx
@@ -47,7 +47,7 @@ const UsersActionCell = ({
 
 			{/* user details modal */}
 			<Modal
-				header={t("USERS.USERS.DETAILS.EDITCAPTION", { username: row.username })}
+				header={t("USERS.USERS.DETAILS.EDITCAPTION", { name: row.username })}
 				classId="user-details-modal"
 				ref={modalRef}
 			>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/55227869-7708-4f08-aebc-acca66dc3cd9)

Screenshot after changes... 