### PR TITLE
Fix datepicker opening twice on start date

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/NewSourcePage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewSourcePage.tsx
@@ -321,7 +321,8 @@ const Upload = <T extends RequiredFormPropsUpload>({
 							{/* One row for each metadata field*/}
 							{sourceMetadata.UPLOAD && sourceMetadata.UPLOAD.metadata.map((field, key) => (
 								<tr key={key}>
-									<td>
+									{/* Set fixed width to prevent date picker from opening twice */}
+									<td style={{ width: "20%" }}>
 										<span>{t(field.label as ParseKeys)}</span>
 										{field.required && <i className="required">*</i>}
 									</td>


### PR DESCRIPTION
Fixes #1388

When creating an event, on the source tab, the datepicker for the start date metadata field is opening again after clicking on a date. The first click also does not change the value. This fixes this somewhat crudely.

### How to test this

Check if the date picker for the start date field in the create event dialog works as expected.