### PR TITLE
Disable i18n debug

### DIFF
--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -54,7 +54,7 @@ i18n
 	.init<HttpBackendOptions>({
 		resources,
 		fallbackLng: "en-US",
-		debug: true,
+		debug: false,
 
 		interpolation: {
 			escapeValue: false,


### PR DESCRIPTION
The web console logs are being swamped with "missing key" messages by i18n. Unfortunately, most of these are false positives and thus do not help at all in finding actual missing keys. This commit disables the debug mode in i18n which stops the messages.