### PR TITLE
Add focus trap to modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "classnames": "^2.5.1",
         "date-fns": "^4.1.0",
         "dompurify": "^3.2.5",
+        "focus-trap-react": "^11.0.4",
         "font-awesome": "^4.7.0",
         "formik": "^2.4.6",
         "http-proxy-middleware": "^3.0.5",
@@ -2821,7 +2822,6 @@
       "version": "19.1.5",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.5.tgz",
       "integrity": "sha512-CMCjrWucUBZvohgZxkjd6S9h0nZxXjzus6yDfUb+xLxYM7VvjKNH1tQrE9GWLql1XoOP4/Ds3bwFqShHUYraGg==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
@@ -5084,6 +5084,31 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/focus-trap": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.5.tgz",
+      "integrity": "sha512-7Ke1jyybbbPZyZXFxEftUtxFGLMpE2n6A+z//m4CRDlj0hW+o3iYSmh8nFlYMurOiJVDmJRilUQtJr08KfIxlg==",
+      "license": "MIT",
+      "dependencies": {
+        "tabbable": "^6.2.0"
+      }
+    },
+    "node_modules/focus-trap-react": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-11.0.4.tgz",
+      "integrity": "sha512-tC7jC/yqeAqhe4irNIzdyDf9XCtGSeECHiBSYJBO/vIN0asizbKZCt8TarB6/XqIceu42ajQ/U4lQJ9pZlWjrg==",
+      "license": "MIT",
+      "dependencies": {
+        "focus-trap": "^7.6.5",
+        "tabbable": "^6.2.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/follow-redirects": {
       "version": "1.15.6",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "classnames": "^2.5.1",
     "date-fns": "^4.1.0",
     "dompurify": "^3.2.5",
+    "focus-trap-react": "^11.0.4",
     "font-awesome": "^4.7.0",
     "formik": "^2.4.6",
     "http-proxy-middleware": "^3.0.5",

--- a/src/components/shared/modals/Modal.tsx
+++ b/src/components/shared/modals/Modal.tsx
@@ -4,10 +4,7 @@ import { useHotkeys } from "react-hotkeys-hook";
 import { availableHotkeys } from "../../../configs/hotkeysConfig";
 import { useTranslation } from "react-i18next";
 import ButtonLikeAnchor from "../ButtonLikeAnchor";
-// TODO: Implement focus trapping
-// Attempted to do that with focus-trap-react, but it would not focus
-// the correct element in e.g. the new event modal
-// import { FocusTrap } from "focus-trap-react";
+import { FocusTrap } from "focus-trap-react";
 
 export type ModalProps = {
 	open?: boolean
@@ -63,26 +60,28 @@ export const Modal = forwardRef<ModalHandle, PropsWithChildren<ModalProps>>(({
 
 	return ReactDOM.createPortal(
 		isOpen &&
-			<div>
-				<div className="modal-animation modal-overlay" />
-				<section
-					id={classId}
-					className={className ? className : "modal wizard modal-animation"}
-				>
-					<header>
-						<ButtonLikeAnchor
-							extraClassName="fa fa-times close-modal"
-							onClick={close}
-							tabIndex={0}
-						/>
-						<h2>
-							{header}
-						</h2>
-					</header>
+			<FocusTrap>
+				<div>
+					<div className="modal-animation modal-overlay" />
+					<section
+						id={classId}
+						className={className ? className : "modal wizard modal-animation"}
+					>
+						<header>
+							<ButtonLikeAnchor
+								extraClassName="fa fa-times close-modal"
+								onClick={close}
+								tabIndex={0}
+							/>
+							<h2>
+								{header}
+							</h2>
+						</header>
 
-						{children}
-				</section>
-			</div>,
+							{children}
+					</section>
+				</div>
+			</FocusTrap>,
 		document.body,
 	);
 


### PR DESCRIPTION
Fixes #600.
Adds the "focus-trap-react" dependency  and applies it to modals. This should confine keyboard navigation inside modals.