### PR TITLE
Basebutton tooltip params

### DIFF
--- a/src/components/shared/BaseButton.tsx
+++ b/src/components/shared/BaseButton.tsx
@@ -30,7 +30,7 @@ const BaseButton = React.forwardRef<HTMLButtonElement, BaseButtonProps>(({
 	if (tooltipText) {
 		return (
 			<Tooltip title={tooltipParams ? t(tooltipText, tooltipParams) : t(tooltipText)}>
-			{buttonComponent}
+				{buttonComponent}
 			</Tooltip>
 		);
 	}

--- a/src/components/shared/BaseButton.tsx
+++ b/src/components/shared/BaseButton.tsx
@@ -29,8 +29,8 @@ const BaseButton = React.forwardRef<HTMLButtonElement, BaseButtonProps>(({
 
 	if (tooltipText) {
 		return (
-			<Tooltip title={tooltipParams ? t(tooltipText) : t(tooltipText, tooltipParams)}>
-				{buttonComponent}
+			<Tooltip title={tooltipParams ? t(tooltipText, tooltipParams) : t(tooltipText)}>
+			{buttonComponent}
 			</Tooltip>
 		);
 	}


### PR DESCRIPTION
This PR fixes an issue where tooltipParams were ignored when rendering the tooltip in BaseButton.
Previously, placeholders like {{filterName}} in translations were not being replaced even when tooltipParams was provided.

<img width="1916" height="196" alt="image" src="https://github.com/user-attachments/assets/41647b98-11b7-418d-82dd-65e0ca3a3f49" />
