### PR TITLE
Fix selection of capture agent input selection in add events dialog

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsSchedulingTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsSchedulingTab.tsx
@@ -92,7 +92,6 @@ const EventDetailsSchedulingTab = ({
 
 	const sourceStartDate = new Date(source.start.date);
 	const endStartDate = new Date(source.start.date);
-
 	useEffect(() => {
 		dispatch(removeNotificationWizardForm());
 		dispatch(checkConflicts({

--- a/src/slices/eventDetailsSlice.ts
+++ b/src/slices/eventDetailsSlice.ts
@@ -1111,7 +1111,6 @@ export const saveSchedulingInfo = createAppAsyncThunk("eventDetails/saveScheduli
 	endDate: Date
 }, { dispatch, getState }) => {
 	const { eventId, values, startDate, endDate } = params;
-
 	const state = getState();
 	const oldSource = getSchedulingSource(state);
 	const captureAgents = getRecordings(state);

--- a/src/slices/eventSlice.ts
+++ b/src/slices/eventSlice.ts
@@ -437,7 +437,7 @@ export const postNewEvent = createAppAsyncThunk("events/postNewEvent", async (pa
 	values: {
 		policies: TransformedAcl[],
 		configuration: { [key: string]: unknown },
-		deviceInputs?: string[],
+		inputs?: string[],
 		processingWorkflow: string,
 		repeatOn: string[],
 		scheduleDurationHours: string,
@@ -456,7 +456,6 @@ export const postNewEvent = createAppAsyncThunk("events/postNewEvent", async (pa
 	extendedMetadata: MetadataCatalog[],
 }, { dispatch, getState }) => {
 	const { values, metadataInfo, extendedMetadata } = params;
-
 	// get asset upload options from redux store
 	const state = getState();
 	const uploadAssetOptions = getAssetUploadOptions(state);
@@ -544,7 +543,7 @@ export const postNewEvent = createAppAsyncThunk("events/postNewEvent", async (pa
 			metadata: {
 				start: startDate,
 				device: values.location,
-				inputs: values.deviceInputs ? values.deviceInputs.join(",") : "",
+				inputs: values.inputs ? values.inputs.join(",") : "",
 				end: endDate,
 				duration: duration.toString(),
 			},


### PR DESCRIPTION
Fix issue with user-selected inputs not being saved when posting new events

This PR addresses a problem where user choices for device inputs were not persisted despite appearing correctly in the form submission. The fix involved ensuring the correct property from the form values is accessed and included in the request payload.

To further improve code quality and prevent regressions, I can add unit tests covering this behavior in a follow-up PR if desired.


