### PR TITLE
Sorting capture devices by last-updated-timestamp isn't possible

### DIFF
--- a/src/configs/tableConfigs/recordingsTableConfig.ts
+++ b/src/configs/tableConfigs/recordingsTableConfig.ts
@@ -29,7 +29,7 @@ export const recordingsTableConfig: TableConfig = {
 			template: "RecordingsUpdateCell",
 			name: "update",
 			label: "RECORDINGS.RECORDINGS.TABLE.UPDATED",
-			sortable: true,
+			sortable: false,
 		},
 		{
 			template: "RecordingsActionCell",

--- a/src/configs/tableConfigs/recordingsTableConfig.ts
+++ b/src/configs/tableConfigs/recordingsTableConfig.ts
@@ -27,9 +27,9 @@ export const recordingsTableConfig: TableConfig = {
 		},
 		{
 			template: "RecordingsUpdateCell",
-			name: "update",
+			name: "updated",
 			label: "RECORDINGS.RECORDINGS.TABLE.UPDATED",
-			sortable: false,
+			sortable: true,
 		},
 		{
 			template: "RecordingsActionCell",


### PR DESCRIPTION
Let's disable the sorting table by this column.

Fixes #1209 