### PR TITLE
Filtering from events cells in pages other than first page now works!

### DIFF
--- a/src/components/events/partials/EventsLocationCell.tsx
+++ b/src/components/events/partials/EventsLocationCell.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { getFilters } from "../../../selectors/tableFilterSelectors";
 import { editFilterValue } from "../../../slices/tableFilterSlice";
 import { loadEventsIntoTable } from "../../../thunks/tableThunks";
@@ -6,6 +6,9 @@ import { useAppDispatch, useAppSelector } from "../../../store";
 import { fetchEvents } from "../../../slices/eventSlice";
 import { Event } from "../../../slices/eventSlice";
 import { IconButton } from "../../shared/IconButton";
+import {
+	goToPage,
+} from "../../../thunks/tableThunks";
 
 /**
  * This component renders the location cells of events in the table view
@@ -15,19 +18,43 @@ const EventsLocationCell = ({
 }: {
 	row: Event
 }) => {
+	// Using itemValue with useState in order to use as flag in useEffect as watcher!
+	const [itemValue, setItemValue] = useState('');
 	const dispatch = useAppDispatch();
 
 	const filterMap = useAppSelector(state => getFilters(state, "events"));
 
 	// Filter with value of current cell
-	const addFilter = (location: string) => {
+	const addFilter = async (location: string) => {
+		let mustApplyChanges = false;
 		let filter = filterMap.find(({ name }) => name === "location");
 		if (!!filter) {
-			dispatch(editFilterValue({filterName: filter.name, value: location}));
-			dispatch(fetchEvents());
-			dispatch(loadEventsIntoTable());
+			await dispatch(editFilterValue({filterName: filter.name, value: location}));
+			mustApplyChanges = true;
+		}
+		if (mustApplyChanges) {
+			setItemValue(location);
 		}
 	};
+
+	const applyFilterChangesDebounced = async () => {
+		// No matter what, we go to page one.
+		dispatch(goToPage(0))
+		// Reload of resource
+		await dispatch(fetchEvents());
+		dispatch(loadEventsIntoTable());
+		setItemValue('');
+	};
+
+	useEffect(() => {
+		if (itemValue) {
+			// Call to apply filter changes with 500MS debounce!
+			let applyFilterChangesDebouncedTimeoutId = setTimeout(applyFilterChangesDebounced, 500);
+
+			return () => clearTimeout(applyFilterChangesDebouncedTimeoutId);
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [itemValue]);
 
 	return (
 		// Link template for location of event

--- a/src/components/events/partials/EventsPresentersCell.tsx
+++ b/src/components/events/partials/EventsPresentersCell.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { getFilters } from "../../../selectors/tableFilterSelectors";
 import { editFilterValue } from "../../../slices/tableFilterSlice";
 import { loadEventsIntoTable } from "../../../thunks/tableThunks";
@@ -6,6 +6,9 @@ import { useAppDispatch, useAppSelector } from "../../../store";
 import { fetchEvents } from "../../../slices/eventSlice";
 import { Event } from "../../../slices/eventSlice";
 import { IconButton } from "../../shared/IconButton";
+import {
+	goToPage,
+} from "../../../thunks/tableThunks";
 
 /**
  * This component renders the presenters cells of events in the table view
@@ -15,21 +18,45 @@ const EventsPresentersCell = ({
 }: {
 	row: Event
 }) => {
+	// Using itemValue with useState in order to use as flag in useEffect as watcher!
+	const [itemValue, setItemValue] = useState('');
 	const dispatch = useAppDispatch();
 
 	const filterMap = useAppSelector(state => getFilters(state, "events"));
 
 	// Filter with value of current cell
 	const addFilter = async (presenter: string) => {
+		let mustApplyChanges = false;
 		let filter = filterMap.find(
 			({ name }) => name === "presentersBibliographic"
 		);
 		if (!!filter) {
 			await dispatch(editFilterValue({filterName: filter.name, value: presenter}));
-			await dispatch(fetchEvents());
-			dispatch(loadEventsIntoTable());
+			mustApplyChanges = true;
+		}
+		if (mustApplyChanges) {
+			setItemValue(presenter);
 		}
 	};
+
+	const applyFilterChangesDebounced = async () => {
+		// No matter what, we go to page one.
+		dispatch(goToPage(0))
+		// Reload of resource
+		await dispatch(fetchEvents());
+		dispatch(loadEventsIntoTable());
+		setItemValue('');
+	};
+
+	useEffect(() => {
+		if (itemValue) {
+			// Call to apply filter changes with 500MS debounce!
+			let applyFilterChangesDebouncedTimeoutId = setTimeout(applyFilterChangesDebounced, 500);
+
+			return () => clearTimeout(applyFilterChangesDebouncedTimeoutId);
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [itemValue]);
 
 	return (
 		// Link template for presenter of event

--- a/src/components/events/partials/EventsSeriesCell.tsx
+++ b/src/components/events/partials/EventsSeriesCell.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { getFilters } from "../../../selectors/tableFilterSelectors";
 import { editFilterValue } from "../../../slices/tableFilterSlice";
 import { loadEventsIntoTable } from "../../../thunks/tableThunks";
@@ -6,6 +6,9 @@ import { useAppDispatch, useAppSelector } from "../../../store";
 import { fetchEvents } from "../../../slices/eventSlice";
 import { Event } from "../../../slices/eventSlice";
 import { IconButton } from "../../shared/IconButton";
+import {
+	goToPage,
+} from "../../../thunks/tableThunks";
 
 /**
  * This component renders the series cells of events in the table view
@@ -15,19 +18,43 @@ const EventsSeriesCell = ({
 }: {
 	row: Event
 }) => {
+	// Using itemValue with useState in order to use as flag in useEffect as watcher!
+	const [itemValue, setItemValue] = useState('');
 	const dispatch = useAppDispatch();
 
 	const filterMap = useAppSelector(state => getFilters(state, "events"));
 
 	// Filter with value of current cell
 	const addFilter = async (seriesId: string) => {
+		let mustApplyChanges = false;
 		let filter = filterMap.find(({ name }) => name === "series");
 		if (!!filter) {
 			await dispatch(editFilterValue({filterName: filter.name, value: seriesId}));
-			await dispatch(fetchEvents());
-			dispatch(loadEventsIntoTable());
+			mustApplyChanges = true;
+		}
+		if (mustApplyChanges) {
+			setItemValue(seriesId);
 		}
 	};
+
+	const applyFilterChangesDebounced = async () => {
+		// No matter what, we go to page one.
+		dispatch(goToPage(0))
+		// Reload of resource
+		await dispatch(fetchEvents());
+		dispatch(loadEventsIntoTable());
+		setItemValue('');
+	};
+
+	useEffect(() => {
+		if (itemValue) {
+			// Call to apply filter changes with 500MS debounce!
+			let applyFilterChangesDebouncedTimeoutId = setTimeout(applyFilterChangesDebounced, 500);
+
+			return () => clearTimeout(applyFilterChangesDebouncedTimeoutId);
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [itemValue]);
 
 	return (
 		!!row.series ? (

--- a/src/components/events/partials/EventsTechnicalDateCell.tsx
+++ b/src/components/events/partials/EventsTechnicalDateCell.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { getFilters } from "../../../selectors/tableFilterSelectors";
 import { editFilterValue } from "../../../slices/tableFilterSlice";
@@ -8,6 +8,9 @@ import { fetchEvents } from "../../../slices/eventSlice";
 import { renderValidDate } from "../../../utils/dateUtils";
 import { Event } from "../../../slices/eventSlice";
 import { IconButton } from "../../shared/IconButton";
+import {
+	goToPage,
+} from "../../../thunks/tableThunks";
 
 /**
  * This component renders the technical date cells of events in the table view
@@ -17,6 +20,8 @@ const EventsTechnicalDateCell = ({
 }: {
 	row: Event
 }) => {
+	// Using itemValue with useState in order to use as flag in useEffect as watcher!
+	const [itemValue, setItemValue] = useState('');
 	const { t } = useTranslation();
 	const dispatch = useAppDispatch();
 
@@ -24,13 +29,35 @@ const EventsTechnicalDateCell = ({
 
 	// Filter with value of current cell
 	const addFilter = async (date: string) => {
+		let mustApplyChanges = false;
 		let filter = filterMap.find(({ name }) => name === "technicalStart");
 		if (!!filter) {
 			await dispatch(editFilterValue({filterName: filter.name, value: date + "/" + date}));
-			await dispatch(fetchEvents());
-			dispatch(loadEventsIntoTable());
+			mustApplyChanges = true;
+		}
+		if (mustApplyChanges) {
+			setItemValue(date);
 		}
 	};
+
+	const applyFilterChangesDebounced = async () => {
+		// No matter what, we go to page one.
+		dispatch(goToPage(0))
+		// Reload of resource
+		await dispatch(fetchEvents());
+		dispatch(loadEventsIntoTable());
+		setItemValue('');
+	};
+
+	useEffect(() => {
+		if (itemValue) {
+			// Call to apply filter changes with 500MS debounce!
+			let applyFilterChangesDebouncedTimeoutId = setTimeout(applyFilterChangesDebounced, 500);
+
+			return () => clearTimeout(applyFilterChangesDebouncedTimeoutId);
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [itemValue]);
 
 	return (
 		// Link template for technical date of event


### PR DESCRIPTION
This PR fixes #1229,

Applying a debouncing mechanism when the filtering should be applied in order to fetch the events and load them into the table. Using debounce helps reduce unwanted redundent calls.
In addition, we use useState and useEffect in order to use the advantage of async and watcher properties!

The main problem also was the fact that by applying filters no matter which page the table is set to, it has to be set to first page, so here we use `goToPage(0)`

### TESTING
Please make sure to test all event cells that are filterable, by clicking on the values! don't hesitate to ask if you have any question. Thanks in advance!