### PR TITLE
Activate eslint no-non-null-asserted-optional-chain

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,7 +23,6 @@ export default [
             "@typescript-eslint/no-explicit-any": "off",
             "@typescript-eslint/no-floating-promises": "off",
             "@typescript-eslint/no-misused-promises": "off",
-            "@typescript-eslint/no-non-null-asserted-optional-chain": "off",
             "@typescript-eslint/no-unsafe-argument": "off",
             "@typescript-eslint/no-unsafe-assignment": "off",
             "@typescript-eslint/no-unsafe-call": "off",

--- a/src/components/shared/Tooltip.tsx
+++ b/src/components/shared/Tooltip.tsx
@@ -39,8 +39,14 @@ export const Tooltip = (
 					 areaRef.current?.getBoundingClientRect().width,
 					 0,
 				 );
-			 default:
-				 return areaRef.current?.getBoundingClientRect()!;
+			default: {
+				const rect = areaRef.current?.getBoundingClientRect();
+				if (!rect) {
+					return new DOMRect();
+				} else {
+					return rect;
+				}
+			}
 		}
 	};
 


### PR DESCRIPTION
Turn on the eslint rule no-non-null-asserted-optional-chain.