### PR TITLE
Fix the disappearing filter when the bell icon is clicked

### DIFF
--- a/src/slices/tableFilterSlice.ts
+++ b/src/slices/tableFilterSlice.ts
@@ -186,7 +186,10 @@ export const setSpecificServiceFilter = createAppAsyncThunk('tableFilters/setSpe
 	let filterToChange = tableFilters.data.find(({ name }) => name === filter);
 
 	if (!filterToChange) {
-		await dispatch(fetchFilters("services"));
+		const fetchedFilters = await dispatch(fetchFilters("services")) as {
+			payload: { filtersList: FilterData[] }
+		};
+		filterToChange = fetchedFilters.payload.filtersList.find(({ name }: { name: string }) => name === filter);
 	}
 
 	if (!!filterToChange) {


### PR DESCRIPTION
Fixes #876 

When clicking on the "Bell Icon" -> Backend Services, there should be a filter activated. When switching to the services page **the first time**, the filter will not be set / will disappear instantly. This PR should fix this, so the filter will be set correctly, especially when opening the page the first time.