### PR TITLE
Add autofocus for saved filter sets

### DIFF
--- a/src/components/shared/TableFilterProfiles.tsx
+++ b/src/components/shared/TableFilterProfiles.tsx
@@ -224,6 +224,7 @@ const TableFiltersProfiles = ({
 									value={profileName}
 									onChange={(e) => handleChange(e)}
 									placeholder={t("TABLE_FILTERS.PROFILES.NAME_PLACEHOLDER")}
+									autoFocus={true}
 								/>
 
 								<label>{t("TABLE_FILTERS.PROFILES.DESCRIPTION")}</label>


### PR DESCRIPTION
Fixes #1219.

This should make sure that when accessing saved filters, the first field in the modal (the "name" field") is focused.