### PR TITLE
Safari: Dropdown for multiselects opens immediately

### DIFF
--- a/src/components/shared/wizard/RenderMultiField.tsx
+++ b/src/components/shared/wizard/RenderMultiField.tsx
@@ -166,7 +166,6 @@ const EditMultiSelect = ({
 						onChange={(e) => handleChange(e)}
 						placeholder={t("EDITABLE.MULTI.PLACEHOLDER")}
 						list="data-list"
-						autoFocus={true}
 					/>
 					{/* Display possible options for values as some kind of dropdown */}
 					<datalist id="data-list">


### PR DESCRIPTION
In Safari, open the details of an event and click on one of the multi-select fields (e.g. presenters, contributors). This will open up a dropdown which hides already selected values. This is not desirable. Like in other browsers, the dropdown should only open after clicking the field an additional time.

This patch fixes the issue by removing autoFocus attribute from the input element. This has an annoying side effect in that while you now need two clicks in Safari, you need three clicks in other browsers (e.g. Firefox). Arguably a better solution would be to get rid of `<datalist>` entirely, as it is not well supported. But this quick fix should be acceptable for now.

### How to test this

Can be tested as usual. Test with different browsers, Safari and otherwise.