### PR TITLE
Use formik 'FastField' instead of 'Field' for performance reasons

### DIFF
--- a/src/components/shared/Field.tsx
+++ b/src/components/shared/Field.tsx
@@ -1,4 +1,4 @@
-import { Field as FormikField } from "formik";
+import { FastField as FormikFastField } from "formik";
 import { FieldAttributes } from "formik/dist/Field";
 
 /**
@@ -6,7 +6,7 @@ import { FieldAttributes } from "formik/dist/Field";
  */
 export const Field = (props: FieldAttributes<any>) => {
   return (
-    <FormikField
+    <FormikFastField
       {...props}
       onKeyDown={(event: KeyboardEvent) => {
         // Handler for basic html inputs to remove focus, if no custom component is passed


### PR DESCRIPTION
On an Opencast system with a large number of series (>4,000), entering text in the create or edit event dialogue box is slow. Using the formik 'FastField' instead of 'Field' improves the performance.

Fixes https://github.com/opencast/opencast-admin-interface/issues/1406