### PR TITLE
Fix Tobira paste bug

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/NewTobiraPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewTobiraPage.tsx
@@ -213,155 +213,155 @@ const NewTobiraPage = <T extends TobiraFormProps>({
 
 	return <>
 		<ModalContent>
-				<p className="tab-description">{t("EVENTS.SERIES.NEW.TOBIRA.DESCRIPTION")}</p>
-				{!error && <>
-					<div className="obj-container padded">
-						<div className="obj">
-							<header>
-								<span>{t("EVENTS.SERIES.NEW.TOBIRA.SELECT_PAGE")}</span>
-							</header>
-							<div className="breadcrumb">
-								{formik.values.breadcrumbs.map((breadcrumb, key) => (
-									<ButtonLikeAnchor
-										key={key}
-										className="breadcrumb-link"
-										onClick={() => back(key)}
+			<p className="tab-description">{t("EVENTS.SERIES.NEW.TOBIRA.DESCRIPTION")}</p>
+			{!error && <>
+				<div className="obj-container padded">
+					<div className="obj">
+						<header>
+							<span>{t("EVENTS.SERIES.NEW.TOBIRA.SELECT_PAGE")}</span>
+						</header>
+						<div className="breadcrumb">
+							{formik.values.breadcrumbs.map((breadcrumb, key) => (
+								<ButtonLikeAnchor
+									key={key}
+									className="breadcrumb-link"
+									onClick={() => back(key)}
+								>
+									{breadcrumb.segment === ""
+										? t("EVENTS.SERIES.NEW.TOBIRA.HOMEPAGE")
+										: breadcrumb.title
+									}
+								</ButtonLikeAnchor>
+							))}
+						</div>
+						<table className="main-tbl highlight-hover">
+							<thead>
+								<tr>
+									{currentPage.children.length > 0 && <th className="small"/>}
+									<th>
+										{t("EVENTS.SERIES.NEW.TOBIRA.PAGE_TITLE") /* Title */}
+									</th>
+									<th>
+										{t("EVENTS.SERIES.NEW.TOBIRA.PATH_SEGMENT") /* Path segment */}
+									</th>
+									<th>
+										{t("EVENTS.SERIES.NEW.TOBIRA.SUBPAGES") /* Sub-pages */}
+									</th>
+									{editing && <th />}
+								</tr>
+							</thead>
+							<tbody>
+								{currentPage.children.map((page, key) => <tr key={key}>
+									<Tooltip
+										title={t("EVENTS.SERIES.NEW.TOBIRA.MOUNT_DISCLAIMER")}
+										active={!!page.blocks?.length}
+										placement="left"
 									>
-										{breadcrumb.segment === ""
-											? t("EVENTS.SERIES.NEW.TOBIRA.HOMEPAGE")
-											: breadcrumb.title
-										}
-									</ButtonLikeAnchor>
-								))}
-							</div>
-							<table className="main-tbl highlight-hover">
-								<thead>
-									<tr>
-										{currentPage.children.length > 0 && <th className="small"/>}
-										<th>
-											{t("EVENTS.SERIES.NEW.TOBIRA.PAGE_TITLE") /* Title */}
-										</th>
-										<th>
-											{t("EVENTS.SERIES.NEW.TOBIRA.PATH_SEGMENT") /* Path segment */}
-										</th>
-										<th>
-											{t("EVENTS.SERIES.NEW.TOBIRA.SUBPAGES") /* Sub-pages */}
-										</th>
-										{editing && <th />}
-									</tr>
-								</thead>
-								<tbody>
-									{currentPage.children.map((page, key) => <tr key={key}>
-										<Tooltip
-											title={t("EVENTS.SERIES.NEW.TOBIRA.MOUNT_DISCLAIMER")}
-											active={!!page.blocks?.length}
-											placement="left"
-										>
-											<td>
-												<input
-													type="checkbox"
-													checked={checkboxActive(page, key)}
-													disabled={!!page.blocks?.length}
-													onChange={() => page.blocks?.length || select(page)}
-												/>
-											</td>
-										</Tooltip>
 										<td>
+											<input
+												type="checkbox"
+												checked={checkboxActive(page, key)}
+												disabled={!!page.blocks?.length}
+												onChange={() => page.blocks?.length || select(page)}
+											/>
+										</td>
+									</Tooltip>
+									<td>
+										{page.new
+											? <input
+												placeholder={t("EVENTS.SERIES.NEW.TOBIRA.PAGE_TITLE")}
+												disabled={checkboxActive(page, key)}
+												value={checkboxActive(page, key)
+													? t("EVENTS.SERIES.NEW.TOBIRA.TITLE_OF_SERIES")
+													: (page.title ?? "")
+												}
+												onChange={e => setPage(key, e, "title")}
+											/>
+											: <ButtonLikeAnchor
+												className={
+													(!page.blocks?.length
+														? "tobira-selectable"
+														: "tobira-button-disabled"
+													)
+												}
+												disabled={!!page.blocks?.length}
+												onClick={() => page.blocks?.length || select(page)}
+											>{checkboxActive(page, key) && formik.values.selectedPage
+												? t("EVENTS.SERIES.NEW.TOBIRA.TITLE_OF_SERIES")
+												: page.title
+											}</ButtonLikeAnchor>
+										}
+									</td>
+									<td>
+										<code className="tobira-path">
 											{page.new
 												? <input
-													placeholder={t("EVENTS.SERIES.NEW.TOBIRA.PAGE_TITLE")}
-													disabled={checkboxActive(page, key)}
-													value={checkboxActive(page, key)
-														? t("EVENTS.SERIES.NEW.TOBIRA.TITLE_OF_SERIES")
-														: (page.title ?? "")
-													}
-													onChange={e => setPage(key, e, "title")}
+													placeholder={t("EVENTS.SERIES.NEW.TOBIRA.PATH_SEGMENT")}
+													value={page.segment ?? ""}
+													onChange={e => setPage(key, e, "segment")}
 												/>
-												: <ButtonLikeAnchor
-													className={
-														(!page.blocks?.length
-															? "tobira-selectable"
-															: "tobira-button-disabled"
-														)
-													}
-													disabled={!!page.blocks?.length}
-													onClick={() => page.blocks?.length || select(page)}
-												>{checkboxActive(page, key) && formik.values.selectedPage
-													? t("EVENTS.SERIES.NEW.TOBIRA.TITLE_OF_SERIES")
-													: page.title
-												}</ButtonLikeAnchor>
+												: <span style={{ fontWeight: "inherit" }}>
+													{page.segment}
+												</span>
 											}
-										</td>
-										<td>
-											<code className="tobira-path">
-												{page.new
-													? <input
-														placeholder={t("EVENTS.SERIES.NEW.TOBIRA.PATH_SEGMENT")}
-														value={page.segment ?? ""}
-														onChange={e => setPage(key, e, "segment")}
-													/>
-													: <span style={{ fontWeight: "inherit" }}>
-														{page.segment}
-													</span>
-												}
-											</code>
-										</td>
-										<td>
-											{((!page.new || isValid) && page.title) && <ButtonLikeAnchor
-												className="details-link"
-												onClick={() => goto(page)}
-											>
-												{t("EVENTS.SERIES.NEW.TOBIRA.SUBPAGES")}
-											</ButtonLikeAnchor>}
-										</td>
-										{editing && <td>
-											{page.new && <ButtonLikeAnchor
-												onClick={() => {
-													dispatch(setTobiraPage({
-														...currentPage,
-														children: currentPage.children.filter((_, idx) => (
-															idx !== currentPage.children.length - 1
-														)),
-													}));
-													select(undefined);
-												}}
-												title={t("EVENTS.SERIES.NEW.TOBIRA.CANCEL")}
-												className="remove"
-											/>}
-										</td>}
-									</tr>)}
-									{!editing && <tr>
-										<td colSpan={4}>
-											<ButtonLikeAnchor
-												onClick={() => addChild()}
-											>
-												+ {t("EVENTS.SERIES.NEW.TOBIRA.ADD_SUBPAGE")}
-											</ButtonLikeAnchor>
-										</td>
-									</tr>}
-								</tbody>
-							</table>
-						</div>
-						{/* Notifications */}
-						<Notifications context={NOTIFICATION_CONTEXT_TOBIRA} />
+										</code>
+									</td>
+									<td>
+										{((!page.new || isValid) && page.title) && <ButtonLikeAnchor
+											className="details-link"
+											onClick={() => goto(page)}
+										>
+											{t("EVENTS.SERIES.NEW.TOBIRA.SUBPAGES")}
+										</ButtonLikeAnchor>}
+									</td>
+									{editing && <td>
+										{page.new && <ButtonLikeAnchor
+											onClick={() => {
+												dispatch(setTobiraPage({
+													...currentPage,
+													children: currentPage.children.filter((_, idx) => (
+														idx !== currentPage.children.length - 1
+													)),
+												}));
+												select(undefined);
+											}}
+											title={t("EVENTS.SERIES.NEW.TOBIRA.CANCEL")}
+											className="remove"
+										/>}
+									</td>}
+								</tr>)}
+								{!editing && <tr>
+									<td colSpan={4}>
+										<ButtonLikeAnchor
+											onClick={() => addChild()}
+										>
+											+ {t("EVENTS.SERIES.NEW.TOBIRA.ADD_SUBPAGE")}
+										</ButtonLikeAnchor>
+									</td>
+								</tr>}
+							</tbody>
+						</table>
 					</div>
+					{/* Notifications */}
+					<Notifications context={NOTIFICATION_CONTEXT_TOBIRA} />
+				</div>
 
-					<p style={{ margin: "12px 0", fontSize: 12 }}>
-						{(!!formik.values.selectedPage && formik.values.selectedPage?.path !== "" && isValid)
-							? <>
-								{t("EVENTS.SERIES.NEW.TOBIRA.SELECTED_PAGE")}:
-								<code className="tobira-path">
-									{formik.values.selectedPage?.path}
-								</code>
-							</>
-							: (mode.edit && !mode.mount
-								? t("EVENTS.SERIES.NEW.TOBIRA.NO_PAGE_SELECTED_EDIT")
-								: t("EVENTS.SERIES.NEW.TOBIRA.NO_PAGE_SELECTED")
-							)
-						}
-					</p>
-					{!mode.edit && <p style={{ fontSize: 12 }}>{t("EVENTS.SERIES.NEW.TOBIRA.DIRECT_LINK")}</p>}
-				</>}
+				<p style={{ margin: "12px 0", fontSize: 12 }}>
+					{(!!formik.values.selectedPage && formik.values.selectedPage?.path !== "" && isValid)
+						? <>
+							{t("EVENTS.SERIES.NEW.TOBIRA.SELECTED_PAGE")}:
+							<code className="tobira-path">
+								{formik.values.selectedPage?.path}
+							</code>
+						</>
+						: (mode.edit && !mode.mount
+							? t("EVENTS.SERIES.NEW.TOBIRA.NO_PAGE_SELECTED_EDIT")
+							: t("EVENTS.SERIES.NEW.TOBIRA.NO_PAGE_SELECTED")
+						)
+					}
+				</p>
+				{!mode.edit && <p style={{ fontSize: 12 }}>{t("EVENTS.SERIES.NEW.TOBIRA.DIRECT_LINK")}</p>}
+			</>}
 		</ModalContent>
 		{/* Render buttons for saving or resetting updated path */}
 		{mode.edit && <SaveEditFooter

--- a/src/components/events/partials/ModalTabsAndPages/NewTobiraPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewTobiraPage.tsx
@@ -188,7 +188,7 @@ const NewTobiraPage = <T extends TobiraFormProps>({
 					...kind === "title"
 						? { title: e.target.value }
 						: {
-							path: updatePath(p, e.target.value),
+							path: updatePath({ ...p, segment: e.target.value }, e.target.value),
 							segment: e.target.value,
 						},
 				};


### PR DESCRIPTION
Fixes an issue where pasting a value in the Tobira path segment input would not register that value when submitting the form.

For reviewing: Either turn off white space changes or ignore the first commit, which fixes the indentation of a large code block.