### PR TITLE
Updating groups now preserves previously selected roles

### DIFF
--- a/src/components/users/partials/modal/GroupDetails.tsx
+++ b/src/components/users/partials/modal/GroupDetails.tsx
@@ -24,26 +24,15 @@ const GroupDetails: React.FC<{
 	const groupDetails = useAppSelector(state => getGroupDetails(state));
 
 	const [page, setPage] = useState(0);
-		// transform roles for use in SelectContainer
 
-	const [roleNames, setRoleNames] = useState<{ name: string }[]>([]);
-
-
-	useEffect(() => {
-		const roleNames = [];
-		for (let i = 0; i < groupDetails.roles.length; i++) {
-			if (!groupDetails.roles[i].startsWith("ROLE_GROUP")) {
-				roleNames.push({
-					name: groupDetails.roles[i],
-				});
-			}
-		}
-		setRoleNames(roleNames);
-	}, [groupDetails.roles]);
-
+	// Since we are using the initialValues to be consumed by SelectContainer via Formik later on,
+	// we should not use useState because the asynchronous nature! which has no use here,
+	// and in fact prevents the "roles" to get the data properly!
 	const initialValues = {
-		...groupDetails,
-		roles: roleNames,
+	...groupDetails,
+	roles: groupDetails.roles
+		.filter(role => !role.startsWith("ROLE_GROUP"))
+		.map(role => ({ name: role })),
 	};
 
 	// information about tabs

--- a/src/slices/aclSlice.ts
+++ b/src/slices/aclSlice.ts
@@ -126,7 +126,7 @@ export const fetchRolesWithTarget = async (target: string) => {
 	let response = await axios.get("/admin-ng/acl/roles.json", { params: params });
 	let data : Role[] = response.data
 
-	return await data;
+	return data;
 };
 
 // post new acl to backend


### PR DESCRIPTION
This PR fixes #1237,
### Description
Updating groups removes the already assigned Roles

### Problem
Because of using Formik with `const initialValues` and consuming its values later on in the SelectContainer component automatically, we should not use the `useState` to set values to roles as in `roleNames` => **asynchronously** and then directly use it in a const **synchronously**

### Solution
The changes just make sure the `initialValues` gets the mapped roles properly!