### PR TITLE
Fix Metadata field getting cut off

### DIFF
--- a/src/styles/components/modals/_modal-base.scss
+++ b/src/styles/components/modals/_modal-base.scss
@@ -283,6 +283,7 @@
                 line-height: 25px !important;
                 padding-top: 4px;
                 padding-bottom: 4px;
+                word-break: break-word;
 
                 > a {
                     float: none;

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -169,7 +169,7 @@ a {
     // border-radius: 0;
     // border-bottom: 1px dashed #999;
 
-    width: auto;
+    width: 98%;
   }
   .single-value:focus{
     width: 98%;
@@ -187,7 +187,7 @@ a {
     // border-radius: 0;
     // border-bottom: 1px dashed #999;
 
-    width: auto;
+    width: 98%;
     // height: auto;
   }
   .single-value-textarea:focus{


### PR DESCRIPTION
Some metadata fields would not display their full content even if there was still space available. This patch should help with that.

Before:
<img width="1081" height="533" alt="Bildschirmfoto vom 2025-07-30 09-08-13" src="https://github.com/user-attachments/assets/04794b85-f659-427b-8410-f3e9b6e420e0" />

After:
<img width="1086" height="474" alt="Bildschirmfoto vom 2025-07-30 09-07-54" src="https://github.com/user-attachments/assets/d92efe1e-d1e7-4346-b26b-1094eca34c60" />

### How to test

Check that inputs/textareas in modals do not behave strangely.