### PR TITLE
Make drag and drop instructions translatable

### DIFF
--- a/src/components/shared/EditTableViewModal.tsx
+++ b/src/components/shared/EditTableViewModal.tsx
@@ -221,6 +221,7 @@ const EditTableViewModalContent = ({
 								<li>
 									<DragDropContext
 										onDragEnd={onDragEnd}
+										dragHandleUsageInstructions={t("PREFERENCES.TABLE.DRAG_HANDLE_USAGE_INSTRUCTIONS")}
 									>
 										<Droppable droppableId="droppable">
 											{(provided, snapshot) => (

--- a/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
@@ -105,7 +105,8 @@
 			"SELECTED_COLUMNS": "Selected columns",
 			"FOOTER_TEXT": "The order and selection will be saved automatically. Press \"{{resetTranslation}}\" to restore the default view.",
 			"ADD_COLUMN": "Add column",
-			"REMOVE_COLUMN": "Remove column"
+			"REMOVE_COLUMN": "Remove column",
+			"DRAG_HANDLE_USAGE_INSTRUCTIONS": "Press space bar to start a drag. When dragging you can use the arrow keys to move the item around and escape to cancel. Some screen readers may require you to be in focus mode or to use your pass through key"
 		}
 	},
 	"CONFIRMATIONS": {


### PR DESCRIPTION
Fix #1267.
Adds a new translation key for drag and drop instructions for screen readers.