### PR TITLE
Fix/role dropdown width

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -278,13 +278,15 @@ div.editable {
 }
 td.editable {
   cursor: text;
-
+ 
   &> div {
     overflow: visible;
+   padding-right: 11px;
+
   }
 
   input {
-    padding-right: 10px;
+    padding-right: 1000px;
     padding-top: 3px;
     padding-bottom: 3px;
     padding-left: 5px;


### PR DESCRIPTION
This PR addresses a layout issue where the Role dropdown in the Access Policy modal was overflowing into the adjacent Read column.
Fixes #1273 