### PR TITLE
Direct link to the Tobira video/series

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/DetailsTobiraTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/DetailsTobiraTab.tsx
@@ -58,7 +58,7 @@ const DetailsTobiraTab = ({ kind, id }: DetailsTobiraTabProps) => {
 
 	const i18nKey = kind === "series" ? "SERIES" : "EVENTS";
 	const prefix = kind === "series" ? "s" : "v";
-	const directTobiraLink = tobiraData.baseURL + `/!${prefix}/:` + id;
+	const directTobiraLink = tobiraData.baseURL + `/!${prefix}/` + (tobiraData.id.length > 2 ? tobiraData.id.substring(2) : `:${id}`);
 
 	const getBreadcrumbs = (currentPage: TobiraPage) => {
 		const homepage = {
@@ -204,6 +204,7 @@ type TobiraTableProps = {
 const TobiraTable = ({ tobiraData, i18nKey, openSubTab, handleDelete }: TobiraTableProps) => {
 	const { t } = useTranslation();
 	const deleteConfirmationModalRef = useRef<ModalHandle>(null);
+	const prefix = i18nKey === "SERIES" ? 's' : 'v';
 
 	return <div className="obj">
 		<header>{t(`EVENTS.${i18nKey}.DETAILS.TOBIRA.PAGES`)}</header>
@@ -222,7 +223,8 @@ const TobiraTable = ({ tobiraData, i18nKey, openSubTab, handleDelete }: TobiraTa
 				</tr>}
 				{tobiraData.hostPages.map(hostPage => <tr key={hostPage.path}>
 					<td>
-						<a href={tobiraData.baseURL + hostPage.path}>
+						<a href={tobiraData.baseURL + hostPage.path +
+							(tobiraData.id.length > 2 ? `/${prefix}/${tobiraData.id.substring(2)}` : '')}>
 							{hostPage.path !== '/' && <>
 								<span className="tobira-page-separator">/</span>
 								{hostPage.ancestors.map((ancestor, key) => (

--- a/src/slices/eventDetailsSlice.ts
+++ b/src/slices/eventDetailsSlice.ts
@@ -597,6 +597,7 @@ const initialState: EventDetailsState = {
 	hasStatisticsError: false,
 	tobiraData: {
 		baseURL: "",
+		id: "",
 		hostPages: [],
 	},
 };

--- a/src/slices/seriesDetailsSlice.ts
+++ b/src/slices/seriesDetailsSlice.ts
@@ -30,6 +30,7 @@ import { handleTobiraError } from './shared/tobiraErrors';
  */
 export type TobiraData = {
 	baseURL: string,
+	id: string,
 	hostPages: TobiraPage[],
 };
 
@@ -91,6 +92,7 @@ const initialState: SeriesDetailsState = {
 	tobiraTab: "main",
 	tobiraData: {
 		baseURL: "",
+		id: "",
 		hostPages: [],
 	},
 };


### PR DESCRIPTION
Tobira uses its own IDs (a hash-like format) for events/series. We should use them in the Tobira tab in event/series details dialog. The URLs to the Tobira realms should also point to the resource.

This PR needs backend changes from https://github.com/opencast/opencast/pull/6789

Event Opencast ID: 18e4c988-e944-4aed-8376-3b25db6a6eb8
Event URL without this patch: https://tobira.opencast.org/!v/:18e4c988-e944-4aed-8376-3b25db6a6eb8

Event Tobira ID: evL52r4riq-hr (the ev prefix used for events in general)
Event URL after: https://tobira.opencast.org/!v/L52r4riq-hr