### PR TITLE
Fix service and servers filters being applied to the wrong tables

### DIFF
--- a/src/components/events/partials/EventsLocationCell.tsx
+++ b/src/components/events/partials/EventsLocationCell.tsx
@@ -23,7 +23,7 @@ const EventsLocationCell = ({
 	const addFilter = (location: string) => {
 		let filter = filterMap.find(({ name }) => name === "location");
 		if (!!filter) {
-			dispatch(editFilterValue({filterName: filter.name, value: location}));
+			dispatch(editFilterValue({filterName: filter.name, value: location, resource: "events"}));
 			dispatch(fetchEvents());
 			dispatch(loadEventsIntoTable());
 		}

--- a/src/components/events/partials/EventsSeriesCell.tsx
+++ b/src/components/events/partials/EventsSeriesCell.tsx
@@ -23,7 +23,7 @@ const EventsSeriesCell = ({
 	const addFilter = async (seriesId: string) => {
 		let filter = filterMap.find(({ name }) => name === "series");
 		if (!!filter) {
-			await dispatch(editFilterValue({filterName: filter.name, value: seriesId}));
+			await dispatch(editFilterValue({filterName: filter.name, value: seriesId, resource: "events"}));
 			await dispatch(fetchEvents());
 			dispatch(loadEventsIntoTable());
 		}

--- a/src/components/events/partials/EventsTechnicalDateCell.tsx
+++ b/src/components/events/partials/EventsTechnicalDateCell.tsx
@@ -26,7 +26,7 @@ const EventsTechnicalDateCell = ({
 	const addFilter = async (date: string) => {
 		let filter = filterMap.find(({ name }) => name === "technicalStart");
 		if (!!filter) {
-			await dispatch(editFilterValue({filterName: filter.name, value: date + "/" + date}));
+			await dispatch(editFilterValue({filterName: filter.name, value: date + "/" + date, resource: "events"}));
 			await dispatch(fetchEvents());
 			dispatch(loadEventsIntoTable());
 		}

--- a/src/components/shared/DateTimeCell.tsx
+++ b/src/components/shared/DateTimeCell.tsx
@@ -7,6 +7,7 @@ import { renderValidDate } from "../../utils/dateUtils";
 import { IconButton } from "../shared/IconButton";
 import { ParseKeys } from "i18next";
 import { AsyncThunk } from "@reduxjs/toolkit";
+import { Resource } from "../../slices/tableSlice";
 
 /**
  * This component renders the start date cells of events in the table view
@@ -19,7 +20,7 @@ const DateTimeCell = ({
 	loadResourceIntoTable,
 	tooltipText,
 }: {
-	resource: string
+	resource: Resource
 	date: string
 	filterName: string
 	fetchResource: AsyncThunk<any, void, any>
@@ -44,7 +45,7 @@ const DateTimeCell = ({
 			endDate.setMinutes(59);
 			endDate.setSeconds(59);
 
-			await dispatch(editFilterValue({filterName: filter.name, value: startDate.toISOString() + "/" + endDate.toISOString()}));
+			await dispatch(editFilterValue({filterName: filter.name, value: startDate.toISOString() + "/" + endDate.toISOString(), resource}));
 			await dispatch(fetchResource());
 			dispatch(loadResourceIntoTable());
 		}

--- a/src/components/shared/MultiValueCell.tsx
+++ b/src/components/shared/MultiValueCell.tsx
@@ -5,6 +5,7 @@ import { AppThunk, useAppDispatch, useAppSelector } from "../../store";
 import { IconButton } from "../shared/IconButton";
 import { AsyncThunk } from "@reduxjs/toolkit";
 import { ParseKeys } from "i18next";
+import { Resource } from "../../slices/tableSlice";
 
 /**
  * This component renders the presenters cells of events in the table view
@@ -17,7 +18,7 @@ const MultiValueCell = ({
 	loadResourceIntoTable,
 	tooltipText,
 }: {
-	resource: string
+	resource: Resource
 	values: string[]
 	filterName: string
 	fetchResource: AsyncThunk<any, void, any>
@@ -34,7 +35,7 @@ const MultiValueCell = ({
 			({ name }) => name === filterName
 		);
 		if (!!filter) {
-			await dispatch(editFilterValue({filterName: filter.name, value: presenter}));
+			await dispatch(editFilterValue({filterName: filter.name, value: presenter, resource}));
 			await dispatch(fetchResource());
 			dispatch(loadResourceIntoTable());
 		}

--- a/src/components/shared/Stats.tsx
+++ b/src/components/shared/Stats.tsx
@@ -38,7 +38,7 @@ const Stats = () => {
 			let filter = filterMap.find(({ name }) => name === f.name);
 			filterValue = f.value;
 			if (!!filter) {
-				dispatch(editFilterValue({filterName: filter.name, value: filterValue}));
+				dispatch(editFilterValue({filterName: filter.name, value: filterValue, resource: "events"}));
 			}
 		});
 		await dispatch(fetchEvents());

--- a/src/components/shared/TableFilters.tsx
+++ b/src/components/shared/TableFilters.tsx
@@ -31,6 +31,7 @@ import DropDown from "./DropDown";
 import { AsyncThunk } from "@reduxjs/toolkit";
 import ButtonLikeAnchor from "./ButtonLikeAnchor";
 import { ParseKeys } from "i18next";
+import { Resource } from "../../slices/tableSlice";
 
 /**
  * This component renders the table filters in the upper right corner of the table
@@ -42,7 +43,7 @@ const TableFilters = ({
 }: {
 	loadResource: AsyncThunk<any, void, any>,
 	loadResourceIntoTable: () => AppThunk,
-	resource: string,
+	resource: Resource,
 }) => {
 	const { t } = useTranslation();
 	const dispatch = useAppDispatch();
@@ -91,7 +92,7 @@ const TableFilters = ({
 			setEndDate(undefined);
 		}
 
-		dispatch(editFilterValue({filterName: filter.name, value: ""}));
+		dispatch(editFilterValue({filterName: filter.name, value: "", resource}));
 
 		// Reload resources when filter is removed
 		await dispatch(loadResource());
@@ -116,7 +117,7 @@ const TableFilters = ({
 		if (name === "secondFilter") {
 			let filter = filterMap.find(({ name }) => name === selectedFilter);
 			if (!!filter) {
-				dispatch(editFilterValue({filterName: filter.name, value: value}));
+				dispatch(editFilterValue({filterName: filter.name, value: value, resource}));
 				setFilterSelector(false);
 				dispatch(removeSelectedFilter());
 				dispatch(removeSecondFilter());
@@ -195,7 +196,8 @@ const TableFilters = ({
 			if (filter) {
 				dispatch(editFilterValue({
 					filterName: filter.name,
-					value: start.toISOString() + "/" + end.toISOString()
+					value: start.toISOString() + "/" + end.toISOString(),
+					resource
 				}));
 				setFilterSelector(false);
 				dispatch(removeSelectedFilter());

--- a/src/slices/tableFilterSlice.ts
+++ b/src/slices/tableFilterSlice.ts
@@ -3,6 +3,7 @@ import axios from 'axios';
 import { relativeDateSpanToFilterValue } from '../utils/dateUtils';
 import { createAppAsyncThunk } from '../createAsyncThunkWithTypes';
 import { FilterProfile } from './tableFilterProfilesSlice';
+import { Resource } from './tableSlice';
 
 /**
  * This file contains redux reducer for actions affecting the state of table filters
@@ -174,7 +175,8 @@ export const setSpecificEventFilter = createAppAsyncThunk('tableFilters/setSpeci
 	if (!!filterToChange) {
 		await dispatch(editFilterValue({
 			filterName: filterToChange.name,
-			value: filterValue
+			value: filterValue,
+			resource: "events"
 		}));
 	}
 });
@@ -195,7 +197,8 @@ export const setSpecificServiceFilter = createAppAsyncThunk('tableFilters/setSpe
 	if (!!filterToChange) {
 		await dispatch(editFilterValue({
 			filterName: filterToChange.name,
-			value: filterValue
+			value: filterValue,
+			resource: "services"
 		}));
 	}
 });
@@ -290,10 +293,11 @@ const tableFilterSlice = createSlice({
 		editFilterValue(state, action: PayloadAction<{
 			filterName: TableFilterState["data"][0]["name"],
 			value: TableFilterState["data"][0]["value"],
+			resource: Resource
 		}>) {
-			const { filterName, value } = action.payload;
+			const { filterName, value, resource } = action.payload;
 			state.data = state.data.map((filter) => {
-				return filter.name === filterName
+				return filter.name === filterName && filter.resource === resource
 					? { ...filter, value: value }
 					: filter;
 			})


### PR DESCRIPTION
Fixes #1284.

Fixes an issue where setting a filter with name "example" would set that filter for all tables that have a filter with the name "example".
This would result in filters being set for tables that should not have been set, sometimes with illegal values.

### How to test this

See linked issue, try if you can still reproduce the problem described there.