### PR TITLE
Dock saved filter sets modal to the right

### DIFF
--- a/src/styles/components/data-filter/_filter-profiles.scss
+++ b/src/styles/components/data-filter/_filter-profiles.scss
@@ -34,7 +34,7 @@
 @mixin filter-dd-content-mixin ($width) {
     // Base styles
     position: absolute;
-    top: 52px; left: 0;
+    top: 52px; right: 0;
     z-index: variables.$max-z;
     visibility: hidden;
     opacity: 0;


### PR DESCRIPTION
Fixes #1238 .

Previously it was docked to the left, which would cause it to move in case the filter field was streching very long.

![Bildschirmfoto vom 2025-06-16 16-37-51](https://github.com/user-attachments/assets/668cff70-0f56-4314-b7a2-ee11bfa06119)
