### PR TITLE
Mini workflow tab rework

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsTabHierarchyNavigation.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsTabHierarchyNavigation.tsx
@@ -19,6 +19,8 @@ const EventDetailsTabHierarchyNavigation = <T, >({
 	subTabArgument1,
 	translationKey2,
 	subTabArgument2,
+	translationKey3,
+	subTabArgument3,
 }: {
 	openSubTab: (tabType: T) => void,
 	hierarchyDepth: number,
@@ -28,6 +30,8 @@ const EventDetailsTabHierarchyNavigation = <T, >({
 	subTabArgument1?: T,
 	translationKey2?: ParseKeys,
 	subTabArgument2?: T,
+	translationKey3?: ParseKeys,
+	subTabArgument3?: T,
 }) => {
 	const { t } = useTranslation();
 
@@ -67,10 +71,23 @@ const EventDetailsTabHierarchyNavigation = <T, >({
 			{hierarchyDepth > 1 && subTabArgument2 && (
 				<ButtonLikeAnchor
 					extraClassName="breadcrumb-link scope"
-					style={styleNavHierarchy}
+					style={
+						hierarchyDepth === 2
+							? styleNavHierarchy
+							: styleNavHierarchyInactive
+					}
 					onClick={() => openSubTab(subTabArgument2)}
 				>
 					{translationKey2 && t(translationKey2)}
+				</ButtonLikeAnchor>
+			)}
+			{hierarchyDepth > 2 && subTabArgument3 && (
+				<ButtonLikeAnchor
+					extraClassName="breadcrumb-link scope"
+					style={styleNavHierarchy}
+					onClick={() => openSubTab(subTabArgument3)}
+				>
+					{translationKey3 && t(translationKey3)}
 				</ButtonLikeAnchor>
 			)}
 		</nav>

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowDetails.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowDetails.tsx
@@ -239,7 +239,7 @@ const EventDetailsWorkflowDetails = ({
 							{/* 'Workflow Operation table */}
 							<div className="obj tbl-container more-info-actions">
 								<header>
-									{t("EVENTS.EVENTS.DETAILS.WORKFLOW_DETAILS.LATEST_OPERATION")}
+									{t("EVENTS.EVENTS.DETAILS.WORKFLOW_DETAILS.OPERATIONS")}
 								</header>
 
 								<table className="main-tbl">
@@ -322,6 +322,14 @@ const OperationsPreview = ({
 
 	const workflowId = useAppSelector(state => getModalWorkflowId(state));
 	const operationsEntry = useAppSelector(state => getLatestWorkflowOperation(state));
+	const workflow = useAppSelector(state => getWorkflow(state));
+
+	// Parse translation key to state
+	let workflowDone = false;
+	if ("status" in workflow) {
+		const workflowStatus = workflow.status.split(".").pop();
+		workflowDone = !(workflowStatus === "SUCCEEDED" || workflowStatus === "FAILED" || workflowStatus === "STOPPED");
+	}
 
 	const loadWorkflowOperations = async () => {
 		// Fetching workflow operations from server
@@ -351,9 +359,13 @@ const OperationsPreview = ({
 	return (
 		<div className="obj tbl-container more-info-actions">
 			<header>
-				{t("EVENTS.EVENTS.DETAILS.WORKFLOW_DETAILS.LATEST_OPERATION")}
+				{ workflowDone
+					? t("EVENTS.EVENTS.DETAILS.WORKFLOW_DETAILS.CURRENT_OPERATION")
+					: t("EVENTS.EVENTS.DETAILS.WORKFLOW_DETAILS.OPERATIONS")
+				}
 			</header>
 
+			{ workflowDone && <>
 			<table className="main-tbl">
 				<thead>
 					<tr>
@@ -380,6 +392,7 @@ const OperationsPreview = ({
 				</tbody>
 			</table>
 			<hr style={{ height: "1px", border: 0, borderTop: "1px solid #ccc", margin: "0", padding: "0"}} />
+			</>}
 
 			{/* links to 'Operations' or 'Errors & Warnings' sub-Tabs */}
 			<div className="obj-container">

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowDetails.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowDetails.tsx
@@ -236,6 +236,37 @@ const EventDetailsWorkflowDetails = ({
 					{/* empty view for displaying, while the data is being fetched */}
 					{isFetching && (
 						<>
+							{/* 'Workflow Operation table */}
+							<div className="obj tbl-container more-info-actions">
+								<header>
+									{t("EVENTS.EVENTS.DETAILS.WORKFLOW_DETAILS.LATEST_OPERATION")}
+								</header>
+
+								<table className="main-tbl">
+									<tbody>
+										<tr />
+									</tbody>
+								</table>
+							</div>
+
+							{/* 'Workflow Errors' table */}
+							<div className="obj tbl-details">
+								<header>
+									{
+										t(
+											"EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.HEADER",
+										) /* Errors & Warnings */
+									}
+								</header>
+								<div className="obj-container">
+									<table className="main-tbl vertical-headers">
+										<tbody>
+											<tr />
+										</tbody>
+									</table>
+								</div>
+							</div>
+
 							{/* 'Workflow Details' table */}
 							<div className="obj tbl-details">
 								<header>

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowDetails.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowDetails.tsx
@@ -20,6 +20,7 @@ import { useTranslation } from "react-i18next";
 import ButtonLikeAnchor from "../../../shared/ButtonLikeAnchor";
 import { ParseKeys } from "i18next";
 import ModalContentTable from "../../../shared/modals/ModalContentTable";
+import EventDetailsWorkflowErrors from "./EventDetailsWorkflowErrors";
 
 /**
  * This component manages the workflow details for the workflows tab of the event details modal
@@ -66,6 +67,8 @@ const EventDetailsWorkflowDetails = ({
 		>
 					{/* Notifications */}
 					<Notifications context="not_corner" />
+
+					<EventDetailsWorkflowErrors eventId={eventId} />
 
 					{/* the contained view is only displayed, if the data has been fetched */}
 					{isFetching || (
@@ -238,25 +241,6 @@ const EventDetailsWorkflowDetails = ({
 												}
 											</ButtonLikeAnchor>
 										</li>
-										<li>
-											<span>
-												{
-													t(
-														"EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.TITLE",
-													) /* Errors & Warnings */
-												}
-											</span>
-											<ButtonLikeAnchor
-												extraClassName="details-link"
-												onClick={() => openSubTab("errors-and-warnings")}
-											>
-												{
-													t(
-														"EVENTS.EVENTS.DETAILS.WORKFLOWS.DETAILS",
-													) /* Details */
-												}
-											</ButtonLikeAnchor>
-										</li>
 									</ul>
 								</div>
 							</div>
@@ -321,22 +305,6 @@ const EventDetailsWorkflowDetails = ({
 													t(
 														"EVENTS.EVENTS.DETAILS.WORKFLOW_OPERATIONS.DETAILS_LINK",
 													) /* Operations */
-												}
-											</span>
-											<ButtonLikeAnchor extraClassName="details-link">
-												{
-													t(
-														"EVENTS.EVENTS.DETAILS.WORKFLOWS.DETAILS",
-													) /* Details */
-												}
-											</ButtonLikeAnchor>
-										</li>
-										<li>
-											<span>
-												{
-													t(
-														"EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.TITLE",
-													) /* Errors & Warnings */
 												}
 											</span>
 											<ButtonLikeAnchor extraClassName="details-link">

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowDetails.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowDetails.tsx
@@ -45,6 +45,7 @@ const EventDetailsWorkflowDetails = ({
 	const isFetching = useAppSelector(state => isFetchingWorkflowDetails(state));
 
 	useEffect(() => {
+		// Get latest workflow. Ideally we would have an endpoint that gives us the latest workflow straight up.
 		if (!workflowId) {
 			dispatch(fetchWorkflows(eventId)).unwrap()
 				.then(workflows => {

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowDetails.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowDetails.tsx
@@ -14,6 +14,8 @@ import {
 	fetchWorkflowDetails,
 	fetchWorkflowOperationDetails,
 	fetchWorkflowOperations,
+	fetchWorkflows,
+	setModalWorkflowId,
 	setModalWorkflowTabHierarchy,
 } from "../../../../slices/eventDetailsSlice";
 import { removeNotificationWizardForm } from "../../../../slices/notificationSlice";
@@ -43,8 +45,18 @@ const EventDetailsWorkflowDetails = ({
 	const isFetching = useAppSelector(state => isFetchingWorkflowDetails(state));
 
 	useEffect(() => {
-		dispatch(fetchWorkflowDetails({ eventId, workflowId }));
-		// eslint-disable-next-line react-hooks/exhaustive-deps
+		if (!workflowId) {
+			dispatch(fetchWorkflows(eventId)).unwrap()
+				.then(workflows => {
+					const currentWorkflow = workflows.entries[workflows.entries.length - 1];
+					dispatch(fetchWorkflowDetails({ eventId, workflowId: currentWorkflow.id }));
+					dispatch(setModalWorkflowId(currentWorkflow.id));
+				},
+			);
+		} else {
+			dispatch(fetchWorkflowDetails({ eventId, workflowId }));
+		}
+	// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
 	const openSubTab = (tabType: WorkflowTabHierarchy) => {
@@ -63,9 +75,11 @@ const EventDetailsWorkflowDetails = ({
 				/* Hierarchy navigation */
 			<EventDetailsTabHierarchyNavigation
 				openSubTab={openSubTab}
-				hierarchyDepth={0}
-				translationKey0={"EVENTS.EVENTS.DETAILS.WORKFLOW_DETAILS.TITLE"}
-				subTabArgument0={"workflow-details"}
+				hierarchyDepth={1}
+				translationKey0={"EVENTS.EVENTS.DETAILS.WORKFLOW_INSTANCES.TITLE"}
+				subTabArgument0={"workflows"}
+				translationKey1={"EVENTS.EVENTS.DETAILS.WORKFLOW_DETAILS.TITLE"}
+				subTabArgument1={"workflow-details"}
 			/>
 			}
 		>

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowDetails.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowDetails.tsx
@@ -26,7 +26,7 @@ import ButtonLikeAnchor from "../../../shared/ButtonLikeAnchor";
 import { ParseKeys } from "i18next";
 import ModalContentTable from "../../../shared/modals/ModalContentTable";
 import EventDetailsWorkflowErrors from "./EventDetailsWorkflowErrors";
-import { Operation } from "./EventDetailsWorkflowOperations";
+import { Operation, WorfklowOperationsTableBody } from "./EventDetailsWorkflowOperations";
 
 /**
  * This component manages the workflow details for the workflows tab of the event details modal
@@ -366,32 +366,14 @@ const OperationsPreview = ({
 			</header>
 
 			{ workflowDone && <>
-			<table className="main-tbl">
-				<thead>
-					<tr>
-						<th>
-							{t("EVENTS.EVENTS.DETAILS.WORKFLOW_OPERATIONS.TABLE_HEADERS.STATUS") /* Status */}
-						</th>
-						<th>
-							{t("EVENTS.EVENTS.DETAILS.WORKFLOW_OPERATIONS.TABLE_HEADERS.TITLE") /* Title */}
-						</th>
-						<th>
-							{t("EVENTS.EVENTS.DETAILS.WORKFLOW_OPERATIONS.TABLE_HEADERS.DESCRIPTION") /* Description */}
-						</th>
-						<th className="medium" />
-					</tr>
-				</thead>
-				<tbody>
-					{ operationsEntry &&
-						<Operation
-							operationId={operationsEntry.index}
-							item={operationsEntry.operation}
-							openSubTab={openDetailsSubTab}
-						/>
+				<WorfklowOperationsTableBody
+					operations={operationsEntry
+						? [{ operation: operationsEntry.operation, operationId: operationsEntry.index}]
+						: []
 					}
-				</tbody>
-			</table>
-			<hr style={{ height: "1px", border: 0, borderTop: "1px solid #ccc", margin: "0", padding: "0"}} />
+					openSubTab={openDetailsSubTab}
+				/>
+				<hr style={{ height: "1px", border: 0, borderTop: "1px solid #ccc", margin: "0", padding: "0"}} />
 			</>}
 
 			{/* links to 'Operations' or 'Errors & Warnings' sub-Tabs */}
@@ -399,21 +381,13 @@ const OperationsPreview = ({
 				<ul>
 					<li>
 						<span>
-							{
-								t(
-									"EVENTS.EVENTS.DETAILS.WORKFLOW_OPERATIONS.DETAILS_LINK",
-								) /* Operations */
-							}
+							{t("EVENTS.EVENTS.DETAILS.WORKFLOW_OPERATIONS.DETAILS_LINK") /* Operations */}
 						</span>
 						<ButtonLikeAnchor
 							extraClassName="details-link"
 							onClick={() => openSubTab("workflow-operations")}
 						>
-							{
-								t(
-									"EVENTS.EVENTS.DETAILS.WORKFLOWS.DETAILS",
-								) /* Details */
-							}
+							{t("EVENTS.EVENTS.DETAILS.WORKFLOWS.DETAILS") /* Details */}
 						</ButtonLikeAnchor>
 					</li>
 				</ul>

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowDetails.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowDetails.tsx
@@ -333,7 +333,9 @@ const OperationsPreview = ({
 
 	const loadWorkflowOperations = async () => {
 		// Fetching workflow operations from server
-		dispatch(fetchWorkflowOperations({ eventId, workflowId }));
+		if (workflowId) {
+			dispatch(fetchWorkflowOperations({ eventId, workflowId }));
+		}
 	};
 
 	useEffect(() => {

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowErrorDetails.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowErrorDetails.tsx
@@ -14,7 +14,7 @@ import { WorkflowTabHierarchy } from "../modals/EventDetails";
 import { useTranslation } from "react-i18next";
 import { fetchWorkflowOperationDetails, setModalWorkflowTabHierarchy } from "../../../../slices/eventDetailsSlice";
 import ModalContentTable from "../../../shared/modals/ModalContentTable";
-import { Operation } from "./EventDetailsWorkflowOperations";
+import { WorkflowOperationsTable } from "./EventDetailsWorkflowOperations";
 
 /**
  * This component manages the workflow error details for the workflows tab of the event details modal
@@ -63,45 +63,19 @@ const EventDetailsWorkflowErrorDetails = ({
 			modalBodyChildren={<Notifications context="not_corner" />}
 		>
 			{/* Error operation table */}
-			<div className="obj tbl-container">
-				<header>
-					{t("EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.DETAILS.OPERATION")}
-				</header>
-				<table className="main-tbl">
-					<thead>
-						<tr>
-							<th>
-								{t("EVENTS.EVENTS.DETAILS.WORKFLOW_OPERATIONS.TABLE_HEADERS.STATUS") /* Status */}
-							</th>
-							<th>
-								{t("EVENTS.EVENTS.DETAILS.WORKFLOW_OPERATIONS.TABLE_HEADERS.TITLE") /* Title */}
-							</th>
-							<th>
-								{t("EVENTS.EVENTS.DETAILS.WORKFLOW_OPERATIONS.TABLE_HEADERS.DESCRIPTION") /* Description */}
-							</th>
-							<th className="medium" />
-						</tr>
-					</thead>
-					<tbody>
-						{ operationsEntry &&
-							<Operation
-								operationId={operationsEntry.index}
-								item={operationsEntry.operation}
-								openSubTab={openOperationDetailsSubTab}
-							/>
-						}
-					</tbody>
-				</table>
-			</div>
+			<WorkflowOperationsTable
+				operations={operationsEntry
+					? [{ operation: operationsEntry.operation, operationId: operationsEntry.index}]
+					: []
+				}
+				openSubTab={openOperationDetailsSubTab}
+				title={"EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.DETAILS.OPERATION"}
+			/>
 
 			{/* 'Error Details' table */}
 			<div className="obj tbl-details">
 				<header>
-					{
-						t(
-							"EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.DETAILS.HEADER",
-						) /* Error Details */
-					}
+					{t("EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.DETAILS.HEADER") /* Error Details */}
 				</header>
 				<div className="obj-container">
 					<table className="main-tbl">
@@ -109,51 +83,31 @@ const EventDetailsWorkflowErrorDetails = ({
 							<tbody>
 								<tr>
 									<td>
-										{
-											t(
-												"EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.DETAILS.SEVERITY",
-											) /* Severity */
-										}
+										{t("EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.DETAILS.SEVERITY") /* Severity */}
 									</td>
 									<td>{errorDetails.severity}</td>
 								</tr>
 								<tr>
 									<td>
-										{
-											t(
-												"EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.DETAILS.TITLE",
-											) /* Title */
-										}
+										{t("EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.DETAILS.TITLE") /* Title */}
 									</td>
 									<td>{errorDetails.title}</td>
 								</tr>
 								<tr>
 									<td>
-										{
-											t(
-												"EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.DETAILS.DESCRIPTION",
-											) /* Description */
-										}
+										{t("EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.DETAILS.DESCRIPTION") /* Description */}
 									</td>
 									<td>{errorDetails.description}</td>
 								</tr>
 								<tr>
 									<td>
-										{
-											t(
-												"EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.DETAILS.JOB_ID",
-											) /* Job ID */
-										}
+										{t("EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.DETAILS.JOB_ID") /* Job ID */}
 									</td>
 									<td>{errorDetails.jobId}</td>
 								</tr>
 								<tr>
 									<td>
-										{
-											t(
-												"EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.DETAILS.DATE",
-											) /* Date */
-										}
+										{t("EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.DETAILS.DATE") /* Date */}
 									</td>
 									<td>
 										{t("dateFormats.dateTime.medium", {
@@ -163,31 +117,19 @@ const EventDetailsWorkflowErrorDetails = ({
 								</tr>
 								<tr>
 									<td>
-										{
-											t(
-												"EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.DETAILS.HOST",
-											) /* Host */
-										}
+										{t("EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.DETAILS.HOST") /* Host */}
 									</td>
 									<td>{errorDetails.processingHost}</td>
 								</tr>
 								<tr>
 									<td>
-										{
-											t(
-												"EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.DETAILS.TYPE",
-											) /* Type */
-										}
+										{t("EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.DETAILS.TYPE") /* Type */}
 									</td>
 									<td>{errorDetails.serviceType}</td>
 								</tr>
 								<tr>
 									<td>
-										{
-											t(
-												"EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.DETAILS.TECHNICAL_DETAILS",
-											) /* Technical Details */
-										}
+										{t("EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.DETAILS.TECHNICAL_DETAILS") /* Technical Details */}
 									</td>
 
 									{/* list of technical error details */}

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowErrorDetails.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowErrorDetails.tsx
@@ -34,13 +34,13 @@ const EventDetailsWorkflowErrorDetails = () => {
 				/* Hierarchy navigation */
 				<EventDetailsTabHierarchyNavigation
 				openSubTab={openSubTab}
-				hierarchyDepth={1}
-				translationKey0={"EVENTS.EVENTS.DETAILS.WORKFLOW_DETAILS.TITLE"}
-				subTabArgument0={"workflow-details"}
-				translationKey1={
-					"EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.DETAILS.HEADER"
-				}
-				subTabArgument1={"workflow-error-details"}
+				hierarchyDepth={2}
+				translationKey0={"EVENTS.EVENTS.DETAILS.WORKFLOW_INSTANCES.TITLE"}
+				subTabArgument0={"workflows"}
+				translationKey1={"EVENTS.EVENTS.DETAILS.WORKFLOW_DETAILS.TITLE"}
+				subTabArgument1={"workflow-details"}
+				translationKey2={"EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.DETAILS.HEADER"}
+				subTabArgument2={"workflow-error-details"}
 			/>
 			}
 			modalBodyChildren={<Notifications context="not_corner" />}

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowErrorDetails.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowErrorDetails.tsx
@@ -34,15 +34,13 @@ const EventDetailsWorkflowErrorDetails = () => {
 				/* Hierarchy navigation */
 				<EventDetailsTabHierarchyNavigation
 				openSubTab={openSubTab}
-				hierarchyDepth={2}
+				hierarchyDepth={1}
 				translationKey0={"EVENTS.EVENTS.DETAILS.WORKFLOW_DETAILS.TITLE"}
 				subTabArgument0={"workflow-details"}
-				translationKey1={"EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.TITLE"}
-				subTabArgument1={"errors-and-warnings"}
-				translationKey2={
+				translationKey1={
 					"EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.DETAILS.HEADER"
 				}
-				subTabArgument2={"workflow-error-details"}
+				subTabArgument1={"workflow-error-details"}
 			/>
 			}
 			modalBodyChildren={<Notifications context="not_corner" />}

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowErrors.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowErrors.tsx
@@ -63,11 +63,7 @@ const EventDetailsWorkflowErrors = ({
 	return (
 		<div className="obj tbl-container">
 			<header>
-				{
-					t(
-						"EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.HEADER",
-					) /* Errors & Warnings */
-				}
+				{t("EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.HEADER") /* Errors & Warnings */}
 			</header>
 
 			{
@@ -96,20 +92,10 @@ const EventDetailsWorkflowErrors = ({
 									<tr>
 										<th className="small" />
 										<th>
-											{
-												t(
-													"EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.DATE",
-												) /* Date */
-											}
-											<i />
+											{t("EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.DATE") /* Date */}
 										</th>
 										<th>
-											{
-												t(
-													"EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.TITLE",
-												) /* Errors & Warnings */
-											}
-											<i />
+											{t("EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.TITLE") /* Errors & Warnings */}
 										</th>
 										<th className="medium" />
 									</tr>
@@ -143,11 +129,7 @@ const EventDetailsWorkflowErrors = ({
 															openSubTab("workflow-error-details", item.id)
 														}
 													>
-														{
-															t(
-																"EVENTS.EVENTS.DETAILS.MEDIA.DETAILS",
-															) /*  Details */
-														}
+														{t("EVENTS.EVENTS.DETAILS.MEDIA.DETAILS") /*  Details */}
 													</ButtonLikeAnchor>
 												</td>
 											</tr>

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowErrors.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowErrors.tsx
@@ -70,90 +70,95 @@ const EventDetailsWorkflowErrors = ({
 				}
 			</header>
 
-			<div className="obj-container">
-				<table className="main-tbl">
-					{isFetching || (
-						<>
-							<thead>
-								<tr>
-									<th className="small" />
-									<th>
-										{
-											t(
-												"EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.DATE",
-											) /* Date */
-										}
-										<i />
-									</th>
-									<th>
-										{
-											t(
-												"EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.TITLE",
-											) /* Errors & Warnings */
-										}
-										<i />
-									</th>
-									<th className="medium" />
-								</tr>
-							</thead>
-							<tbody>
+			{
+				/* No errors message */
+				errors.entries.length === 0 && (
+					<table className="main-tbl">
+						<tr>
+							<td colSpan={4}>
 								{
-									/* error details */
-									errors.entries.map((item, key) => (
-										<tr key={key}>
-											<td>
-												{!!item.severity && (
-													<div
-														className={`circle ${severityColor(
-															item.severity,
-														)}`}
-													/>
-												)}
-											</td>
-											<td>
-												{t("dateFormats.dateTime.medium", {
-													dateTime: renderValidDate(item.timestamp),
-												})}
-											</td>
-											<td>{item.title}</td>
+									t(
+										"EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.EMPTY",
+									) /* No errors found. */
+								}
+							</td>
+						</tr>
+					</table>
+				)
+			}
 
-											{/* link to 'Error Details'  sub-Tab */}
-											<td>
-												<ButtonLikeAnchor
-													extraClassName="details-link"
-													onClick={() =>
-														openSubTab("workflow-error-details", item.id)
-													}
-												>
-													{
-														t(
-															"EVENTS.EVENTS.DETAILS.MEDIA.DETAILS",
-														) /*  Details */
-													}
-												</ButtonLikeAnchor>
-											</td>
-										</tr>
-									))
-								}
-								{
-									/* No errors message */
-									errors.entries.length === 0 && (
-										<tr>
-											<td colSpan={4}>
-												{
-													t(
-														"EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.EMPTY",
-													) /* No errors found. */
-												}
-											</td>
-										</tr>
-									)
-								}
-							</tbody>
-						</>
-					)}
-				</table>
-			</div>
+			{ errors.entries.length !== 0 && (
+				<div className="obj-container">
+					<table className="main-tbl">
+						{isFetching || (
+							<>
+								<thead>
+									<tr>
+										<th className="small" />
+										<th>
+											{
+												t(
+													"EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.DATE",
+												) /* Date */
+											}
+											<i />
+										</th>
+										<th>
+											{
+												t(
+													"EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.TITLE",
+												) /* Errors & Warnings */
+											}
+											<i />
+										</th>
+										<th className="medium" />
+									</tr>
+								</thead>
+								<tbody>
+									{
+										/* error details */
+										errors.entries.map((item, key) => (
+											<tr key={key}>
+												<td>
+													{!!item.severity && (
+														<div
+															className={`circle ${severityColor(
+																item.severity,
+															)}`}
+														/>
+													)}
+												</td>
+												<td>
+													{t("dateFormats.dateTime.medium", {
+														dateTime: renderValidDate(item.timestamp),
+													})}
+												</td>
+												<td>{item.title}</td>
+
+												{/* link to 'Error Details'  sub-Tab */}
+												<td>
+													<ButtonLikeAnchor
+														extraClassName="details-link"
+														onClick={() =>
+															openSubTab("workflow-error-details", item.id)
+														}
+													>
+														{
+															t(
+																"EVENTS.EVENTS.DETAILS.MEDIA.DETAILS",
+															) /*  Details */
+														}
+													</ButtonLikeAnchor>
+												</td>
+											</tr>
+										))
+									}
+								</tbody>
+							</>
+						)}
+					</table>
+				</div>
+			)}
 		</div>
 	);
 };

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowErrors.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowErrors.tsx
@@ -1,12 +1,10 @@
 import { useEffect } from "react";
-import Notifications from "../../../shared/Notifications";
 import {
 	getModalWorkflowId,
 	getWorkflow,
 	getWorkflowErrors,
 	isFetchingWorkflowErrors,
 } from "../../../../selectors/eventDetailsSelectors";
-import EventDetailsTabHierarchyNavigation from "./EventDetailsTabHierarchyNavigation";
 import { useAppDispatch, useAppSelector } from "../../../../store";
 import { removeNotificationWizardForm } from "../../../../slices/notificationSlice";
 import {
@@ -18,7 +16,6 @@ import { renderValidDate } from "../../../../utils/dateUtils";
 import { WorkflowTabHierarchy } from "../modals/EventDetails";
 import { useTranslation } from "react-i18next";
 import ButtonLikeAnchor from "../../../shared/ButtonLikeAnchor";
-import ModalContentTable from "../../../shared/modals/ModalContentTable";
 
 /**
  * This component manages the workflow errors for the workflows tab of the event details modal
@@ -62,117 +59,102 @@ const EventDetailsWorkflowErrors = ({
 		}
 	};
 
+	{ /* 'Errors & Warnings' table */ }
 	return (
-		<ModalContentTable
-			modalContentChildren={
-				/* Hierarchy navigation */
-				<EventDetailsTabHierarchyNavigation
-					openSubTab={openSubTab}
-					hierarchyDepth={1}
-					translationKey0={"EVENTS.EVENTS.DETAILS.WORKFLOW_DETAILS.TITLE"}
-					subTabArgument0={"workflow-details"}
-					translationKey1={"EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.TITLE"}
-					subTabArgument1={"errors-and-warnings"}
-				/>
-			}
-			modalBodyChildren={<Notifications context="not_corner" />}
-		>
-		{/* 'Errors & Warnings' table */}
-			<div className="obj tbl-container">
-				<header>
-					{
-						t(
-							"EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.HEADER",
-						) /* Errors & Warnings */
-					}
-				</header>
+		<div className="obj tbl-container">
+			<header>
+				{
+					t(
+						"EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.HEADER",
+					) /* Errors & Warnings */
+				}
+			</header>
 
-				<div className="obj-container">
-					<table className="main-tbl">
-						{isFetching || (
-							<>
-								<thead>
-									<tr>
-										<th className="small" />
-										<th>
-											{
-												t(
-													"EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.DATE",
-												) /* Date */
-											}
-											<i />
-										</th>
-										<th>
-											{
-												t(
-													"EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.TITLE",
-												) /* Errors & Warnings */
-											}
-											<i />
-										</th>
-										<th className="medium" />
-									</tr>
-								</thead>
-								<tbody>
-									{
-										/* error details */
-										errors.entries.map((item, key) => (
-											<tr key={key}>
-												<td>
-													{!!item.severity && (
-														<div
-															className={`circle ${severityColor(
-																item.severity,
-															)}`}
-														/>
-													)}
-												</td>
-												<td>
-													{t("dateFormats.dateTime.medium", {
-														dateTime: renderValidDate(item.timestamp),
-													})}
-												</td>
-												<td>{item.title}</td>
+			<div className="obj-container">
+				<table className="main-tbl">
+					{isFetching || (
+						<>
+							<thead>
+								<tr>
+									<th className="small" />
+									<th>
+										{
+											t(
+												"EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.DATE",
+											) /* Date */
+										}
+										<i />
+									</th>
+									<th>
+										{
+											t(
+												"EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.TITLE",
+											) /* Errors & Warnings */
+										}
+										<i />
+									</th>
+									<th className="medium" />
+								</tr>
+							</thead>
+							<tbody>
+								{
+									/* error details */
+									errors.entries.map((item, key) => (
+										<tr key={key}>
+											<td>
+												{!!item.severity && (
+													<div
+														className={`circle ${severityColor(
+															item.severity,
+														)}`}
+													/>
+												)}
+											</td>
+											<td>
+												{t("dateFormats.dateTime.medium", {
+													dateTime: renderValidDate(item.timestamp),
+												})}
+											</td>
+											<td>{item.title}</td>
 
-												{/* link to 'Error Details'  sub-Tab */}
-												<td>
-													<ButtonLikeAnchor
-														extraClassName="details-link"
-														onClick={() =>
-															openSubTab("workflow-error-details", item.id)
-														}
-													>
-														{
-															t(
-																"EVENTS.EVENTS.DETAILS.MEDIA.DETAILS",
-															) /*  Details */
-														}
-													</ButtonLikeAnchor>
-												</td>
-											</tr>
-										))
-									}
-									{
-										/* No errors message */
-										errors.entries.length === 0 && (
-											<tr>
-												<td colSpan={4}>
+											{/* link to 'Error Details'  sub-Tab */}
+											<td>
+												<ButtonLikeAnchor
+													extraClassName="details-link"
+													onClick={() =>
+														openSubTab("workflow-error-details", item.id)
+													}
+												>
 													{
 														t(
-															"EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.EMPTY",
-														) /* No errors found. */
+															"EVENTS.EVENTS.DETAILS.MEDIA.DETAILS",
+														) /*  Details */
 													}
-												</td>
-											</tr>
-										)
-									}
-								</tbody>
-							</>
-						)}
-					</table>
-				</div>
+												</ButtonLikeAnchor>
+											</td>
+										</tr>
+									))
+								}
+								{
+									/* No errors message */
+									errors.entries.length === 0 && (
+										<tr>
+											<td colSpan={4}>
+												{
+													t(
+														"EVENTS.EVENTS.DETAILS.ERRORS_AND_WARNINGS.EMPTY",
+													) /* No errors found. */
+												}
+											</td>
+										</tr>
+									)
+								}
+							</tbody>
+						</>
+					)}
+				</table>
 			</div>
-		</ModalContentTable>
+		</div>
 	);
 };
 

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowErrors.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowErrors.tsx
@@ -47,7 +47,9 @@ const EventDetailsWorkflowErrors = ({
 	};
 
 	useEffect(() => {
-		dispatch(fetchWorkflowErrors({ eventId, workflowId })).then();
+		if (workflowId) {
+			dispatch(fetchWorkflowErrors({ eventId, workflowId })).then();
+		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowOperationDetails.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowOperationDetails.tsx
@@ -50,11 +50,7 @@ const EventDetailsWorkflowOperationDetails = () => {
 			{/* 'Operation Details' table */}
 			<div className="obj tbl-details">
 				<header>
-					{
-						t(
-							"EVENTS.EVENTS.DETAILS.OPERATION_DETAILS.TITLE",
-						) /* Operation Details */
-					}
+					{t("EVENTS.EVENTS.DETAILS.OPERATION_DETAILS.TITLE") /* Operation Details */}
 				</header>
 				<div className="obj-container">
 					<table className="main-tbl">
@@ -62,71 +58,43 @@ const EventDetailsWorkflowOperationDetails = () => {
 							<tbody>
 								<tr>
 									<td>
-										{
-											t(
-												"EVENTS.EVENTS.DETAILS.OPERATION_DETAILS.TABLE_HEADERS.TITLE",
-											) /* Title */
-										}
+										{t("EVENTS.EVENTS.DETAILS.OPERATION_DETAILS.TABLE_HEADERS.TITLE") /* Title */}
 									</td>
 									<td>{operationDetails.name}</td>
 								</tr>
 								<tr>
 									<td>
-										{
-											t(
-												"EVENTS.EVENTS.DETAILS.OPERATION_DETAILS.TABLE_HEADERS.DESCRIPTION",
-											) /* Description */
-										}
+										{t("EVENTS.EVENTS.DETAILS.OPERATION_DETAILS.TABLE_HEADERS.DESCRIPTION") /* Description */}
 									</td>
 									<td>{operationDetails.description}</td>
 								</tr>
 								<tr>
 									<td>
-										{
-											t(
-												"EVENTS.EVENTS.DETAILS.OPERATION_DETAILS.TABLE_HEADERS.STATE",
-											) /* State */
-										}
+										{t("EVENTS.EVENTS.DETAILS.OPERATION_DETAILS.TABLE_HEADERS.STATE") /* State */}
 									</td>
 									<td>{t(operationDetails.state as ParseKeys)}</td>
 								</tr>
 								<tr>
 									<td>
-										{
-											t(
-												"EVENTS.EVENTS.DETAILS.OPERATION_DETAILS.TABLE_HEADERS.EXECUTION_HOST",
-											) /* Execution Host */
-										}
+										{t("EVENTS.EVENTS.DETAILS.OPERATION_DETAILS.TABLE_HEADERS.EXECUTION_HOST") /* Execution Host */}
 									</td>
 									<td>{operationDetails.executionHost}</td>
 								</tr>
 								<tr>
 									<td>
-										{
-											t(
-												"EVENTS.EVENTS.DETAILS.OPERATION_DETAILS.TABLE_HEADERS.JOB",
-											) /* Job */
-										}
+										{t("EVENTS.EVENTS.DETAILS.OPERATION_DETAILS.TABLE_HEADERS.JOB") /* Job */}
 									</td>
 									<td>{operationDetails.job}</td>
 								</tr>
 								<tr>
 									<td>
-										{
-											t(
-												"EVENTS.EVENTS.DETAILS.OPERATION_DETAILS.TABLE_HEADERS.TIME_IN_QUEUE",
-											) /* Time in Queue */
-										}
+										{t("EVENTS.EVENTS.DETAILS.OPERATION_DETAILS.TABLE_HEADERS.TIME_IN_QUEUE") /* Time in Queue */}
 									</td>
 									<td>{operationDetails.timeInQueue}ms</td>
 								</tr>
 								<tr>
 									<td>
-										{
-											t(
-												"EVENTS.EVENTS.DETAILS.OPERATION_DETAILS.TABLE_HEADERS.STARTED",
-											) /* Started */
-										}
+										{t("EVENTS.EVENTS.DETAILS.OPERATION_DETAILS.TABLE_HEADERS.STARTED") /* Started */}
 									</td>
 									<td>
 										{t("dateFormats.dateTime.medium", {
@@ -136,11 +104,7 @@ const EventDetailsWorkflowOperationDetails = () => {
 								</tr>
 								<tr>
 									<td>
-										{
-											t(
-												"EVENTS.EVENTS.DETAILS.OPERATION_DETAILS.TABLE_HEADERS.FINISHED",
-											) /* Finished */
-										}
+										{t("EVENTS.EVENTS.DETAILS.OPERATION_DETAILS.TABLE_HEADERS.FINISHED") /* Finished */}
 									</td>
 									<td>
 										{t("dateFormats.dateTime.medium", {
@@ -150,51 +114,31 @@ const EventDetailsWorkflowOperationDetails = () => {
 								</tr>
 								<tr>
 									<td>
-										{
-											t(
-												"EVENTS.EVENTS.DETAILS.OPERATION_DETAILS.TABLE_HEADERS.RETRY_STRATEGY",
-											) /* Retry Strategy */
-										}
+										{t("EVENTS.EVENTS.DETAILS.OPERATION_DETAILS.TABLE_HEADERS.RETRY_STRATEGY") /* Retry Strategy */}
 									</td>
 									<td>{operationDetails.retryStrategy}</td>
 								</tr>
 								<tr>
 									<td>
-										{
-											t(
-												"EVENTS.EVENTS.DETAILS.OPERATION_DETAILS.TABLE_HEADERS.FAILED_ATTEMPTS",
-											) /* Failed Attempts */
-										}
+										{t("EVENTS.EVENTS.DETAILS.OPERATION_DETAILS.TABLE_HEADERS.FAILED_ATTEMPTS") /* Failed Attempts */}
 									</td>
 									<td>{operationDetails.failedAttempts}</td>
 								</tr>
 								<tr>
 									<td>
-										{
-											t(
-												"EVENTS.EVENTS.DETAILS.OPERATION_DETAILS.TABLE_HEADERS.MAX_ATTEMPTS",
-											) /* Max */
-										}
+										{t("EVENTS.EVENTS.DETAILS.OPERATION_DETAILS.TABLE_HEADERS.MAX_ATTEMPTS") /* Max */}
 									</td>
 									<td>{operationDetails.maxAttempts}</td>
 								</tr>
 								<tr>
 									<td>
-										{
-											t(
-												"EVENTS.EVENTS.DETAILS.OPERATION_DETAILS.TABLE_HEADERS.EXCEPTION_HANDLER_WORKFLOW",
-											) /* Exception Handler Workflow */
-										}
+										{t("EVENTS.EVENTS.DETAILS.OPERATION_DETAILS.TABLE_HEADERS.EXCEPTION_HANDLER_WORKFLOW") /* Exception Handler Workflow */}
 									</td>
 									<td>{operationDetails.exceptionHandlerWorkflow}</td>
 								</tr>
 								<tr>
 									<td>
-										{
-											t(
-												"EVENTS.EVENTS.DETAILS.OPERATION_DETAILS.TABLE_HEADERS.FAIL_ON_ERROR",
-											) /* Fail on Error */
-										}
+										{t("EVENTS.EVENTS.DETAILS.OPERATION_DETAILS.TABLE_HEADERS.FAIL_ON_ERROR") /* Fail on Error */}
 									</td>
 									<td>{operationDetails.failOnError}</td>
 								</tr>

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowOperationDetails.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowOperationDetails.tsx
@@ -34,13 +34,15 @@ const EventDetailsWorkflowOperationDetails = () => {
 				/* Hierarchy navigation */
 			<EventDetailsTabHierarchyNavigation
 				openSubTab={openSubTab}
-				hierarchyDepth={2}
-				translationKey0={"EVENTS.EVENTS.DETAILS.WORKFLOW_DETAILS.TITLE"}
-				subTabArgument0={"workflow-details"}
-				translationKey1={"EVENTS.EVENTS.DETAILS.WORKFLOW_OPERATIONS.TITLE"}
-				subTabArgument1={"workflow-operations"}
-				translationKey2={"EVENTS.EVENTS.DETAILS.OPERATION_DETAILS.TITLE"}
-				subTabArgument2={"workflow-operation-details"}
+				hierarchyDepth={3}
+				translationKey0={"EVENTS.EVENTS.DETAILS.WORKFLOW_INSTANCES.TITLE"}
+				subTabArgument0={"workflows"}
+				translationKey1={"EVENTS.EVENTS.DETAILS.WORKFLOW_DETAILS.TITLE"}
+				subTabArgument1={"workflow-details"}
+				translationKey2={"EVENTS.EVENTS.DETAILS.WORKFLOW_OPERATIONS.TITLE"}
+				subTabArgument2={"workflow-operations"}
+				translationKey3={"EVENTS.EVENTS.DETAILS.OPERATION_DETAILS.TITLE"}
+				subTabArgument3={"workflow-operation-details"}
 			/>
 			}
 			modalBodyChildren={<Notifications context="not_corner" />}

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowOperations.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowOperations.tsx
@@ -111,33 +111,62 @@ const EventDetailsWorkflowOperations = ({
 						<tbody>
 							{/* workflow operation details */}
 							{operations.entries.map((item, key) => (
-								<tr key={key}>
-									<td>{t(item.status as ParseKeys)}</td>
-									<td>{item.title}</td>
-									<td>{item.description}</td>
-
-									{/* link to 'Operation Details'  sub-Tab */}
-									<td>
-										<ButtonLikeAnchor
-											extraClassName="details-link"
-											onClick={() =>
-												openSubTab("workflow-operation-details", key)
-											}
-										>
-											{
-												t(
-													"EVENTS.EVENTS.DETAILS.MEDIA.DETAILS",
-												) /* Details */
-											}
-										</ButtonLikeAnchor>
-									</td>
-								</tr>
+								<Operation
+									key={key}
+									operationId={key}
+									item={item}
+									openSubTab={openSubTab}
+								/>
 							))}
 						</tbody>
 					</table>
 				</div>
 			</div>
 		</ModalContentTable>
+	);
+};
+
+export const Operation = ({
+	operationId,
+	item,
+	openSubTab,
+}: {
+	operationId: number,
+	item: {
+		configuration: {
+				[key: string]: string;
+		};
+		description: string;
+		id: number;
+		status: string;
+		title: string;
+	},
+	openSubTab: (tab: WorkflowTabHierarchy, operationId: number | undefined) => void,
+}) => {
+	const { t } = useTranslation();
+
+	return (
+		<tr>
+			<td>{t(item.status as ParseKeys)}</td>
+			<td>{item.title}</td>
+			<td>{item.description}</td>
+
+			{/* link to 'Operation Details'  sub-Tab */}
+			<td>
+				<ButtonLikeAnchor
+					extraClassName="details-link"
+					onClick={() =>
+						openSubTab("workflow-operation-details", operationId)
+					}
+				>
+					{
+						t(
+							"EVENTS.EVENTS.DETAILS.MEDIA.DETAILS",
+						) /* Details */
+					}
+				</ButtonLikeAnchor>
+			</td>
+		</tr>
 	);
 };
 

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowOperations.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowOperations.tsx
@@ -60,11 +60,13 @@ const EventDetailsWorkflowOperations = ({
 				/* Hierarchy navigation */
 				<EventDetailsTabHierarchyNavigation
 					openSubTab={openSubTab}
-					hierarchyDepth={1}
-					translationKey0={"EVENTS.EVENTS.DETAILS.WORKFLOW_DETAILS.TITLE"}
-					subTabArgument0={"workflow-details"}
-					translationKey1={"EVENTS.EVENTS.DETAILS.WORKFLOW_OPERATIONS.TITLE"}
-					subTabArgument1={"workflow-operations"}
+					hierarchyDepth={2}
+					translationKey0={"EVENTS.EVENTS.DETAILS.WORKFLOW_INSTANCES.TITLE"}
+					subTabArgument0={"workflows"}
+					translationKey1={"EVENTS.EVENTS.DETAILS.WORKFLOW_DETAILS.TITLE"}
+					subTabArgument1={"workflow-details"}
+					translationKey2={"EVENTS.EVENTS.DETAILS.WORKFLOW_OPERATIONS.TITLE"}
+					subTabArgument2={"workflow-operations"}
 				/>
 			}
 			modalBodyChildren={<Notifications context="not_corner" />}

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowOperations.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowOperations.tsx
@@ -8,6 +8,7 @@ import {
 	fetchWorkflowOperationDetails,
 	fetchWorkflowOperations,
 	setModalWorkflowTabHierarchy,
+	WorkflowOperation,
 } from "../../../../slices/eventDetailsSlice";
 import { useTranslation } from "react-i18next";
 import { WorkflowTabHierarchy } from "../modals/EventDetails";
@@ -25,7 +26,6 @@ const EventDetailsWorkflowOperations = ({
 }: {
 	eventId: string,
 }) => {
-	const { t } = useTranslation();
 	const dispatch = useAppDispatch();
 
 	const workflowId = useAppSelector(state => getModalWorkflowId(state));
@@ -73,60 +73,87 @@ const EventDetailsWorkflowOperations = ({
 			}
 			modalBodyChildren={<Notifications context="not_corner" />}
 		>
-		{/* 'Workflow Operations' table */}
-			<div className="obj tbl-container">
-				<header>
-					{
-						t(
-							"EVENTS.EVENTS.DETAILS.WORKFLOW_OPERATIONS.TITLE",
-						) /* Workflow Operations */
-					}
-				</header>
-				<div className="obj-container">
-					<table className="main-tbl">
-						<thead>
-							<tr>
-								<th>
-									{
-										t(
-											"EVENTS.EVENTS.DETAILS.WORKFLOW_OPERATIONS.TABLE_HEADERS.STATUS",
-										) /* Status */
-									}
-								</th>
-								<th>
-									{
-										t(
-											"EVENTS.EVENTS.DETAILS.WORKFLOW_OPERATIONS.TABLE_HEADERS.TITLE",
-										) /* Title */
-									}
-									<i />
-								</th>
-								<th>
-									{
-										t(
-											"EVENTS.EVENTS.DETAILS.WORKFLOW_OPERATIONS.TABLE_HEADERS.DESCRIPTION",
-										) /* Description */
-									}
-									<i />
-								</th>
-								<th className="medium" />
-							</tr>
-						</thead>
-						<tbody>
-							{/* workflow operation details */}
-							{operations.entries.map((item, key) => (
-								<Operation
-									key={key}
-									operationId={key}
-									item={item}
-									openSubTab={openSubTab}
-								/>
-							))}
-						</tbody>
-					</table>
-				</div>
-			</div>
+			{/* 'Workflow Operations' table */}
+			<WorkflowOperationsTable
+				operations={operations.entries.map((entry, index) => (
+					{ operation: entry, operationId: index }
+				))}
+				openSubTab={openSubTab}
+				title={"EVENTS.EVENTS.DETAILS.WORKFLOW_OPERATIONS.TITLE"}
+			/>
 		</ModalContentTable>
+	);
+};
+
+export const WorkflowOperationsTable = ({
+	operations,
+	openSubTab,
+	title,
+}: {
+	operations: {
+		operation: WorkflowOperation
+		operationId: number
+	}[]
+	openSubTab: (tab: WorkflowTabHierarchy, operationId: number | undefined) => void
+	title?: ParseKeys
+}) => {
+	const { t } = useTranslation();
+
+	return (
+		<div className="obj tbl-container">
+			<header>
+				{t(title ?? "EVENTS.EVENTS.DETAILS.WORKFLOW_OPERATIONS.TITLE")}
+			</header>
+			<div className="obj-container">
+				<WorfklowOperationsTableBody
+					operations={operations}
+					openSubTab={openSubTab}
+				/>
+			</div>
+		</div>
+	);
+};
+
+export const WorfklowOperationsTableBody = ({
+	operations,
+	openSubTab,
+}: {
+	operations: {
+		operation: WorkflowOperation
+		operationId: number
+	}[]
+	openSubTab: (tab: WorkflowTabHierarchy, operationId: number | undefined) => void
+}) => {
+	const { t } = useTranslation();
+
+	return (
+		<table className="main-tbl">
+			<thead>
+				<tr>
+					<th>
+						{t("EVENTS.EVENTS.DETAILS.WORKFLOW_OPERATIONS.TABLE_HEADERS.STATUS") /* Status */}
+					</th>
+					<th>
+						{t("EVENTS.EVENTS.DETAILS.WORKFLOW_OPERATIONS.TABLE_HEADERS.TITLE") /* Title */}
+					</th>
+					<th>
+						{t("EVENTS.EVENTS.DETAILS.WORKFLOW_OPERATIONS.TABLE_HEADERS.DESCRIPTION") /* Description */}
+					</th>
+					<th className="medium" />
+				</tr>
+			</thead>
+			<tbody>
+				{/* workflow operation details */}
+				{operations.map((item, key) => (
+					<Operation
+						key={key}
+						operationId={item.operationId}
+						item={item.operation}
+						openSubTab={openSubTab}
+					/>
+				))}
+			</tbody>
+		</table>
 	);
 };
 
@@ -136,15 +163,7 @@ export const Operation = ({
 	openSubTab,
 }: {
 	operationId: number,
-	item: {
-		configuration: {
-				[key: string]: string;
-		};
-		description: string;
-		id: number;
-		status: string;
-		title: string;
-	},
+	item: WorkflowOperation,
 	openSubTab: (tab: WorkflowTabHierarchy, operationId: number | undefined) => void,
 }) => {
 	const { t } = useTranslation();
@@ -166,11 +185,7 @@ export const Operation = ({
 						openSubTab("workflow-operation-details", operationId)
 					}
 				>
-					{
-						t(
-							"EVENTS.EVENTS.DETAILS.MEDIA.DETAILS",
-						) /* Details */
-					}
+					{t("EVENTS.EVENTS.DETAILS.MEDIA.DETAILS") /* Details */}
 				</ButtonLikeAnchor>
 			</td>
 		</tr>

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowOperations.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowOperations.tsx
@@ -14,6 +14,8 @@ import { WorkflowTabHierarchy } from "../modals/EventDetails";
 import ButtonLikeAnchor from "../../../shared/ButtonLikeAnchor";
 import { ParseKeys } from "i18next";
 import ModalContentTable from "../../../shared/modals/ModalContentTable";
+import { LuCheck, LuEllipsis, LuLoader, LuPause, LuRotateCcw, LuX } from "react-icons/lu";
+import { GoDash } from "react-icons/go";
 
 /**
  * This component manages the workflow operations for the workflows tab of the event details modal
@@ -149,7 +151,10 @@ export const Operation = ({
 
 	return (
 		<tr>
-			<td>{t(item.status as ParseKeys)}</td>
+			<td style={{ display: "flex", alignItems: "center" }}>
+				<OperationStatusIcon status={item.status} />
+				{t(item.status as ParseKeys)}
+			</td>
 			<td>{item.title}</td>
 			<td>{item.description}</td>
 
@@ -171,5 +176,35 @@ export const Operation = ({
 		</tr>
 	);
 };
+
+const OperationStatusIcon = ({
+	status,
+}: {
+	status: string
+}) => {
+	// Parse translation key to state
+	const state = status.split(".").pop();
+
+	const iconStyle = { marginRight: "5px"};
+
+	switch (state) {
+		case "INSTANTIATED":
+			return <LuEllipsis style={{ ...iconStyle, color: "#666"}}/>;
+		case "RUNNING":
+			return <LuLoader className="fa-spin" style={{ ...iconStyle, color: "#666"}}/>;
+		case "PAUSED":
+			return <LuPause style={{ ...iconStyle, color: "#666"}}/>;
+		case "SUCCEEDED":
+			return <LuCheck style={{ ...iconStyle, color: "#37c180"}}/>;
+		case "FAILED":
+			return <LuX style={{ ...iconStyle, color: "#fa1919"}}/>;
+		case "SKIPPED":
+			return <GoDash style={{ ...iconStyle, color: "#378dd4"}}/>;
+		case "RETRY":
+			return <LuRotateCcw className="fa-spin" style={{ ...iconStyle, color: "#666"}}/>;
+		default:
+			return <></>;
+	}
+}
 
 export default EventDetailsWorkflowOperations;

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowTab.tsx
@@ -31,6 +31,8 @@ import { useTranslation } from "react-i18next";
 import ButtonLikeAnchor from "../../../shared/ButtonLikeAnchor";
 import { formatWorkflowsForDropdown } from "../../../../utils/dropDownUtils";
 import { ParseKeys } from "i18next";
+import ModalContent from "../../../shared/modals/ModalContent";
+import EventDetailsTabHierarchyNavigation from "./EventDetailsTabHierarchyNavigation";
 
 type InitialValues = {
 	workflowDefinition: string;
@@ -94,6 +96,10 @@ const EventDetailsWorkflowTab = ({
 		}
 	};
 
+	const openThisTab = (subTabName: WorkflowTabHierarchy) => {
+		dispatch(setModalWorkflowTabHierarchy(subTabName));
+	};
+
 	const openSubTab = (tabType: WorkflowTabHierarchy, workflowId: string) => {
 		dispatch(setModalWorkflowId(workflowId));
 		dispatch(setModalWorkflowTabHierarchy(tabType));
@@ -128,352 +134,358 @@ const EventDetailsWorkflowTab = ({
 	};
 
 	return (
-		<div className="modal-content" data-modal-tab-content="workflows">
-			<div className="modal-body">
-				<div className="full-col">
-					{/* Notifications */}
-					<Notifications context="not_corner" />
+		<ModalContent
+			data-modal-tab-content="workflows"
+			modalContentChildren={
+				/* Hierarchy navigation */
+				<EventDetailsTabHierarchyNavigation
+					openSubTab={openThisTab}
+					hierarchyDepth={0}
+					translationKey0={"EVENTS.EVENTS.DETAILS.WORKFLOW_INSTANCES.TITLE"}
+					subTabArgument0={"workflows"}
+				/>
+			}
+		>
+			{/* Notifications */}
+			<Notifications context="not_corner" />
 
-					<ul>
-						<li>
-							{workflows.scheduling || (
-								<div className="obj tbl-container">
-									<header>
-										{
-											t(
-												"EVENTS.EVENTS.DETAILS.WORKFLOW_INSTANCES.TITLE",
-											) /* Workflow instances */
-										}
-									</header>
-									<div className="obj-container">
-										<table className="main-tbl">
-											<thead>
-												<tr>
-													<th>
-														{t("EVENTS.EVENTS.DETAILS.WORKFLOWS.ID") /* ID */}
-													</th>
-													<th>
-														{
-															t(
-																"EVENTS.EVENTS.DETAILS.WORKFLOWS.TITLE",
-															) /* Title */
-														}
-													</th>
-													<th>
-														{
-															t(
-																"EVENTS.EVENTS.DETAILS.WORKFLOWS.SUBMITTER",
-															) /* Submitter */
-														}
-													</th>
-													<th>
-														{
-															t(
-																"EVENTS.EVENTS.DETAILS.WORKFLOWS.SUBMITTED",
-															) /* Submitted */
-														}
-													</th>
-													<th>
-														{
-															t(
-																"EVENTS.EVENTS.DETAILS.WORKFLOWS.STATUS",
-															) /* Status */
-														}
-													</th>
-													{isRoleWorkflowEdit && (
-														<th className="fit">
-															{
-																t(
-																	"EVENTS.EVENTS.DETAILS.WORKFLOWS.ACTIONS",
-																) /* Actions */
-															}
-														</th>
-													)}
-													<th className="medium" />
-												</tr>
-											</thead>
-											<tbody>
-												{isLoading ||
-													workflows.entries.map((
-														item,
-														key, /*orderBy:'submitted':true track by $index"*/
-													) => (
-														<tr key={key}>
-															<td>{item.id}</td>
-															<td>{item.title}</td>
-															<td>{item.submitter}</td>
-															<td>
-																{t("dateFormats.dateTime.medium", {
-																	dateTime: renderValidDate(item.submitted),
-																})}
-															</td>
-															<td>{t(item.status as ParseKeys)}</td>
-															{isRoleWorkflowEdit && (
-																<td>
-																	{item.status ===
-																		"EVENTS.EVENTS.DETAILS.WORKFLOWS.OPERATION_STATUS.RUNNING" && (
-																		<ButtonLikeAnchor
-																			onClick={() =>
-																				workflowAction(item.id, "STOP")
-																			}
-																			extraClassName="stop fa-fw"
-																			tooltipText="EVENTS.EVENTS.DETAILS.WORKFLOWS.TOOLTIP.STOP"
-																		>
-																			{/* STOP */}
-																		</ButtonLikeAnchor>
-																	)}
-																	{item.status ===
-																		"EVENTS.EVENTS.DETAILS.WORKFLOWS.OPERATION_STATUS.PAUSED" && (
-																		<ButtonLikeAnchor
-																			onClick={() =>
-																				workflowAction(item.id, "NONE")
-																			}
-																			extraClassName="fa fa-hand-stop-o fa-fw"
-																			style={{ color: "red" }}
-																			tooltipText="EVENTS.EVENTS.DETAILS.WORKFLOWS.TOOLTIP.ABORT"
-																		>
-																			{/* Abort */}
-																		</ButtonLikeAnchor>
-																	)}
-																	{item.status ===
-																		"EVENTS.EVENTS.DETAILS.WORKFLOWS.OPERATION_STATUS.PAUSED" && (
-																		<ButtonLikeAnchor
-																			onClick={() =>
-																				workflowAction(item.id, "RETRY")
-																			}
-																			extraClassName="fa fa-refresh fa-fw"
-																			tooltipText="EVENTS.EVENTS.DETAILS.WORKFLOWS.TOOLTIP.RETRY"
-																		>
-																			{/* Retry */}
-																		</ButtonLikeAnchor>
-																	)}
-																	{(item.status ===
-																		"EVENTS.EVENTS.DETAILS.WORKFLOWS.OPERATION_STATUS.SUCCEEDED" ||
-																		item.status ===
-																			"EVENTS.EVENTS.DETAILS.WORKFLOWS.OPERATION_STATUS.FAILED" ||
-																		item.status ===
-																			"EVENTS.EVENTS.DETAILS.WORKFLOWS.OPERATION_STATUS.STOPPED") &&
-																		!isCurrentWorkflow(item.id) &&
-																		isRoleWorkflowDelete && (
-																			<ButtonLikeAnchor
-																				onClick={() => deleteWorkflow(item.id)}
-																				extraClassName="remove fa-fw"
-																				tooltipText="EVENTS.EVENTS.DETAILS.WORKFLOWS.TOOLTIP.DELETE"
-																			>
-																				{/* DELETE */}
-																			</ButtonLikeAnchor>
-																		)}
-																</td>
-															)}
-															<td>
-																<ButtonLikeAnchor
-																	extraClassName="details-link"
-																	onClick={() =>
-																		openSubTab("workflow-details", item.id)
-																	}
-																>
-																	{
-																		t(
-																			"EVENTS.EVENTS.DETAILS.MEDIA.DETAILS",
-																		) /* Details */
-																	}
-																</ButtonLikeAnchor>
-															</td>
-														</tr>
-													))}
-											</tbody>
-										</table>
-									</div>
-								</div>
-							)}
-
-							{workflows.scheduling &&
-								(isLoading || (
-									<Formik<InitialValues>
-										initialValues={setInitialValues()}
-										enableReinitialize
-										onSubmit={values => handleSubmit(values)}
-										innerRef={formikRef}
-									>
-										{formik => (
-											<div className="obj list-obj">
-												<header>
+			<ul>
+				<li>
+					{workflows.scheduling || (
+						<div className="obj tbl-container">
+							<header>
+								{
+									t(
+										"EVENTS.EVENTS.DETAILS.WORKFLOW_INSTANCES.TITLE",
+									) /* Workflow instances */
+								}
+							</header>
+							<div className="obj-container">
+								<table className="main-tbl">
+									<thead>
+										<tr>
+											<th>
+												{t("EVENTS.EVENTS.DETAILS.WORKFLOWS.ID") /* ID */}
+											</th>
+											<th>
+												{
+													t(
+														"EVENTS.EVENTS.DETAILS.WORKFLOWS.TITLE",
+													) /* Title */
+												}
+											</th>
+											<th>
+												{
+													t(
+														"EVENTS.EVENTS.DETAILS.WORKFLOWS.SUBMITTER",
+													) /* Submitter */
+												}
+											</th>
+											<th>
+												{
+													t(
+														"EVENTS.EVENTS.DETAILS.WORKFLOWS.SUBMITTED",
+													) /* Submitted */
+												}
+											</th>
+											<th>
+												{
+													t(
+														"EVENTS.EVENTS.DETAILS.WORKFLOWS.STATUS",
+													) /* Status */
+												}
+											</th>
+											{isRoleWorkflowEdit && (
+												<th className="fit">
 													{
 														t(
-															"EVENTS.EVENTS.DETAILS.WORKFLOW_DETAILS.CONFIGURATION",
-														) /* Workflow configuration */
+															"EVENTS.EVENTS.DETAILS.WORKFLOWS.ACTIONS",
+														) /* Actions */
 													}
-												</header>
-												<div className="obj-container">
-													<div className="obj list-obj quick-actions">
-														<table className="main-tbl">
-															<thead>
-																<tr>
-																	<th>
-																		{
-																			t(
-																				"EVENTS.EVENTS.DETAILS.WORKFLOWS.WORKFLOW",
-																			) /*Select Workflow*/
-																		}
-																	</th>
-																</tr>
-															</thead>
-
-															<tbody>
-																<tr>
-																	<td>
-																		<div className="obj-container padded">
-																			<div className="editable">
-																				<DropDown
-																					value={
-																						formik.values.workflowDefinition
-																					}
-																					text={
-																						workflowDefinitions.find(
-																							workflowDef =>
-																								workflowDef.id ===
-																								formik.values.workflowDefinition,
-																						)?.title ?? ""
-																					}
-																					options={
-																						!!workflowDefinitions &&
-																						workflowDefinitions.length > 0
-																							? formatWorkflowsForDropdown(workflowDefinitions)
-																							: []
-																					}
-																					required={true}
-																					handleChange={element => {
-																						if (element) {
-																							formik.setFieldValue("workflowDefinition", element.value);
-																						}
-																					}}
-																					placeholder={
-																						!!workflowDefinitions &&
-																						workflowDefinitions.length > 0
-																							? t(
-																									"EVENTS.EVENTS.NEW.PROCESSING.SELECT_WORKFLOW",
-																							  )
-																							: t(
-																									"EVENTS.EVENTS.NEW.PROCESSING.SELECT_WORKFLOW_EMPTY",
-																							  )
-																					}
-																					disabled={
-																						!hasCurrentAgentAccess() ||
-																						!isRoleWorkflowEdit
-																					}
-																					customCSS={{ width: "100%" }}
-																				/>
-																				{/*pre-select-from="workflowDefinitionIds"*/}
-																			</div>
-																			<div className="obj-container padded">
-																				{workflow.description}
-																			</div>
-																		</div>
-																	</td>
-																</tr>
-															</tbody>
-														</table>
-													</div>
-
-													<div className="obj list-obj quick-actions">
-														<table className="main-tbl">
-															<thead>
-																<tr>
-																	<th>
-																		{
-																			t(
-																				"EVENTS.EVENTS.DETAILS.WORKFLOWS.CONFIGURATION",
-																			) /* Configuration */
-																		}
-																	</th>
-																</tr>
-															</thead>
-
-															<tbody>
-																<tr>
-																	<td>
-																		<div className="obj-container padded">
-																			{hasCurrentAgentAccess() &&
-																				isRoleWorkflowEdit &&
-																				!!workflowConfiguration &&
-																				!!workflowConfiguration.workflowId && (
-																					<div
-																						id="event-workflow-configuration"
-																						className="checkbox-container obj-container"
-																					>
-																						<RenderWorkflowConfig
-																							workflowId={
-																								workflowConfiguration.workflowId
-																							}
-																							formik={formik}
-																						/>
-																					</div>
-																				)}
-																			{(!!workflowConfiguration &&
-																				!!workflowConfiguration.workflowId) || (
-																				<div>
-																					{
-																						t(
-																							"EVENTS.EVENTS.DETAILS.WORKFLOWS.NO_CONFIGURATION",
-																						) /* No config */
-																					}
-																				</div>
-																			)}
-																		</div>
-																	</td>
-																</tr>
-															</tbody>
-														</table>
-													</div>
-												</div>
-
-												{/* Save and cancel buttons */}
-												{hasCurrentAgentAccess() &&
-													isRoleWorkflowEdit &&
-													!!workflowConfiguration &&
-													!!workflowConfiguration.workflowId &&
-													formik.dirty && (
-														<footer style={{ padding: "0 15px" }}>
-															<div className="pull-left">
-																<button
-																	type="reset"
-																	onClick={() => {
-																		formik.resetForm();
-																	}}
-																	disabled={!formik.isValid}
-																	aria-disabled={!formik.isValid}
-																	className={`cancel  ${
-																		!formik.isValid ? "disabled" : ""
-																	}`}
+												</th>
+											)}
+											<th className="medium" />
+										</tr>
+									</thead>
+									<tbody>
+										{isLoading ||
+											workflows.entries.map((
+												item,
+												key, /*orderBy:'submitted':true track by $index"*/
+											) => (
+												<tr key={key}>
+													<td>{item.id}</td>
+													<td>{item.title}</td>
+													<td>{item.submitter}</td>
+													<td>
+														{t("dateFormats.dateTime.medium", {
+															dateTime: renderValidDate(item.submitted),
+														})}
+													</td>
+													<td>{t(item.status as ParseKeys)}</td>
+													{isRoleWorkflowEdit && (
+														<td>
+															{item.status ===
+																"EVENTS.EVENTS.DETAILS.WORKFLOWS.OPERATION_STATUS.RUNNING" && (
+																<ButtonLikeAnchor
+																	onClick={() =>
+																		workflowAction(item.id, "STOP")
+																	}
+																	extraClassName="stop fa-fw"
+																	tooltipText="EVENTS.EVENTS.DETAILS.WORKFLOWS.TOOLTIP.STOP"
 																>
-																	{t("CANCEL") /* Cancel */}
-																</button>
-															</div>
-															<div className="pull-right">
-																<button
-																	onClick={() => formik.handleSubmit()}
-																	disabled={!(formik.dirty && formik.isValid)}
-																	aria-disabled={!(formik.dirty && formik.isValid)}
-																	className={`save green  ${
-																		!(formik.dirty && formik.isValid)
-																			? "disabled"
-																			: ""
-																	}`}
+																	{/* STOP */}
+																</ButtonLikeAnchor>
+															)}
+															{item.status ===
+																"EVENTS.EVENTS.DETAILS.WORKFLOWS.OPERATION_STATUS.PAUSED" && (
+																<ButtonLikeAnchor
+																	onClick={() =>
+																		workflowAction(item.id, "NONE")
+																	}
+																	extraClassName="fa fa-hand-stop-o fa-fw"
+																	style={{ color: "red" }}
+																	tooltipText="EVENTS.EVENTS.DETAILS.WORKFLOWS.TOOLTIP.ABORT"
 																>
-																	{t("SAVE") /* Save */}
-																</button>
-															</div>
-														</footer>
+																	{/* Abort */}
+																</ButtonLikeAnchor>
+															)}
+															{item.status ===
+																"EVENTS.EVENTS.DETAILS.WORKFLOWS.OPERATION_STATUS.PAUSED" && (
+																<ButtonLikeAnchor
+																	onClick={() =>
+																		workflowAction(item.id, "RETRY")
+																	}
+																	extraClassName="fa fa-refresh fa-fw"
+																	tooltipText="EVENTS.EVENTS.DETAILS.WORKFLOWS.TOOLTIP.RETRY"
+																>
+																	{/* Retry */}
+																</ButtonLikeAnchor>
+															)}
+															{(item.status ===
+																"EVENTS.EVENTS.DETAILS.WORKFLOWS.OPERATION_STATUS.SUCCEEDED" ||
+																item.status ===
+																	"EVENTS.EVENTS.DETAILS.WORKFLOWS.OPERATION_STATUS.FAILED" ||
+																item.status ===
+																	"EVENTS.EVENTS.DETAILS.WORKFLOWS.OPERATION_STATUS.STOPPED") &&
+																!isCurrentWorkflow(item.id) &&
+																isRoleWorkflowDelete && (
+																	<ButtonLikeAnchor
+																		onClick={() => deleteWorkflow(item.id)}
+																		extraClassName="remove fa-fw"
+																		tooltipText="EVENTS.EVENTS.DETAILS.WORKFLOWS.TOOLTIP.DELETE"
+																	>
+																		{/* DELETE */}
+																	</ButtonLikeAnchor>
+																)}
+														</td>
 													)}
+													<td>
+														<ButtonLikeAnchor
+															extraClassName="details-link"
+															onClick={() =>
+																openSubTab("workflow-details", item.id)
+															}
+														>
+															{
+																t(
+																	"EVENTS.EVENTS.DETAILS.MEDIA.DETAILS",
+																) /* Details */
+															}
+														</ButtonLikeAnchor>
+													</td>
+												</tr>
+											))}
+									</tbody>
+								</table>
+							</div>
+						</div>
+					)}
+
+					{workflows.scheduling &&
+						(isLoading || (
+							<Formik<InitialValues>
+								initialValues={setInitialValues()}
+								enableReinitialize
+								onSubmit={values => handleSubmit(values)}
+								innerRef={formikRef}
+							>
+								{formik => (
+									<div className="obj list-obj">
+										<header>
+											{
+												t(
+													"EVENTS.EVENTS.DETAILS.WORKFLOW_DETAILS.CONFIGURATION",
+												) /* Workflow configuration */
+											}
+										</header>
+										<div className="obj-container">
+											<div className="obj list-obj quick-actions">
+												<table className="main-tbl">
+													<thead>
+														<tr>
+															<th>
+																{
+																	t(
+																		"EVENTS.EVENTS.DETAILS.WORKFLOWS.WORKFLOW",
+																	) /*Select Workflow*/
+																}
+															</th>
+														</tr>
+													</thead>
+
+													<tbody>
+														<tr>
+															<td>
+																<div className="obj-container padded">
+																	<div className="editable">
+																		<DropDown
+																			value={
+																				formik.values.workflowDefinition
+																			}
+																			text={
+																				workflowDefinitions.find(
+																					workflowDef =>
+																						workflowDef.id ===
+																						formik.values.workflowDefinition,
+																				)?.title ?? ""
+																			}
+																			options={
+																				!!workflowDefinitions &&
+																				workflowDefinitions.length > 0
+																					? formatWorkflowsForDropdown(workflowDefinitions)
+																					: []
+																			}
+																			required={true}
+																			handleChange={element => {
+																				if (element) {
+																					formik.setFieldValue("workflowDefinition", element.value);
+																				}
+																			}}
+																			placeholder={
+																				!!workflowDefinitions &&
+																				workflowDefinitions.length > 0
+																					? t(
+																							"EVENTS.EVENTS.NEW.PROCESSING.SELECT_WORKFLOW",
+																						)
+																					: t(
+																							"EVENTS.EVENTS.NEW.PROCESSING.SELECT_WORKFLOW_EMPTY",
+																						)
+																			}
+																			disabled={
+																				!hasCurrentAgentAccess() ||
+																				!isRoleWorkflowEdit
+																			}
+																			customCSS={{ width: "100%" }}
+																		/>
+																		{/*pre-select-from="workflowDefinitionIds"*/}
+																	</div>
+																	<div className="obj-container padded">
+																		{workflow.description}
+																	</div>
+																</div>
+															</td>
+														</tr>
+													</tbody>
+												</table>
 											</div>
-										)}
-									</Formik>
-								))}
-						</li>
-					</ul>
-				</div>
-			</div>
-		</div>
+
+											<div className="obj list-obj quick-actions">
+												<table className="main-tbl">
+													<thead>
+														<tr>
+															<th>
+																{
+																	t(
+																		"EVENTS.EVENTS.DETAILS.WORKFLOWS.CONFIGURATION",
+																	) /* Configuration */
+																}
+															</th>
+														</tr>
+													</thead>
+
+													<tbody>
+														<tr>
+															<td>
+																<div className="obj-container padded">
+																	{hasCurrentAgentAccess() &&
+																		isRoleWorkflowEdit &&
+																		!!workflowConfiguration &&
+																		!!workflowConfiguration.workflowId && (
+																			<div
+																				id="event-workflow-configuration"
+																				className="checkbox-container obj-container"
+																			>
+																				<RenderWorkflowConfig
+																					workflowId={
+																						workflowConfiguration.workflowId
+																					}
+																					formik={formik}
+																				/>
+																			</div>
+																		)}
+																	{(!!workflowConfiguration &&
+																		!!workflowConfiguration.workflowId) || (
+																		<div>
+																			{
+																				t(
+																					"EVENTS.EVENTS.DETAILS.WORKFLOWS.NO_CONFIGURATION",
+																				) /* No config */
+																			}
+																		</div>
+																	)}
+																</div>
+															</td>
+														</tr>
+													</tbody>
+												</table>
+											</div>
+										</div>
+
+										{/* Save and cancel buttons */}
+										{hasCurrentAgentAccess() &&
+											isRoleWorkflowEdit &&
+											!!workflowConfiguration &&
+											!!workflowConfiguration.workflowId &&
+											formik.dirty && (
+												<footer style={{ padding: "0 15px" }}>
+													<div className="pull-left">
+														<button
+															type="reset"
+															onClick={() => {
+																formik.resetForm();
+															}}
+															disabled={!formik.isValid}
+															className={`cancel  ${
+																!formik.isValid ? "disabled" : ""
+															}`}
+														>
+															{t("CANCEL") /* Cancel */}
+														</button>
+													</div>
+													<div className="pull-right">
+														<button
+															onClick={() => formik.handleSubmit()}
+															disabled={!(formik.dirty && formik.isValid)}
+															aria-disabled={!(formik.dirty && formik.isValid)}
+															className={`save green  ${
+																!(formik.dirty && formik.isValid)
+																	? "disabled"
+																	: ""
+															}`}
+														>
+															{t("SAVE") /* Save */}
+														</button>
+													</div>
+												</footer>
+											)}
+									</div>
+								)}
+							</Formik>
+						))}
+				</li>
+			</ul>
+		</ModalContent>
 	);
 };
 

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowTab.tsx
@@ -6,9 +6,9 @@ import {
 	getWorkflow,
 	getWorkflowConfiguration,
 	getWorkflowDefinitions,
-	getWorkflows,
 	isFetchingWorkflows,
 	performingWorkflowAction as getPerformingWorkflowAction,
+	getWorkflowsSortedByDate,
 } from "../../../../selectors/eventDetailsSelectors";
 import Notifications from "../../../shared/Notifications";
 import RenderWorkflowConfig from "../wizards/RenderWorkflowConfig";
@@ -58,7 +58,7 @@ const EventDetailsWorkflowTab = ({
 	const workflow = useAppSelector(state => getWorkflow(state));
 	const workflowConfiguration = useAppSelector(state => getWorkflowConfiguration(state));
 	const workflowDefinitions = useAppSelector(state => getWorkflowDefinitions(state));
-	const workflows = useAppSelector(state => getWorkflows(state));
+	const workflows = useAppSelector(state => getWorkflowsSortedByDate(state));
 	const isLoading = useAppSelector(state => isFetchingWorkflows(state));
 	const performingWorkflowAction = useAppSelector(state => getPerformingWorkflowAction(state));
 

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowTab.tsx
@@ -168,32 +168,16 @@ const EventDetailsWorkflowTab = ({
 												{t("EVENTS.EVENTS.DETAILS.WORKFLOWS.ID") /* ID */}
 											</th>
 											<th>
-												{
-													t(
-														"EVENTS.EVENTS.DETAILS.WORKFLOWS.TITLE",
-													) /* Title */
-												}
+												{t("EVENTS.EVENTS.DETAILS.WORKFLOWS.TITLE") /* Title */}
 											</th>
 											<th>
-												{
-													t(
-														"EVENTS.EVENTS.DETAILS.WORKFLOWS.SUBMITTER",
-													) /* Submitter */
-												}
+												{t("EVENTS.EVENTS.DETAILS.WORKFLOWS.SUBMITTER") /* Submitter */}
 											</th>
 											<th>
-												{
-													t(
-														"EVENTS.EVENTS.DETAILS.WORKFLOWS.SUBMITTED",
-													) /* Submitted */
-												}
+												{t("EVENTS.EVENTS.DETAILS.WORKFLOWS.SUBMITTED") /* Submitted */}
 											</th>
 											<th>
-												{
-													t(
-														"EVENTS.EVENTS.DETAILS.WORKFLOWS.STATUS",
-													) /* Status */
-												}
+												{t("EVENTS.EVENTS.DETAILS.WORKFLOWS.STATUS") /* Status */}
 											</th>
 											{isRoleWorkflowEdit && (
 												<th className="fit">
@@ -313,11 +297,7 @@ const EventDetailsWorkflowTab = ({
 								{formik => (
 									<div className="obj list-obj">
 										<header>
-											{
-												t(
-													"EVENTS.EVENTS.DETAILS.WORKFLOW_DETAILS.CONFIGURATION",
-												) /* Workflow configuration */
-											}
+											{t("EVENTS.EVENTS.DETAILS.WORKFLOW_DETAILS.CONFIGURATION") /* Workflow configuration */}
 										</header>
 										<div className="obj-container">
 											<div className="obj list-obj quick-actions">
@@ -325,11 +305,7 @@ const EventDetailsWorkflowTab = ({
 													<thead>
 														<tr>
 															<th>
-																{
-																	t(
-																		"EVENTS.EVENTS.DETAILS.WORKFLOWS.WORKFLOW",
-																	) /*Select Workflow*/
-																}
+																{t("EVENTS.EVENTS.DETAILS.WORKFLOWS.WORKFLOW") /*Select Workflow*/}
 															</th>
 														</tr>
 													</thead>
@@ -395,11 +371,7 @@ const EventDetailsWorkflowTab = ({
 													<thead>
 														<tr>
 															<th>
-																{
-																	t(
-																		"EVENTS.EVENTS.DETAILS.WORKFLOWS.CONFIGURATION",
-																	) /* Configuration */
-																}
+																{t("EVENTS.EVENTS.DETAILS.WORKFLOWS.CONFIGURATION") /* Configuration */}
 															</th>
 														</tr>
 													</thead>
@@ -427,11 +399,7 @@ const EventDetailsWorkflowTab = ({
 																	{(!!workflowConfiguration &&
 																		!!workflowConfiguration.workflowId) || (
 																		<div>
-																			{
-																				t(
-																					"EVENTS.EVENTS.DETAILS.WORKFLOWS.NO_CONFIGURATION",
-																				) /* No config */
-																			}
+																			{t("EVENTS.EVENTS.DETAILS.WORKFLOWS.NO_CONFIGURATION") /* No config */}
 																		</div>
 																	)}
 																</div>

--- a/src/components/events/partials/modals/EventDetails.tsx
+++ b/src/components/events/partials/modals/EventDetails.tsx
@@ -64,7 +64,7 @@ export enum EventDetailsPage {
 	Statistics,
 }
 
-export type WorkflowTabHierarchy = "entry" | "workflow-details" | "workflow-operations" | "workflow-operation-details" | "errors-and-warnings" | "workflow-error-details"
+export type WorkflowTabHierarchy = "workflows" | "workflow-details" | "workflow-operations" | "workflow-operation-details" | "errors-and-warnings" | "workflow-error-details"
 export type AssetTabHierarchy = "entry" | "add-asset" | "asset-attachments" | "attachment-details" | "asset-catalogs" | "catalog-details" | "asset-media" | "media-details" | "asset-publications" | "publication-details";
 
 /**
@@ -219,7 +219,7 @@ const EventDetails = ({
 
 	const openTab = (tabNr: EventDetailsPage) => {
 		dispatch(removeNotificationWizardForm());
-		dispatch(openModalTab(tabNr, "entry", "entry"));
+		dispatch(openModalTab(tabNr, "workflow-details", "entry"));
 	};
 
 	return (
@@ -269,7 +269,7 @@ const EventDetails = ({
 					/>
 				)}
 				{page === EventDetailsPage.Workflow &&
-					((workflowTabHierarchy === "entry" && (
+					((workflowTabHierarchy === "workflows" && (
 						<EventDetailsWorkflowTab
 							eventId={eventId}
 							formikRef={formikRef}

--- a/src/components/events/partials/modals/EventDetails.tsx
+++ b/src/components/events/partials/modals/EventDetails.tsx
@@ -288,11 +288,6 @@ const EventDetails = ({
 						(workflowTabHierarchy === "workflow-operation-details" && (
 							<EventDetailsWorkflowOperationDetails />
 						)) ||
-						(workflowTabHierarchy === "errors-and-warnings" && (
-							<EventDetailsWorkflowErrors
-								eventId={eventId}
-							/>
-						)) ||
 						(workflowTabHierarchy === "workflow-error-details" && (
 							<EventDetailsWorkflowErrorDetails />
 						)))}

--- a/src/components/events/partials/modals/EventDetails.tsx
+++ b/src/components/events/partials/modals/EventDetails.tsx
@@ -289,7 +289,9 @@ const EventDetails = ({
 							<EventDetailsWorkflowOperationDetails />
 						)) ||
 						(workflowTabHierarchy === "workflow-error-details" && (
-							<EventDetailsWorkflowErrorDetails />
+							<EventDetailsWorkflowErrorDetails
+								eventId={eventId}
+							/>
 						)))}
 				{page === EventDetailsPage.AccessPolicy && (
 					<EventDetailsAccessPolicyTab

--- a/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
@@ -991,7 +991,6 @@
 					"ACTIONS": "Actions",
 					"DETAILS": "Details",
 					"DESCRIPTION": "Description",
-					"MORE_INFO": "More Information",
 					"ID": "ID",
 					"TYPE": "Type",
 					"TITLE": "Title",
@@ -1031,11 +1030,12 @@
 				},
 				"WORKFLOW_DETAILS": {
 					"TITLE": "Workflow details",
-					"CONFIGURATION": "Workflow configuration"
+					"CONFIGURATION": "Workflow configuration",
+					"LATEST_OPERATION": "Latest workflow operation"
 				},
 				"WORKFLOW_OPERATIONS": {
 					"TITLE": "Workflow operations",
-					"DETAILS_LINK": "Operations",
+					"DETAILS_LINK": "All operations",
 					"TABLE_HEADERS": {
 						"TITLE": "Title",
 						"STATUS": "Status",

--- a/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
@@ -1031,7 +1031,8 @@
 				"WORKFLOW_DETAILS": {
 					"TITLE": "Workflow details",
 					"CONFIGURATION": "Workflow configuration",
-					"LATEST_OPERATION": "Latest workflow operation"
+					"OPERATIONS": "Operations",
+					"CURRENT_OPERATION": "Current workflow operation"
 				},
 				"WORKFLOW_OPERATIONS": {
 					"TITLE": "Workflow operations",

--- a/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
@@ -1095,7 +1095,8 @@
 						"DATE": "Date",
 						"HOST": "Processing host",
 						"TYPE": "Service type",
-						"TECHNICAL_DETAILS": "Technical details"
+						"TECHNICAL_DETAILS": "Technical details",
+						"OPERATION": "Operation the error occured in"
 					}
 				}
 			}

--- a/src/selectors/eventDetailsSelectors.ts
+++ b/src/selectors/eventDetailsSelectors.ts
@@ -131,6 +131,36 @@ export const getLatestWorkflowOperation = createSelector(
 		return null; // if none found
 	},
 );
+// Get operation by root_job_id, or jobId
+export const getWorkflowByJobId = createSelector(
+	[
+		getWorkflowOperations,
+		(_operations, rootJobId: number) => rootJobId,
+		(_operations, rootJobId: number, jobId: number) => jobId,
+	],
+	(operations, rootJobId, jobId) => {
+		let operation = null;
+		let index = null;
+
+		index = operations.entries.findIndex(
+			entry => entry.id === rootJobId,
+		);
+		operation = operations.entries[index];
+
+		if (!operation) {
+			index = operations.entries.findIndex(
+				entry => entry.id === jobId,
+			);
+			operation = operations.entries[index];
+		}
+
+		if (operation) {
+			return { operation, index };
+		}
+
+		return null;
+	},
+);
 export const isFetchingWorkflowOperations = (state: RootState) =>
 	state.eventDetails.statusWorkflowOperations === "loading";
 export const getWorkflowOperationDetails = (state: RootState) =>

--- a/src/selectors/eventDetailsSelectors.ts
+++ b/src/selectors/eventDetailsSelectors.ts
@@ -115,6 +115,22 @@ export const deletingWorkflow = (state: RootState) =>
 	state.eventDetails.statusDeleteWorkflow === "loading";
 export const getWorkflowOperations = (state: RootState) =>
 	state.eventDetails.workflowOperations;
+// Get the workflow operation currently running (or the last one that was run)
+export const getLatestWorkflowOperation = createSelector(
+	[getWorkflowOperations],
+	operations => {
+		const entries = operations.entries;
+
+		for (let i = entries.length - 1; i >= 0; i--) {
+			const operation = entries[i];
+			if (operation.id !== null) {
+				return { operation, index: i };
+			}
+		}
+
+		return null; // if none found
+	},
+);
 export const isFetchingWorkflowOperations = (state: RootState) =>
 	state.eventDetails.statusWorkflowOperations === "loading";
 export const getWorkflowOperationDetails = (state: RootState) =>

--- a/src/selectors/eventDetailsSelectors.ts
+++ b/src/selectors/eventDetailsSelectors.ts
@@ -1,3 +1,4 @@
+import { createSelector } from "@reduxjs/toolkit";
 import { RootState } from "../store";
 
 /* selectors for modal */
@@ -87,6 +88,17 @@ export const isCheckingConflicts = (state: RootState) =>
 
 /* selectors for workflows */
 export const getWorkflows = (state: RootState) => state.eventDetails.workflows;
+export const getWorkflowsSortedByDate = createSelector(
+	[getWorkflows],
+	workflows => {
+		return ({
+			...workflows,
+			entries: [...workflows.entries].sort(
+				(a, b) => new Date(b.submitted).getTime() - new Date(a.submitted).getTime(),
+			),
+		})
+	},
+);
 export const isFetchingWorkflows = (state: RootState) =>
 	state.eventDetails.statusWorkflows === "loading";
 export const getWorkflowDefinitions = (state: RootState) =>

--- a/src/selectors/eventDetailsSelectors.ts
+++ b/src/selectors/eventDetailsSelectors.ts
@@ -107,7 +107,7 @@ export const getWorkflowConfiguration = (state: RootState) =>
 	state.eventDetails.workflowConfiguration;
 export const getWorkflow = (state: RootState) => state.eventDetails.workflows.workflow;
 export const isFetchingWorkflowDetails = (state: RootState) =>
-	state.eventDetails.statusWorkflowDetails === "loading";
+	state.eventDetails.statusWorkflowDetails === "loading" || state.eventDetails.statusWorkflowDetails === "uninitialized";
 export const getBaseWorkflow = (state: RootState) => state.eventDetails.baseWorkflow;
 export const performingWorkflowAction = (state: RootState) =>
 	state.eventDetails.statusDoWorkflowAction === "loading";

--- a/src/slices/eventDetailsSlice.ts
+++ b/src/slices/eventDetailsSlice.ts
@@ -359,6 +359,7 @@ type EventDetailsState = {
 		}[],
 		id: number,
 		jobId: number,
+		rootJobId?: number,
 		processingHost: string,
 		serviceType: string,
 		severity: string,

--- a/src/slices/eventDetailsSlice.ts
+++ b/src/slices/eventDetailsSlice.ts
@@ -102,6 +102,14 @@ type Workflow = {
 	}
 }
 
+export type WorkflowOperation = {
+	configuration: { [key: string]: string },
+	description: string,
+	id: number,
+	status: string,  // translation key, ending on INSTANTIATED, RUNNING, PAUSED, SUCCEEDED, FAILED, SKIPPED, RETRY
+	title: string,
+}
+
 type Device = {
 	id: string,
 	inputs: { id: string, value: string }[],
@@ -319,13 +327,7 @@ type EventDetailsState = {
 		configuration?: {[key: string]: unknown}
 	},
 	workflowOperations: {
-		entries: {
-			configuration: { [key: string]: string },
-			description: string,
-			id: number,
-			status: string,  // translation key, ending on INSTANTIATED, RUNNING, PAUSED, SUCCEEDED, FAILED, SKIPPED, RETRY
-			title: string,
-		}[]
+		entries: WorkflowOperation[]
 	},
 	workflowOperationDetails: {
 		completed: string,  // date

--- a/src/slices/eventDetailsSlice.ts
+++ b/src/slices/eventDetailsSlice.ts
@@ -323,7 +323,7 @@ type EventDetailsState = {
 			configuration: { [key: string]: string },
 			description: string,
 			id: number,
-			status: string,  // translation key
+			status: string,  // translation key, ending on INSTANTIATED, RUNNING, PAUSED, SUCCEEDED, FAILED, SKIPPED, RETRY
 			title: string,
 		}[]
 	},

--- a/src/slices/eventDetailsSlice.ts
+++ b/src/slices/eventDetailsSlice.ts
@@ -439,7 +439,7 @@ const initialState: EventDetailsState = {
 		show: false,
 		page: EventDetailsPage.Metadata,
 		event: null,
-		workflowTabHierarchy: "entry",
+		workflowTabHierarchy: "workflow-details",
 		assetsTabHierarchy: "entry",
 		workflowId: "",
 	},
@@ -1422,7 +1422,7 @@ export const fetchWorkflowOperations = createAppAsyncThunk("eventDetails/fetchWo
 export const openModal = (
 	page: EventDetailsPage,
 	event: Event,
-	workflowTab: WorkflowTabHierarchy = "entry",
+	workflowTab: WorkflowTabHierarchy = "workflow-details",
 	assetsTab: AssetTabHierarchy = "entry",
 	workflowId: string = "",
 ) => (dispatch: AppDispatch) => {


### PR DESCRIPTION
Helps with #1292.

Makes various changes to the workflow tab in the event details modal.

- When opening the workflow tab, start on the details page for the latest workflow.
  - Most of the time, users only care about processing status or failures of the latest workflow
  - Other workflow of course remain accessible
- Put links to operations at the top instead of the bottom and display the latest operation
  - Should make it easier to check workflow status
- Put errors just below operations. Directly display errors here (if applicable).
- Sort workflows by newest first (how it was in the old admin ui).

![Bildschirmfoto vom 2025-07-08 10-19-17](https://github.com/user-attachments/assets/5c1bd824-6486-4969-91cd-4e4e886ca634)

### How to test this

No further changes required for testing. Check if this lets you access the information you are usually looking for faster than before, without obfuscating information.

-----
EDIT #1: The latest commit shows the related workflow operation on the error details page. This requires https://github.com/opencast/opencast/pull/6888, else the operation will not show. Not having the backend PR should NOT break this PR.

