### PR TITLE
Fix modal data not being loaded

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -52,10 +52,16 @@ const NavBar = ({
 	const newResourceModalRef = useRef<ModalHandle>(null);
 
 	const showNewResourceModal = async () => {
+		if (create && create.onShowModal) {
+			await create.onShowModal();
+		}
 		newResourceModalRef.current?.open()
 	};
 
 	const hideNewResourceModal = () => {
+		if (create && create.onHideModal) {
+			create.onHideModal();
+		}
 		newResourceModalRef.current?.close?.()
 	};
 


### PR DESCRIPTION
One of the recent eslint PRs removed this by accident, causing modals to not load their data (i.e. the event details not loading metadata). This fixes that.