### PR TITLE
Prevent tobira tab crash when ID is missing

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/DetailsTobiraTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/DetailsTobiraTab.tsx
@@ -60,7 +60,7 @@ const DetailsTobiraTab = ({ kind, id }: DetailsTobiraTabProps) => {
 
 	const i18nKey = kind === "series" ? "SERIES" : "EVENTS";
 	const prefix = kind === "series" ? "s" : "v";
-	const directTobiraLink = tobiraData.baseURL + `/!${prefix}/` + (tobiraData.id.length > 2 ? tobiraData.id.substring(2) : `:${id}`);
+	const directTobiraLink = tobiraData.baseURL + `/!${prefix}/` + (tobiraData.id?.length > 2 ? tobiraData.id.substring(2) : `:${id}`);
 
 	const getBreadcrumbs = (currentPage: TobiraPage) => {
 		const homepage = {
@@ -226,7 +226,7 @@ const TobiraTable = ({ tobiraData, i18nKey, openSubTab, handleDelete }: TobiraTa
 				{tobiraData.hostPages.map(hostPage => <tr key={hostPage.path}>
 					<td>
 						<a href={tobiraData.baseURL + hostPage.path +
-							(tobiraData.id.length > 2 ? `/${prefix}/${tobiraData.id.substring(2)}` : "")}>
+							(tobiraData.id?.length > 2 ? `/${prefix}/${tobiraData.id.substring(2)}` : "")}>
 							{hostPage.path !== "/" && <>
 								<span className="tobira-page-separator">/</span>
 								{hostPage.ancestors.map((ancestor, key) => (


### PR DESCRIPTION
I recently observed that in some cases, the Tobira API does not send an ID for its respective asset (i.e. video or series).
I have not been able to reproduce this anymore, so it's hard to identify the unterlying issue. But since others have reported this as well, in order to prevent this leading to crashes, this now uses optional chaining for `id` operations.

This won't break anything, it just means that in cases where the (Tobira) ID is actually missing, the Opencast ID is used in links to these assets instead.

Fixes #1403 