### PR TITLE
Adding goToPage(0) to Filters from within the Table and the Stats Bar

### DIFF
--- a/src/components/events/partials/EventsDateCell.tsx
+++ b/src/components/events/partials/EventsDateCell.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { editFilterValue } from "../../../slices/tableFilterSlice";
-import { loadEventsIntoTable } from "../../../thunks/tableThunks";
+import { loadEventsIntoTable, goToPage } from "../../../thunks/tableThunks";
 import { getFilters } from "../../../selectors/tableFilterSelectors";
 import { useAppDispatch, useAppSelector } from "../../../store";
 import { fetchEvents } from "../../../slices/eventSlice";
@@ -35,6 +35,7 @@ const EventsDateCell = ({
 			endDate.setMinutes(59);
 			endDate.setSeconds(59);
 
+      dispatch(goToPage(0));
 			await dispatch(editFilterValue({filterName: filter.name, value: startDate.toISOString() + "/" + endDate.toISOString()}));
 			await dispatch(fetchEvents());
 			dispatch(loadEventsIntoTable());

--- a/src/components/events/partials/EventsDateCell.tsx
+++ b/src/components/events/partials/EventsDateCell.tsx
@@ -34,8 +34,7 @@ const EventsDateCell = ({
 			endDate.setHours(23);
 			endDate.setMinutes(59);
 			endDate.setSeconds(59);
-
-      dispatch(goToPage(0));
+			dispatch(goToPage(0));
 			await dispatch(editFilterValue({filterName: filter.name, value: startDate.toISOString() + "/" + endDate.toISOString()}));
 			await dispatch(fetchEvents());
 			dispatch(loadEventsIntoTable());

--- a/src/components/events/partials/EventsLocationCell.tsx
+++ b/src/components/events/partials/EventsLocationCell.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { getFilters } from "../../../selectors/tableFilterSelectors";
 import { editFilterValue } from "../../../slices/tableFilterSlice";
-import { loadEventsIntoTable } from "../../../thunks/tableThunks";
+import { loadEventsIntoTable, goToPage } from "../../../thunks/tableThunks";
 import { useAppDispatch, useAppSelector } from "../../../store";
 import { fetchEvents } from "../../../slices/eventSlice";
 import { Event } from "../../../slices/eventSlice";
@@ -23,6 +23,7 @@ const EventsLocationCell = ({
 	const addFilter = (location: string) => {
 		let filter = filterMap.find(({ name }) => name === "location");
 		if (!!filter) {
+      dispatch(goToPage(0));
 			dispatch(editFilterValue({filterName: filter.name, value: location}));
 			dispatch(fetchEvents());
 			dispatch(loadEventsIntoTable());

--- a/src/components/events/partials/EventsLocationCell.tsx
+++ b/src/components/events/partials/EventsLocationCell.tsx
@@ -23,7 +23,7 @@ const EventsLocationCell = ({
 	const addFilter = (location: string) => {
 		let filter = filterMap.find(({ name }) => name === "location");
 		if (!!filter) {
-      dispatch(goToPage(0));
+			dispatch(goToPage(0));
 			dispatch(editFilterValue({filterName: filter.name, value: location}));
 			dispatch(fetchEvents());
 			dispatch(loadEventsIntoTable());

--- a/src/components/events/partials/EventsPresentersCell.tsx
+++ b/src/components/events/partials/EventsPresentersCell.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { getFilters } from "../../../selectors/tableFilterSelectors";
 import { editFilterValue } from "../../../slices/tableFilterSlice";
-import { loadEventsIntoTable } from "../../../thunks/tableThunks";
+import { loadEventsIntoTable, goToPage } from "../../../thunks/tableThunks";
 import { useAppDispatch, useAppSelector } from "../../../store";
 import { fetchEvents } from "../../../slices/eventSlice";
 import { Event } from "../../../slices/eventSlice";
@@ -25,6 +25,7 @@ const EventsPresentersCell = ({
 			({ name }) => name === "presentersBibliographic"
 		);
 		if (!!filter) {
+      dispatch(goToPage(0));
 			await dispatch(editFilterValue({filterName: filter.name, value: presenter}));
 			await dispatch(fetchEvents());
 			dispatch(loadEventsIntoTable());

--- a/src/components/events/partials/EventsPresentersCell.tsx
+++ b/src/components/events/partials/EventsPresentersCell.tsx
@@ -25,7 +25,7 @@ const EventsPresentersCell = ({
 			({ name }) => name === "presentersBibliographic"
 		);
 		if (!!filter) {
-      dispatch(goToPage(0));
+			dispatch(goToPage(0));
 			await dispatch(editFilterValue({filterName: filter.name, value: presenter}));
 			await dispatch(fetchEvents());
 			dispatch(loadEventsIntoTable());

--- a/src/components/events/partials/EventsSeriesCell.tsx
+++ b/src/components/events/partials/EventsSeriesCell.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { getFilters } from "../../../selectors/tableFilterSelectors";
 import { editFilterValue } from "../../../slices/tableFilterSlice";
-import { loadEventsIntoTable } from "../../../thunks/tableThunks";
+import { loadEventsIntoTable, goToPage } from "../../../thunks/tableThunks";
 import { useAppDispatch, useAppSelector } from "../../../store";
 import { fetchEvents } from "../../../slices/eventSlice";
 import { Event } from "../../../slices/eventSlice";
@@ -23,6 +23,7 @@ const EventsSeriesCell = ({
 	const addFilter = async (seriesId: string) => {
 		let filter = filterMap.find(({ name }) => name === "series");
 		if (!!filter) {
+      dispatch(goToPage(0));
 			await dispatch(editFilterValue({filterName: filter.name, value: seriesId}));
 			await dispatch(fetchEvents());
 			dispatch(loadEventsIntoTable());

--- a/src/components/events/partials/EventsSeriesCell.tsx
+++ b/src/components/events/partials/EventsSeriesCell.tsx
@@ -23,7 +23,7 @@ const EventsSeriesCell = ({
 	const addFilter = async (seriesId: string) => {
 		let filter = filterMap.find(({ name }) => name === "series");
 		if (!!filter) {
-      dispatch(goToPage(0));
+			dispatch(goToPage(0));
 			await dispatch(editFilterValue({filterName: filter.name, value: seriesId}));
 			await dispatch(fetchEvents());
 			dispatch(loadEventsIntoTable());

--- a/src/components/events/partials/EventsTechnicalDateCell.tsx
+++ b/src/components/events/partials/EventsTechnicalDateCell.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { getFilters } from "../../../selectors/tableFilterSelectors";
 import { editFilterValue } from "../../../slices/tableFilterSlice";
-import { loadEventsIntoTable } from "../../../thunks/tableThunks";
+import { loadEventsIntoTable, goToPage } from "../../../thunks/tableThunks";
 import { useAppDispatch, useAppSelector } from "../../../store";
 import { fetchEvents } from "../../../slices/eventSlice";
 import { renderValidDate } from "../../../utils/dateUtils";
@@ -26,6 +26,7 @@ const EventsTechnicalDateCell = ({
 	const addFilter = async (date: string) => {
 		let filter = filterMap.find(({ name }) => name === "technicalStart");
 		if (!!filter) {
+      dispatch(goToPage(0));
 			await dispatch(editFilterValue({filterName: filter.name, value: date + "/" + date}));
 			await dispatch(fetchEvents());
 			dispatch(loadEventsIntoTable());

--- a/src/components/events/partials/EventsTechnicalDateCell.tsx
+++ b/src/components/events/partials/EventsTechnicalDateCell.tsx
@@ -26,7 +26,7 @@ const EventsTechnicalDateCell = ({
 	const addFilter = async (date: string) => {
 		let filter = filterMap.find(({ name }) => name === "technicalStart");
 		if (!!filter) {
-      dispatch(goToPage(0));
+			dispatch(goToPage(0));
 			await dispatch(editFilterValue({filterName: filter.name, value: date + "/" + date}));
 			await dispatch(fetchEvents());
 			dispatch(loadEventsIntoTable());

--- a/src/components/shared/Stats.tsx
+++ b/src/components/shared/Stats.tsx
@@ -38,7 +38,7 @@ const Stats = () => {
 			let filter = filterMap.find(({ name }) => name === f.name);
 			filterValue = f.value;
 			if (!!filter) {
-        dispatch(goToPage(0));
+				dispatch(goToPage(0));
 				dispatch(editFilterValue({filterName: filter.name, value: filterValue}));
 			}
 		});

--- a/src/components/shared/Stats.tsx
+++ b/src/components/shared/Stats.tsx
@@ -9,7 +9,7 @@ import {
 	editTextFilter,
 	removeTextFilter,
 } from "../../slices/tableFilterSlice";
-import { loadEventsIntoTable } from "../../thunks/tableThunks";
+import { loadEventsIntoTable, goToPage } from "../../thunks/tableThunks";
 import { useAppDispatch, useAppSelector } from "../../store";
 import { fetchEvents } from "../../slices/eventSlice";
 import { ParseKeys } from "i18next";
@@ -38,6 +38,7 @@ const Stats = () => {
 			let filter = filterMap.find(({ name }) => name === f.name);
 			filterValue = f.value;
 			if (!!filter) {
+        dispatch(goToPage(0));
 				dispatch(editFilterValue({filterName: filter.name, value: filterValue}));
 			}
 		});


### PR DESCRIPTION
As described in Issue https://github.com/opencast/opencast-admin-interface/issues/1089 when filtering the Event Table via the `addFilter` functionality of the links within the table or the stats bar the offset was not reset, leading to an empty table. This filter functionality is available for:  
- series names
- locations
- presenter
- date
- all field in the stats bar

This PR fixes the bug by making sure that before fetching the Events with the Filter the UI returns to the first page of the table and thereby resetting the offset to 0. The same behavior was already implemented for filtering the table via the Filter Bar. 

How to test:
- go to the last page of the table (or at least not page 1)
- click on a link/field for filtering the table (one of the fields named above)