### PR TITLE
make cancel buttons work for users/groups/access

### DIFF
--- a/src/components/users/partials/modal/AclDetails.tsx
+++ b/src/components/users/partials/modal/AclDetails.tsx
@@ -88,7 +88,7 @@ const AclDetails = ({
 						{/* Navigation buttons and validation */}
 						<WizardNavigationButtons
 							formik={formik}
-							previousPage={() => close()}
+							previousPage={close}
 							submitPage={
 								async () => {
 									if (await dispatch(checkAcls(formik.values.acls))) {

--- a/src/components/users/partials/modal/AclDetails.tsx
+++ b/src/components/users/partials/modal/AclDetails.tsx
@@ -88,6 +88,7 @@ const AclDetails = ({
 						{/* Navigation buttons and validation */}
 						<WizardNavigationButtons
 							formik={formik}
+							previousPage={() => close()}
 							submitPage={
 								async () => {
 									if (await dispatch(checkAcls(formik.values.acls))) {

--- a/src/components/users/partials/modal/GroupDetails.tsx
+++ b/src/components/users/partials/modal/GroupDetails.tsx
@@ -98,6 +98,7 @@ const GroupDetails: React.FC<{
 						{/* Navigation buttons and validation */}
 						<WizardNavigationButtons
 							formik={formik}
+							previousPage={() => close()}
 							createTranslationString="SUBMIT"
 							cancelTranslationString="CANCEL"
 							isLast

--- a/src/components/users/partials/modal/GroupDetails.tsx
+++ b/src/components/users/partials/modal/GroupDetails.tsx
@@ -98,7 +98,7 @@ const GroupDetails: React.FC<{
 						{/* Navigation buttons and validation */}
 						<WizardNavigationButtons
 							formik={formik}
-							previousPage={() => close()}
+							previousPage={close}
 							createTranslationString="SUBMIT"
 							cancelTranslationString="CANCEL"
 							isLast

--- a/src/components/users/partials/modal/UserDetails.tsx
+++ b/src/components/users/partials/modal/UserDetails.tsx
@@ -84,7 +84,7 @@ const UserDetails: React.FC<{
 						{page !== 2 && (
 							<WizardNavigationButtons
 								formik={formik}
-								previousPage={() => close()}
+								previousPage={close}
 								createTranslationString="SUBMIT"
 								cancelTranslationString="CANCEL"
 								isLast

--- a/src/components/users/partials/modal/UserDetails.tsx
+++ b/src/components/users/partials/modal/UserDetails.tsx
@@ -84,6 +84,7 @@ const UserDetails: React.FC<{
 						{page !== 2 && (
 							<WizardNavigationButtons
 								formik={formik}
+								previousPage={() => close()}
 								createTranslationString="SUBMIT"
 								cancelTranslationString="CANCEL"
 								isLast


### PR DESCRIPTION
Fixes #1182 

Just makes the cancel button close the modal which is the behaviour of the old admin UI