### PR TITLE
Display only directly assigned roles in user modal

### DIFF
--- a/src/components/shared/wizard/SelectContainer.tsx
+++ b/src/components/shared/wizard/SelectContainer.tsx
@@ -252,7 +252,8 @@ const SelectContainer = ({
 							onChange={(e) => handleChangeRemove(e)}
 							value={markedForRemoval}
 						>
-{/* @ts-expect-error TS(7006): Parameter 'item' implicitly has an 'any' type. */}
+							{/* Show assigned users or directly assigned roles*/}
+							{/* @ts-expect-error TS(7006): Parameter 'item' implicitly has an 'any' type. */}
 							{selectedItems.map((item, key) => (
 								<option key={key} value={item.name}>
 									{item.name}

--- a/src/components/shared/wizard/SelectContainer.tsx
+++ b/src/components/shared/wizard/SelectContainer.tsx
@@ -252,7 +252,6 @@ const SelectContainer = ({
 							onChange={(e) => handleChangeRemove(e)}
 							value={markedForRemoval}
 						>
-							{/* Show assigned users or directly assigned roles*/}
 							{/* @ts-expect-error TS(7006): Parameter 'item' implicitly has an 'any' type. */}
 							{selectedItems.map((item, key) => (
 								<option key={key} value={item.name}>

--- a/src/components/users/partials/modal/UserDetails.tsx
+++ b/src/components/users/partials/modal/UserDetails.tsx
@@ -10,6 +10,8 @@ import { useAppDispatch, useAppSelector } from "../../../../store";
 import { UpdateUser, updateUserDetails } from "../../../../slices/userDetailsSlice";
 import WizardNavigationButtons from "../../../shared/wizard/WizardNavigationButtons";
 import { ParseKeys } from "i18next";
+import { UserRole } from "../../../../slices/userSlice";
+import { SerializedError } from "@reduxjs/toolkit";
 
 /**
  * This component manages the pages of the user details
@@ -24,7 +26,7 @@ const UserDetails: React.FC<{
 	const [page, setPage] = useState(0);
 
 	const userDetails = useAppSelector(state => getUserDetails(state));
-	const assignedRoles = userDetails.roles.filter(role => role.type === "GROUP" || role.type === "INTERNAL")
+	const assignedRoles = userDetails.roles.filter(role => role.type === "GROUP" || role.type === "INTERNAL");
 
 	const initialValues = {
 		...userDetails,
@@ -60,7 +62,19 @@ const UserDetails: React.FC<{
 		setPage(tabNr);
 	};
 
-	const handleSubmit = (values: any) => {
+	const handleSubmit = (values: {
+		status?: 'uninitialized' | 'loading' | 'succeeded' | 'failed',
+		error?: SerializedError | null,
+		provider?: string,
+		roles?: UserRole[],
+		name?: string,
+		username: string,
+		email?: string,
+		manageable?: boolean,
+		assignedRoles?: UserRole[],
+		password?: string,
+		passwordConfirmation?: string,
+	}) => {
 		const newValues: UpdateUser = {
 			email: values.email,
 			name: values.name,

--- a/src/components/users/partials/modal/UserDetails.tsx
+++ b/src/components/users/partials/modal/UserDetails.tsx
@@ -63,24 +63,19 @@ const UserDetails: React.FC<{
 	};
 
 	const handleSubmit = (values: {
-		status?: 'uninitialized' | 'loading' | 'succeeded' | 'failed',
-		error?: SerializedError | null,
-		provider?: string,
-		roles?: UserRole[],
-		name?: string,
 		username: string,
+		name?: string,
 		email?: string,
-		manageable?: boolean,
-		assignedRoles?: UserRole[],
 		password?: string,
-		passwordConfirmation?: string,
+		roles?: UserRole[],
+		assignedRoles?: UserRole[],
 	}) => {
 		const newValues: UpdateUser = {
-			email: values.email,
-			name: values.name,
 			username: values.username,
-			roles: values.assignedRoles,
+			name: values.name,
+			email: values.email,
 			password: values.password,
+			roles: values.assignedRoles,
 		};
 
 		dispatch(updateUserDetails({values: newValues, username: userDetails.username}));

--- a/src/components/users/partials/modal/UserDetails.tsx
+++ b/src/components/users/partials/modal/UserDetails.tsx
@@ -24,9 +24,11 @@ const UserDetails: React.FC<{
 	const [page, setPage] = useState(0);
 
 	const userDetails = useAppSelector(state => getUserDetails(state));
+	const assignedRoles = userDetails.roles.filter(role => role.type === "GROUP" || role.type === "INTERNAL")
 
 	const initialValues = {
 		...userDetails,
+		assignedRoles,
 		password: "",
 		passwordConfirmation: "",
 	};
@@ -58,8 +60,16 @@ const UserDetails: React.FC<{
 		setPage(tabNr);
 	};
 
-	const handleSubmit = (values: UpdateUser) => {
-		dispatch(updateUserDetails({values: values, username: userDetails.username}));
+	const handleSubmit = (values: any) => {
+		const newValues: UpdateUser = {
+			email: values.email,
+			name: values.name,
+			username: values.username,
+			roles: values.assignedRoles,
+			password: values.password,
+		};
+
+		dispatch(updateUserDetails({values: newValues, username: userDetails.username}));
 		close();
 	};
 

--- a/src/components/users/partials/wizard/NewUserWizard.tsx
+++ b/src/components/users/partials/wizard/NewUserWizard.tsx
@@ -7,10 +7,11 @@ import UserRolesTab from "./UserRolesTab";
 import { initialFormValuesNewUser } from "../../../../configs/modalConfig";
 import { getUsernames } from "../../../../selectors/userSelectors";
 import { NewUserSchema } from "../../../../utils/validate";
-import { NewUser, postNewUser } from "../../../../slices/userSlice";
+import { NewUser, postNewUser, UserRole } from "../../../../slices/userSlice";
 import { useAppDispatch, useAppSelector } from "../../../../store";
 import ButtonLikeAnchor from "../../../shared/ButtonLikeAnchor";
 import WizardNavigationButtons from "../../../shared/wizard/WizardNavigationButtons";
+import { Role } from "../../../../slices/aclSlice";
 
 /**
  * This component renders the new user wizard
@@ -37,8 +38,24 @@ const NewUserWizard = ({
 		setTab(tabNr);
 	};
 
-	const handleSubmit = (values: NewUser) => {
-		const response = dispatch(postNewUser(values));
+	const handleSubmit = (values: {
+			username: string,
+			name: string,
+			email: string,
+			password: string,
+			passwordConfirmation: string,
+			roles: Role[],
+			assignedRoles: UserRole[],
+			manageable: boolean,
+	}) => {
+		const newValues: NewUser = {
+			username: values.username,
+			name: values.name,
+			email: values.email,
+			password: values.password,
+			roles: values.assignedRoles,
+		}
+		const response = dispatch(postNewUser(newValues));
 		console.info(response);
 		close();
 	};

--- a/src/components/users/partials/wizard/NewUserWizard.tsx
+++ b/src/components/users/partials/wizard/NewUserWizard.tsx
@@ -43,10 +43,8 @@ const NewUserWizard = ({
 			name: string,
 			email: string,
 			password: string,
-			passwordConfirmation: string,
 			roles: Role[],
 			assignedRoles: UserRole[],
-			manageable: boolean,
 	}) => {
 		const newValues: NewUser = {
 			username: values.username,

--- a/src/components/users/partials/wizard/UserRolesTab.tsx
+++ b/src/components/users/partials/wizard/UserRolesTab.tsx
@@ -44,7 +44,7 @@ const UserRolesTab = <T extends RequiredFormProps>({
 							label: "USERS.USERS.DETAILS.ROLES",
 							items: roles,
 						}}
-						formikField="roles"
+						formikField="assignedRoles"
 						manageable={formik.values.manageable}
 					/>
 				)}

--- a/src/configs/modalConfig.ts
+++ b/src/configs/modalConfig.ts
@@ -6,6 +6,7 @@ import { initArray } from "../utils/utils";
 import { EditedEvents, Event, UploadAssetsTrack } from "../slices/eventSlice";
 import { Role } from "../slices/aclSlice";
 import { ParseKeys } from "i18next";
+import { UserRole } from "../slices/userSlice";
 
 // Context for notifications shown in modals
 export const NOTIFICATION_CONTEXT = "modal-form";
@@ -182,6 +183,7 @@ export const initialFormValuesNewUser: {
 	password: string,
 	passwordConfirmation: string,
 	roles: Role[],
+	assignedRoles: UserRole[],
 	manageable: boolean,
 } = {
 	username: "",
@@ -190,6 +192,7 @@ export const initialFormValuesNewUser: {
 	password: "",
 	passwordConfirmation: "",
 	roles: [],
+	assignedRoles: [],
 	manageable: true,
 };
 


### PR DESCRIPTION
fix #1239

This fix ensures that only directly assigned roles are displayed in the roles tab of the user modal.