### PR TITLE
Remove unnecessary state

### DIFF
--- a/src/components/events/partials/modals/EditMetadataEventsModal.tsx
+++ b/src/components/events/partials/modals/EditMetadataEventsModal.tsx
@@ -33,9 +33,8 @@ const EditMetadataEventsModal = ({
 	const { t } = useTranslation();
 	const dispatch = useAppDispatch();
 
-	const selectedRows = useAppSelector(state => getSelectedRows(state));
+	const selectedEvents = useAppSelector(state => getSelectedRows(state));
 
-	const [selectedEvents] = useState(selectedRows);
 	const [metadataFields, setMetadataFields] = useState<{
 		merged: string[],
 		mergedMetadata: MetadataFieldSelected[],


### PR DESCRIPTION
When we never change the state, as indicated by not even bothering to grab the setter here, this is pure overhead.
