### PR TITLE
Reset filters when series changed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 /build
+.idea/

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsCommentsTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsCommentsTab.tsx
@@ -249,6 +249,7 @@ const EventDetailsCommentsTab = ({
 										text={t(commentReason as ParseKeys)}
 										options={Object.entries(commentReasons).map(([key, value]) => ({ label: value, value: key }))}
 										required={true}
+										menuPlacement="top"
 										handleChange={(element) => {
 											if (element) {
 												setCommentReason(element.value)

--- a/src/components/shared/DropDown.tsx
+++ b/src/components/shared/DropDown.tsx
@@ -121,6 +121,7 @@ const DropDown = <T, >({
 
 
   let commonProps: Props = {
+	  	menuPlacement: 'auto',
 		tabIndex: tabIndex,
 		theme: (theme) => (dropDownSpacingTheme(theme)),
 		styles: style,

--- a/src/components/shared/DropDown.tsx
+++ b/src/components/shared/DropDown.tsx
@@ -51,6 +51,7 @@ const DropDown = <T, >({
 	disabled?: boolean,
 	menuIsOpen?: boolean,
 	handleMenuIsOpen?: (open: boolean) => void,
+	menuPlacement?: 'auto' | 'top' | 'bottom',
 	customCSS?: {
 		isMetadataStyle?: boolean,
 		width?: number | string,

--- a/src/slices/tableFilterSlice.ts
+++ b/src/slices/tableFilterSlice.ts
@@ -90,7 +90,7 @@ export const fetchFilters = createAppAsyncThunk('tableFilters/fetchFilters', asy
 	}
 
 	// Do all this purely to keep set filter values saved if the tab gets switched
-	let oldData = getState().tableFilters.data
+	/*let oldData = getState().tableFilters.data
 
 	for (const oldFilter of oldData) {
 		const foundIndex = filtersList.findIndex(x => x.name === oldFilter.name && x.resource === oldFilter.resource);
@@ -100,7 +100,7 @@ export const fetchFilters = createAppAsyncThunk('tableFilters/fetchFilters', asy
 	}
 
 	oldData = oldData.filter(filter => filter.resource !== resource)
-	filtersList.push(...oldData)
+	filtersList.push(...oldData) */
 
 	return { filtersList, resource };
 });


### PR DESCRIPTION
This PR fixes the issue where filters were persisting after switching tabs. Now, filters are reset when the user navigates between tabs.
