### PR TITLE
Remove READ column from ACL modal UI

### DIFF
--- a/src/components/shared/modals/ResourceDetailsAccessPolicyTab.tsx
+++ b/src/components/shared/modals/ResourceDetailsAccessPolicyTab.tsx
@@ -495,6 +495,13 @@ export const AccessPolicyTable = <T extends AccessPolicyTabFormikProps>({
 											) /* <!-- Write --> */
 										}
 									</th>
+									<th className="fit">
+										{
+											t(
+												"EVENTS.EVENTS.DETAILS.ACCESS.ACCESS_POLICY.READ",
+											) /* <!-- Read --> */
+										}
+									</th>
 									{hasActions && (
 										<th className="fit">
 											{
@@ -564,6 +571,31 @@ export const AccessPolicyTable = <T extends AccessPolicyTabFormikProps>({
 															</td>
 
 															{/* Checkboxes for policy.read and policy.write */}
+															<td className="fit text-center">
+																<Field
+																	type="checkbox"
+																	name={`policies.${formik.values.policies.findIndex(p => p === policy)}.read`}
+																	disabled={
+																		transactions.read_only ||
+																		!hasAccess(
+																			editAccessRole,
+																			user,
+																		) ||
+																		(aclDefaults && aclDefaults["read_readonly"] !== "false")
+																	}
+																	className={`${
+																		transactions.read_only
+																			? "disabled"
+																			: "false"
+																	}`}
+																	onChange={(read: React.ChangeEvent<HTMLInputElement>) =>
+																		replace(formik.values.policies.findIndex(p => p === policy), {
+																			...policy,
+																			read: read.target.checked,
+																		})
+																	}
+																/>
+															</td>
 															<td className="fit text-center">
 																<Field
 																	type="checkbox"
@@ -658,7 +690,7 @@ export const AccessPolicyTable = <T extends AccessPolicyTabFormikProps>({
 											{!transactions.read_only &&
 												hasAccess(editAccessRole, user) && (
 													<tr>
-														<td colSpan={4}>
+														<td colSpan={5}>
 															<ButtonLikeAnchor
 																onClick={() =>
 																	push(createPolicy("", isUserTable))

--- a/src/components/shared/modals/ResourceDetailsAccessPolicyTab.tsx
+++ b/src/components/shared/modals/ResourceDetailsAccessPolicyTab.tsx
@@ -491,13 +491,6 @@ export const AccessPolicyTable = <T extends AccessPolicyTabFormikProps>({
 									<th className="fit">
 										{
 											t(
-												"EVENTS.EVENTS.DETAILS.ACCESS.ACCESS_POLICY.READ",
-											) /* <!-- Read --> */
-										}
-									</th>
-									<th className="fit">
-										{
-											t(
 												"EVENTS.EVENTS.DETAILS.ACCESS.ACCESS_POLICY.WRITE",
 											) /* <!-- Write --> */
 										}
@@ -571,31 +564,6 @@ export const AccessPolicyTable = <T extends AccessPolicyTabFormikProps>({
 															</td>
 
 															{/* Checkboxes for policy.read and policy.write */}
-															<td className="fit text-center">
-																<Field
-																	type="checkbox"
-																	name={`policies.${formik.values.policies.findIndex(p => p === policy)}.read`}
-																	disabled={
-																		transactions.read_only ||
-																		!hasAccess(
-																			editAccessRole,
-																			user,
-																		) ||
-																		(aclDefaults && aclDefaults["read_readonly"] !== "false")
-																	}
-																	className={`${
-																		transactions.read_only
-																			? "disabled"
-																			: "false"
-																	}`}
-																	onChange={(read: React.ChangeEvent<HTMLInputElement>) =>
-																		replace(formik.values.policies.findIndex(p => p === policy), {
-																			...policy,
-																			read: read.target.checked,
-																		})
-																	}
-																/>
-															</td>
 															<td className="fit text-center">
 																<Field
 																	type="checkbox"
@@ -690,7 +658,7 @@ export const AccessPolicyTable = <T extends AccessPolicyTabFormikProps>({
 											{!transactions.read_only &&
 												hasAccess(editAccessRole, user) && (
 													<tr>
-														<td colSpan={5}>
+														<td colSpan={4}>
 															<ButtonLikeAnchor
 																onClick={() =>
 																	push(createPolicy("", isUserTable))


### PR DESCRIPTION
This PR removes the READ column from the Access Control List (ACL) modal user interface.
<img width="1205" height="787" alt="image" src="https://github.com/user-attachments/assets/d169a3bd-cf6c-472a-8157-f0ea4cdd760e" />
