### PR TITLE
Revert 1416

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/NewAccessPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewAccessPage.tsx
@@ -29,7 +29,7 @@ import ModalContentTable from "../../../shared/modals/ModalContentTable";
  * This component renders the access page for new events and series in the wizards.
  */
 interface RequiredFormProps {
-	'dublincore/episode_isPartOf': string,
+	isPartOf: string,
 	acls: TransformedAcl[],
 	aclTemplate: string,
 	// theme: string,
@@ -77,14 +77,14 @@ const NewAccessPage = <T extends RequiredFormProps>({
 
 	// If we have to use series ACL, fetch it
 	useEffect(() => {
-		if (initEventAclWithSeriesAcl && formik.values['dublincore/episode_isPartOf']) {
-			dispatch(fetchSeriesDetailsAcls(formik.values['dublincore/episode_isPartOf']));
+		if (initEventAclWithSeriesAcl && formik.values.isPartOf) {
+			dispatch(fetchSeriesDetailsAcls(formik.values.isPartOf));
 		}
-	}, [formik.values, initEventAclWithSeriesAcl, dispatch]);
+	}, [formik.values.isPartOf, initEventAclWithSeriesAcl, dispatch]);
 
 	// If we have to use series ACL, overwrite existing rules
 	useEffect(() => {
-		if (initEventAclWithSeriesAcl && formik.values['dublincore/episode_isPartOf'] && seriesAcl) {
+		if (initEventAclWithSeriesAcl && formik.values.isPartOf && seriesAcl) {
 			formik.setFieldValue("acls", seriesAcl)
 		}
 	// eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
This PR reverts #1416, which breaks the UI when uploading an event with a series.  This was initially missed because I was looking to verify that the series ACL is the default (which does work!), and the UI isn't otherwise obviously broken.  The more subtle issue is if you try and *change* the ACL, which does *not* work and in fact throws the UI into some kind of infinite loop.
