### PR TITLE
Fix ACL role dropdown width

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/NewAccessPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewAccessPage.tsx
@@ -269,7 +269,7 @@ const NewAccessPage = <T extends RequiredFormProps>({
 																						}
 																						skipTranslate
 																						optionHeight={35}
-																						customCSS={{ width: 360, optionPaddingTop: 5 }}
+																						customCSS={{ width: "100%", optionPaddingTop: 5 }}
 																					/>
 																				</td>
 																				{/* Checkboxes for  policy.read and policy.write*/}

--- a/src/components/shared/modals/ResourceDetailsAccessPolicyTab.tsx
+++ b/src/components/shared/modals/ResourceDetailsAccessPolicyTab.tsx
@@ -497,7 +497,7 @@ const ResourceDetailsAccessPolicyTab = ({
 																								}
 																								skipTranslate
 																								optionHeight={35}
-																								customCSS={{ width: 360, optionPaddingTop: 5 }}
+																								customCSS={{ width: "100%", optionPaddingTop: 5 }}
 																							/>
 																						) : (
 																							<p>{policy.role}</p>

--- a/src/components/users/partials/wizard/AclAccessPage.tsx
+++ b/src/components/users/partials/wizard/AclAccessPage.tsx
@@ -229,7 +229,7 @@ const AclAccessPage = <T extends RequiredFormProps>({
 																						disabled={!isAccess}
 																						skipTranslate
 																						optionHeight={35}
-																						customCSS={{ width: 360, optionPaddingTop: 5 }}
+																						customCSS={{ width: "100%", optionPaddingTop: 5 }}
 																					/>
 																				</td>
 																				<td className="fit text-center">


### PR DESCRIPTION
The role dropdown in the ACL tabs could extend over its column width, due to its own fixed width. This fixes that.

Replaces #1365