### PR TITLE
No sorting for ROLES header in users page

### DIFF
--- a/src/configs/tableConfigs/usersTableConfig.ts
+++ b/src/configs/tableConfigs/usersTableConfig.ts
@@ -31,7 +31,7 @@ export const usersTableConfig: TableConfig = {
 			template: "UsersRolesCell",
 			name: "roles",
 			label: "USERS.USERS.TABLE.ROLES",
-			sortable: true,
+			sortable: false,
 		},
 		{
 			name: "provider",

--- a/src/slices/userSlice.ts
+++ b/src/slices/userSlice.ts
@@ -52,7 +52,7 @@ const initialColumns = usersTableConfig.columns.map((column) => ({
 // Initial state of users in redux store
 const initialState: UsersState = {
 	status: 'uninitialized',
-  error: null,
+	error: null,
 	results: [],
 	columns: initialColumns,
 	total: 0,


### PR DESCRIPTION
This PR fixes #1210,

As to simple disable the sorting for the Roles column in users page.
Since it uses redux storage with might happen the cookies data need to be remove for testing!