### PR TITLE
Fix filter cache breaking interface

### DIFF
--- a/src/selectors/tableFilterSelectors.ts
+++ b/src/selectors/tableFilterSelectors.ts
@@ -20,7 +20,7 @@ export const getFilters = createSelector(
 export const getTextFilter = createSelector(
 	[getAllTextFilter, (state, resource: Resource) => resource],
 	(textFilter, resource) => {
-		const textFilte = textFilter.find(obj => obj.resource === resource);
+		const textFilte = (textFilter || []).find(obj => obj.resource === resource);
 		return textFilte?.text ?? "";
 	},
 );


### PR DESCRIPTION
Investigating people complaining develop.opencast.org being broken, it seems like there was a change to the filters which cannot handle the previous data which might still be stored in browsers. Like here means, it completely crashes the interface and users just see a blank page.

The error they get is:

```
Uncaught TypeError: t.find is not a function
    fk tableFilterSelectors.ts:23
    D reselect.mjs:647
    i reselect.mjs:584
    P reselect.mjs:659
    i reselect.mjs:584
    u TableFilters.tsx:55
    <anonymous> Redux
    L use-sync-external-store-with-selector.production.js:40
    h use-sync-external-store-with-selector.production.js:63
    React 2
    useSyncExternalStoreWithSelector use-sync-external-store-with-selector.production.js:74
    n Redux
    qc TableFilters.tsx:55
    React 14
    K scheduler.production.js:152
tableFilterSelectors.ts:23:32
```

This patch makes the code a bit more resilient so it can deal with the previous content.

EDIT: Rebased to `r/18.x` since the problem also appears there.