### PR TITLE
Remove console.info statements from postNewGroup and deleteGroup thunks

### DIFF
--- a/src/components/users/partials/wizard/NewGroupWizard.tsx
+++ b/src/components/users/partials/wizard/NewGroupWizard.tsx
@@ -61,8 +61,7 @@ const NewGroupWizard: React.FC<{
 	const currentValidationSchema = NewGroupSchema[page];
 
 	const handleSubmit = (values: typeof initialFormValuesNewGroup) => {
-		const response = dispatch(postNewGroup(values));
-		console.info(response);
+		dispatch(postNewGroup(values));
 		close();
 	};
 

--- a/src/slices/groupSlice.ts
+++ b/src/slices/groupSlice.ts
@@ -71,7 +71,6 @@ export const postNewGroup = createAppAsyncThunk('groups/postNewGroup', async (va
 			},
 		})
 		.then((response) => {
-			console.info(response);
 			dispatch(addNotification({type: "success", key: "GROUP_ADDED"}));
 		})
 		.catch((response) => {
@@ -89,7 +88,6 @@ export const deleteGroup = createAppAsyncThunk('groups/deleteGroup', async (id: 
 	axios
 		.delete(`/admin-ng/groups/${id}`)
 		.then((res) => {
-			console.info(res);
 			// add success notification
 			dispatch(addNotification({type: "success", key: "GROUP_DELETED"}));
 		})


### PR DESCRIPTION
This fixes #1244,

It helps maintain a cleaner codebase by avoiding the direct exposure of request and response details in the console, which is also beneficial from a security perspective.