### PR TITLE
Fix ACL role dropdown width

### DIFF
--- a/src/components/shared/modals/ResourceDetailsAccessPolicyTab.tsx
+++ b/src/components/shared/modals/ResourceDetailsAccessPolicyTab.tsx
@@ -564,6 +564,7 @@ export const AccessPolicyTable = <T extends AccessPolicyTabFormikProps>({
 																				user,
 																			)
 																		}
+																		customCSS={{ width: "100%" }}
 																	/>
 																) : (
 																	<p>{policy.role}</p>


### PR DESCRIPTION
The role dropdown in the ACL tabs could extend over its column width, due to its own fixed width.
This fixes that.

Before:
![Bildschirmfoto vom 2025-07-09 14-37-02](https://github.com/user-attachments/assets/b8a54e53-84c1-4024-89a4-0fb2ccc8e0b3)

After:
![Bildschirmfoto vom 2025-07-09 14-36-35](https://github.com/user-attachments/assets/4c97b174-c7cd-4fb2-973a-022786d17109)
