### PR TITLE
Fix group roles not showing

### DIFF
--- a/src/components/users/partials/modal/AclDetails.tsx
+++ b/src/components/users/partials/modal/AclDetails.tsx
@@ -98,6 +98,7 @@ const AclDetails = ({
 							createTranslationString="SUBMIT"
 							cancelTranslationString="CANCEL"
 							isLast
+							previousPage={close}
 						/>
 					</>
 				)}

--- a/src/components/users/partials/modal/GroupDetails.tsx
+++ b/src/components/users/partials/modal/GroupDetails.tsx
@@ -88,6 +88,7 @@ const GroupDetails: React.FC<{
 				initialValues={initialValues}
 				validationSchema={EditGroupSchema}
 				onSubmit={(values) => handleSubmit(values)}
+				enableReinitialize={true}
 			>
 				{(formik) => (
 					<>

--- a/src/components/users/partials/modal/UserDetails.tsx
+++ b/src/components/users/partials/modal/UserDetails.tsx
@@ -87,6 +87,7 @@ const UserDetails: React.FC<{
 								createTranslationString="SUBMIT"
 								cancelTranslationString="CANCEL"
 								isLast
+								previousPage={close}
 							/>
 						)}
 					</>


### PR DESCRIPTION
Fixes issue #1201: Selected roles were not showing in the Group Details "Roles" tab even though they were correctly assigned.