### PR TITLE
Fix schedule datepicker not working

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsSchedulingTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsSchedulingTab.tsx
@@ -307,7 +307,7 @@ const EventDetailsSchedulingTab = ({
 															dateFormat="P"
 															popperClassName="datepicker-custom"
 															className="datepicker-custom-input"
-															portalId="root"
+															wrapperClassName="datepicker-custom-wrapper"
 															locale={currentLanguage?.dateLocale}
 															strictParsing
 														/>

--- a/src/components/events/partials/ModalTabsAndPages/NewSourcePage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewSourcePage.tsx
@@ -422,7 +422,7 @@ const Schedule = <T extends {
 									dateFormat="P"
 									popperClassName="datepicker-custom"
 									className="datepicker-custom-input"
-									portalId="root"
+									wrapperClassName="datepicker-custom-wrapper"
 									locale={currentLanguage?.dateLocale}
 									strictParsing
 								/>
@@ -453,7 +453,7 @@ const Schedule = <T extends {
 											dateFormat="P"
 											popperClassName="datepicker-custom"
 											className="datepicker-custom-input"
-											portalId="root"
+											wrapperClassName="datepicker-custom-wrapper"
 											locale={currentLanguage?.dateLocale}
 											strictParsing
 										/>


### PR DESCRIPTION
When scheduling an event, or editing a scheduled event, the datepicker for the scheduled date would not allow users to select a date. This patch fixes that.

### How to test this

Try to schedule an event and change the date.