### PR TITLE
Close the language change dropdown without reloading the whole page

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -31,13 +31,6 @@ const containerHelp = React.createRef<HTMLDivElement>();
 const containerUser = React.createRef<HTMLDivElement>();
 const containerNotify = React.createRef<HTMLDivElement>();
 
-function changeLanguage(code: string) {
-	// Load json-file of the language with provided code
-	i18n.changeLanguage(code);
-	// Reload window for updating the flag of the language dropdown menu
-	window.location.reload();
-}
-
 function logout() {
 	window.location.href = "/j_spring_security_logout";
 }
@@ -83,6 +76,13 @@ const Header = () => {
 		} else {
 			hotKeyCheatSheetModalRef.current?.open()
 		}
+	};
+
+	const handleChangeLanguage = (code: string) => {
+		// Load json-file of the language with provided code
+		i18n.changeLanguage(code);
+		// Close the language dropdown menu
+		setMenuLang(false);
 	};
 
 	useHotkeys(
@@ -153,7 +153,7 @@ const Header = () => {
 								</IconContext.Provider>
 							</button>
 						</Tooltip>
-						{displayMenuLang && <MenuLang />}
+						{displayMenuLang && <MenuLang handleChangeLanguage={handleChangeLanguage}/>}
 					</div>
 
 					{/* Media Module */}
@@ -273,7 +273,11 @@ const Header = () => {
 	);
 };
 
-const MenuLang = () => {
+const MenuLang = ({ handleChangeLanguage }: { handleChangeLanguage: (code: string) => void }) => {
+	// const handleChangeLanguage = (code: string) => {
+	// 	handleChangeLanguage(code);
+	// };
+
 	return (
 		<ul className="dropdown-ul">
 			{/* one list item for each available language */}
@@ -281,7 +285,7 @@ const MenuLang = () => {
 				<li key={key}>
 					<ButtonLikeAnchor
 						extraClassName={(i18n.language === language.code ? "selected" : "")}
-						onClick={() => changeLanguage(language.code)}
+						onClick={() => handleChangeLanguage(language.code)}
 					>
 						{language.long}
 					</ButtonLikeAnchor>


### PR DESCRIPTION
This pull request refactors the language change functionality in the `Header` component to remove the need for a page reload. This way changing the language is instant compared to needing multiple seconds before #1260. 