### PR TITLE
Fix crowdin upload branch name

### DIFF
--- a/.github/workflows/crowdin-upload-keys.yml
+++ b/.github/workflows/crowdin-upload-keys.yml
@@ -26,4 +26,4 @@ jobs:
       env:
         CROWDIN_TOKEN: ${{ secrets.CROWDIN_TOKEN }}
       run: |
-        crowdin upload sources --config .crowdin.yaml -b main
+        crowdin upload sources --config .crowdin.yaml -b "${GITHUB_REF##*/}"


### PR DESCRIPTION
Since we adapted the branching structure of the main opencast repository we do not use main anymore. This patch adapts the run command from the same workflow in the mian repo.