### PR TITLE
Override events ACLs by separate button in Series Details Update

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/SeriesDetailsAccessTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/SeriesDetailsAccessTab.tsx
@@ -46,6 +46,7 @@ const SeriesDetailsAccessTab = ({
 			editAccessRole={"ROLE_UI_SERIES_DETAILS_ACL_EDIT"}
 			policyChanged={policyChanged}
 			setPolicyChanged={setPolicyChanged}
+			withOverrideButton={true}
 		/>
 	);
 };

--- a/src/components/shared/SaveEditFooter.tsx
+++ b/src/components/shared/SaveEditFooter.tsx
@@ -1,10 +1,17 @@
 import { useTranslation } from "react-i18next"
+import { Tooltip } from "./Tooltip";
+import { ParseKeys } from "i18next";
 
 type SaveEditFooterProps = {
     active: boolean;
     reset: () => void;
     submit: () => void;
     isValid?: boolean;
+    additionalButton?: {
+        label: ParseKeys,
+        hint: ParseKeys,
+        onClick: () => void
+    };
 }
 
 export const SaveEditFooter: React.FC<SaveEditFooterProps> = ({
@@ -12,6 +19,7 @@ export const SaveEditFooter: React.FC<SaveEditFooterProps> = ({
     reset,
     submit,
     isValid,
+    additionalButton
 }) => {
     const { t } = useTranslation();
 
@@ -23,6 +31,19 @@ export const SaveEditFooter: React.FC<SaveEditFooterProps> = ({
                     onClick={reset}
                     className="cancel"
                 >{t("CANCEL")}</button>
+            </div>
+        )}
+        {additionalButton && (
+            <div className="pull-right" style={{ marginLeft: 5 }}>
+                <Tooltip title={t(additionalButton.hint)}>
+                    <button
+                        onClick={additionalButton.onClick}
+                        disabled={!isValid || !active}
+                        className={`save green ${
+                            !isValid || !active ? "disabled" : ""
+                        }`}
+                    >{t(additionalButton.label)}</button>
+                </Tooltip>
             </div>
         )}
         <div className="pull-right">

--- a/src/components/shared/modals/ResourceDetailsAccessPolicyTab.tsx
+++ b/src/components/shared/modals/ResourceDetailsAccessPolicyTab.tsx
@@ -55,7 +55,7 @@ const ResourceDetailsAccessPolicyTab = ({
 	policies: TransformedAcl[],
 	fetchHasActiveTransactions?: AsyncThunk<any, string, any>
 	fetchAccessPolicies: AsyncThunk<TransformedAcl[], string, any>,
-	saveNewAccessPolicies: AsyncThunk<boolean, { id: string, policies: { acl: Acl }, override: boolean }, any>
+	saveNewAccessPolicies: AsyncThunk<boolean, { id: string, policies: { acl: Acl }, override?: boolean }, any>
 	descriptionText: string,
 	buttonText: ParseKeys,
 	editAccessRole: string,

--- a/src/components/shared/modals/ResourceDetailsAccessPolicyTab.tsx
+++ b/src/components/shared/modals/ResourceDetailsAccessPolicyTab.tsx
@@ -48,18 +48,20 @@ const ResourceDetailsAccessPolicyTab = ({
 	editAccessRole,
 	policyChanged,
 	setPolicyChanged,
+	withOverrideButton
 }: {
 	resourceId: string,
 	header: ParseKeys,
 	policies: TransformedAcl[],
 	fetchHasActiveTransactions?: AsyncThunk<any, string, any>
 	fetchAccessPolicies: AsyncThunk<TransformedAcl[], string, any>,
-	saveNewAccessPolicies: AsyncThunk<boolean, { id: string, policies: { acl: Acl } }, any>
+	saveNewAccessPolicies: AsyncThunk<boolean, { id: string, policies: { acl: Acl }, override: boolean }, any>
 	descriptionText: string,
 	buttonText: ParseKeys,
 	editAccessRole: string,
 	policyChanged: boolean,
 	setPolicyChanged: (value: boolean) => void,
+	withOverrideButton?: boolean
 }) => {
 	const { t } = useTranslation();
 	const dispatch = useAppDispatch();
@@ -135,7 +137,7 @@ const ResourceDetailsAccessPolicyTab = ({
 
 	/* transforms rules into proper format for saving and checks validity
 	 * if the policies are valid, the new policies are saved in the backend */
-	const saveAccess = (values: { policies: TransformedAcl[] }) => {
+	const saveAccess = (values: { policies: TransformedAcl[] }, override: boolean) => {
 		dispatch(removeNotificationWizardForm());
 		const { roleWithFullRightsExists, allRulesValid } = validatePolicies(
 			values
@@ -163,7 +165,7 @@ const ResourceDetailsAccessPolicyTab = ({
 		}
 
 		if (allRulesValid && roleWithFullRightsExists) {
-			dispatch(saveNewAccessPolicies({id: resourceId, policies: access})).then((success) => {
+			dispatch(saveNewAccessPolicies({id: resourceId, policies: access, override: override})).then((success) => {
 				// fetch new policies from the backend, if save successful
 				if (success) {
 					setPolicyChanged(false);
@@ -321,7 +323,7 @@ const ResourceDetailsAccessPolicyTab = ({
 							enableReinitialize
 							validate={(values) => validateFormik(values)}
 							onSubmit={(values) =>
-								saveAccess(values)
+								saveAccess(values, false)
 							}
 						>
 							{(formik) => (
@@ -650,8 +652,13 @@ const ResourceDetailsAccessPolicyTab = ({
 									{!transactions.read_only && <SaveEditFooter
 										active={policyChanged && formik.dirty}
 										reset={() => resetPolicies(formik.resetForm)}
-										submit={() => saveAccess(formik.values)}
+										submit={() => saveAccess(formik.values, false)}
 										isValid={formik.isValid}
+										additionalButton={withOverrideButton ? {
+											label: "EVENTS.SERIES.DETAILS.ACCESS.ACCESS_POLICY.REPLACE_EVENT_ACLS",
+											hint: "EVENTS.SERIES.DETAILS.ACCESS.ACCESS_POLICY.REPLACE_EVENT_ACLS_HINT",
+											onClick: () => saveAccess(formik.values, true)
+										} : undefined}
 									/>}
 								</div>
 							)}

--- a/src/slices/eventDetailsSlice.ts
+++ b/src/slices/eventDetailsSlice.ts
@@ -1708,7 +1708,7 @@ export const saveAccessPolicies = createAppAsyncThunk('eventDetails/saveAccessPo
 	params: {
 		id: Event["id"],
 		policies: { acl: { ace: Ace[] }},
-		override: boolean, // Although there is no use of parameter here, but in order to keep it sync with series and make the mechanism reuseable, we should keep it!
+		override?: boolean,
 	}, { dispatch }) => {
 	const { id, policies } = params;
 	const headers = getHttpHeaders();

--- a/src/slices/eventDetailsSlice.ts
+++ b/src/slices/eventDetailsSlice.ts
@@ -1704,16 +1704,17 @@ export const updateAssets = createAppAsyncThunk('eventDetails/updateAssets', asy
 		});
 });
 
-export const saveAccessPolicies = createAppAsyncThunk('eventDetails/saveAccessPolicies', async (params: {
-	id: Event["id"],
-	policies: { acl: { ace: Ace[] } }
-}, { dispatch }) => {
+export const saveAccessPolicies = createAppAsyncThunk('eventDetails/saveAccessPolicies', async (
+	params: {
+		id: Event["id"],
+		policies: { acl: { ace: Ace[] }},
+		override: boolean, // Although there is no use of parameter here, but in order to keep it sync with series and make the mechanism reuseable, we should keep it!
+	}, { dispatch }) => {
 	const { id, policies } = params;
 	const headers = getHttpHeaders();
 
 	let data = new URLSearchParams();
 	data.append("acl", JSON.stringify(policies));
-	data.append("override", "true");
 
 	return axios
 		.post(`/admin-ng/event/${id}/access`, data.toString(), headers)

--- a/src/slices/eventDetailsSlice.ts
+++ b/src/slices/eventDetailsSlice.ts
@@ -1708,7 +1708,6 @@ export const saveAccessPolicies = createAppAsyncThunk('eventDetails/saveAccessPo
 	params: {
 		id: Event["id"],
 		policies: { acl: { ace: Ace[] }},
-		override?: boolean,
 	}, { dispatch }) => {
 	const { id, policies } = params;
 	const headers = getHttpHeaders();

--- a/src/slices/seriesDetailsSlice.ts
+++ b/src/slices/seriesDetailsSlice.ts
@@ -254,7 +254,7 @@ export const updateSeriesAccess = createAppAsyncThunk('seriesDetails/updateSerie
 	params: {
 		id: Series["id"],
 		policies: { acl: Acl },
-		override: boolean
+		override?: boolean
 	}, {dispatch}) => {
 	const { id, policies, override } = params;
 

--- a/src/slices/seriesDetailsSlice.ts
+++ b/src/slices/seriesDetailsSlice.ts
@@ -252,14 +252,17 @@ export const updateExtendedSeriesMetadata = createAppAsyncThunk('seriesDetails/u
 
 export const updateSeriesAccess = createAppAsyncThunk('seriesDetails/updateSeriesAccess', async (params: {
 	id: Series["id"],
-	policies: { acl: Acl }
+	policies: { acl: Acl },
+	override: boolean
 }, {dispatch}) => {
-	const { id, policies } = params;
+	const { id, policies, override } = params;
 
 	let data = new URLSearchParams();
 
+	let overrideString = override ? String(true) : String(false);
+
 	data.append("acl", JSON.stringify(policies));
-	data.append("override", String(true));
+	data.append("override", overrideString);
 
 	return axios
 		.post(`/admin-ng/series/${id}/access`, data, {

--- a/src/slices/seriesDetailsSlice.ts
+++ b/src/slices/seriesDetailsSlice.ts
@@ -250,11 +250,12 @@ export const updateExtendedSeriesMetadata = createAppAsyncThunk('seriesDetails/u
 	dispatch(setSeriesDetailsExtendedMetadata(newExtendedMetadata));
 });
 
-export const updateSeriesAccess = createAppAsyncThunk('seriesDetails/updateSeriesAccess', async (params: {
-	id: Series["id"],
-	policies: { acl: Acl },
-	override: boolean
-}, {dispatch}) => {
+export const updateSeriesAccess = createAppAsyncThunk('seriesDetails/updateSeriesAccess', async (
+	params: {
+		id: Series["id"],
+		policies: { acl: Acl },
+		override: boolean
+	}, {dispatch}) => {
 	const { id, policies, override } = params;
 
 	let data = new URLSearchParams();


### PR DESCRIPTION
This PR fixes #1263,
this adds override button functionality to access policy components for series,
The problem was, the override parameter was always "true".
It is now possible to make sure that the overriding of acls onto the events happens intentionally!

In additon, the `SaveEditFooter` component is now tuned to have additional button on demand!