### PR TITLE
Disable tooltips on tables due to performance issues

### DIFF
--- a/src/components/configuration/partials/ThemesActionsCell.tsx
+++ b/src/components/configuration/partials/ThemesActionsCell.tsx
@@ -48,7 +48,7 @@ const ThemesActionsCell = ({
 				onClick={() => showThemeDetails()}
 				className={"more"}
 				editAccessRole={"ROLE_UI_THEMES_EDIT"}
-				tooltipText={"CONFIGURATION.THEMES.TABLE.TOOLTIP.DETAILS"}
+				// tooltipText={"CONFIGURATION.THEMES.TABLE.TOOLTIP.DETAILS"} // Disabled due to performance concerns
 			/>
 
 			{/* themes details modal */}
@@ -64,7 +64,7 @@ const ThemesActionsCell = ({
 			{/* delete themes */}
 			<ActionCellDelete
 				editAccessRole={"ROLE_UI_THEMES_DELETE"}
-				tooltipText={"CONFIGURATION.THEMES.TABLE.TOOLTIP.DELETE"}
+				// tooltipText={"CONFIGURATION.THEMES.TABLE.TOOLTIP.DELETE"} // Disabled due to performance concerns
 				resourceId={row.id}
 				resourceName={row.name}
 				resourceType={"THEME"}

--- a/src/components/events/partials/EventActionCell.tsx
+++ b/src/components/events/partials/EventActionCell.tsx
@@ -95,7 +95,7 @@ const EventActionCell = ({
 				onClick={onClickEventDetails}
 				className={"more"}
 				editAccessRole={"ROLE_UI_EVENTS_DETAILS_VIEW"}
-				tooltipText={"EVENTS.EVENTS.TABLE.TOOLTIP.DETAILS"}
+				// tooltipText={"EVENTS.EVENTS.TABLE.TOOLTIP.DETAILS"} // Disabled due to performance concerns
 			/>
 
 			{/* If event belongs to a series then the corresponding series details can be opened */}
@@ -104,14 +104,14 @@ const EventActionCell = ({
 					onClick={onClickSeriesDetails}
 					className={"more-series"}
 					editAccessRole={"ROLE_UI_SERIES_DETAILS_VIEW"}
-					tooltipText={"EVENTS.SERIES.TABLE.TOOLTIP.DETAILS"}
+					// tooltipText={"EVENTS.SERIES.TABLE.TOOLTIP.DETAILS"} // Disabled due to performance concerns
 				/>
 			)}
 
 			{/* Delete an event */}
 			<ActionCellDelete
 				editAccessRole={"ROLE_UI_EVENTS_DELETE"}
-				tooltipText={"EVENTS.EVENTS.TABLE.TOOLTIP.DELETE"}
+				// tooltipText={"EVENTS.EVENTS.TABLE.TOOLTIP.DELETE"} // Disabled due to performance concerns
 				resourceId={row.id}
 				resourceName={row.title}
 				resourceType={"EVENT"}
@@ -120,13 +120,13 @@ const EventActionCell = ({
 
 			{/* If the event has an preview then the editor can be opened and status if it needs to be cut is shown */}
 			{!!row.has_preview && hasAccess("ROLE_UI_EVENTS_EDITOR_VIEW", user) && (
-				<Tooltip
-					title={
-						row.needs_cutting
-							? t("EVENTS.EVENTS.TABLE.TOOLTIP.EDITOR_NEEDS_CUTTING")
-							: t("EVENTS.EVENTS.TABLE.TOOLTIP.EDITOR")
-					}
-				>
+				// <Tooltip // Disabled due to performance concerns
+				// 	title={
+				// 		row.needs_cutting
+				// 			? t("EVENTS.EVENTS.TABLE.TOOLTIP.EDITOR_NEEDS_CUTTING")
+				// 			: t("EVENTS.EVENTS.TABLE.TOOLTIP.EDITOR")
+				// 	}
+				// >
 					<a
 						href={`/editor-ui/index.html?id=${row.id}`}
 						className="cut"
@@ -134,7 +134,7 @@ const EventActionCell = ({
 					>
 						{row.needs_cutting && <span id="badge" className="badge" />}
 					</a>
-				</Tooltip>
+				// </Tooltip>
 			)}
 
 			{/* If the event has comments and no open comments then the comment tab of event details can be opened directly */}
@@ -142,7 +142,7 @@ const EventActionCell = ({
 				<ButtonLikeAnchor
 					onClick={() => onClickComments()}
 					className={"comments"}
-					tooltipText={"EVENTS.EVENTS.TABLE.TOOLTIP.COMMENTS"}
+					// tooltipText={"EVENTS.EVENTS.TABLE.TOOLTIP.COMMENTS"} // Disabled due to performance concerns
 				/>
 			)}
 
@@ -151,7 +151,7 @@ const EventActionCell = ({
 				<ButtonLikeAnchor
 					onClick={() => onClickComments()}
 					className={"comments-open"}
-					tooltipText={"EVENTS.EVENTS.TABLE.TOOLTIP.COMMENTS"}
+					// tooltipText={"EVENTS.EVENTS.TABLE.TOOLTIP.COMMENTS"} // Disabled due to performance concerns
 				/>
 			)}
 
@@ -162,7 +162,7 @@ const EventActionCell = ({
 					onClick={() => onClickWorkflow()}
 					className={"fa fa-warning"}
 					editAccessRole={"ROLE_UI_EVENTS_DETAILS_WORKFLOWS_EDIT"}
-					tooltipText={"EVENTS.EVENTS.TABLE.TOOLTIP.PAUSED_WORKFLOW"}
+					// tooltipText={"EVENTS.EVENTS.TABLE.TOOLTIP.PAUSED_WORKFLOW"} // Disabled due to performance concerns
 				/>
 			}
 
@@ -171,7 +171,7 @@ const EventActionCell = ({
 				onClick={() => onClickAssets()}
 				className={"fa fa-folder-open"}
 				editAccessRole={"ROLE_UI_EVENTS_DETAILS_ASSETS_VIEW"}
-				tooltipText={"EVENTS.EVENTS.TABLE.TOOLTIP.ASSETS"}
+				// tooltipText={"EVENTS.EVENTS.TABLE.TOOLTIP.ASSETS"} // Disabled due to performance concerns
 			/>
 
 			{/* Open dialog for embedded code*/}
@@ -179,7 +179,7 @@ const EventActionCell = ({
 				onClick={() => showEmbeddingCodeModal()}
 				className={"fa fa-link"}
 				editAccessRole={"ROLE_UI_EVENTS_EMBEDDING_CODE_VIEW"}
-				tooltipText={"EVENTS.EVENTS.TABLE.TOOLTIP.EMBEDDING_CODE"}
+				// tooltipText={"EVENTS.EVENTS.TABLE.TOOLTIP.EMBEDDING_CODE"} // Disabled due to performance concerns
 			/>
 
 			{/* Embedding Code Modal */}

--- a/src/components/events/partials/EventsDateCell.tsx
+++ b/src/components/events/partials/EventsDateCell.tsx
@@ -19,7 +19,7 @@ const EventsDateCell = ({
 			filterName="startDate"
 			fetchResource={fetchEvents}
 			loadResourceIntoTable={loadEventsIntoTable}
-			tooltipText="EVENTS.EVENTS.TABLE.TOOLTIP.START"
+			// tooltipText="EVENTS.EVENTS.TABLE.TOOLTIP.START" // Disabled due to performance concerns
 		/>
 	);
 };

--- a/src/components/events/partials/EventsLocationCell.tsx
+++ b/src/components/events/partials/EventsLocationCell.tsx
@@ -34,7 +34,7 @@ const EventsLocationCell = ({
 		<ButtonLikeAnchor
 			onClick={() => addFilter(row.location)}
 			className={"crosslink"}
-			tooltipText={"EVENTS.EVENTS.TABLE.TOOLTIP.LOCATION"}
+			// tooltipText={"EVENTS.EVENTS.TABLE.TOOLTIP.LOCATION"} // Disabled due to performance concerns
 		>
 			{row.location}
 		</ButtonLikeAnchor>

--- a/src/components/events/partials/EventsPresentersCell.tsx
+++ b/src/components/events/partials/EventsPresentersCell.tsx
@@ -19,7 +19,7 @@ const EventsPresentersCell = ({
 			filterName="presentersBibliographic"
 			fetchResource={fetchEvents}
 			loadResourceIntoTable={loadEventsIntoTable}
-			tooltipText="EVENTS.EVENTS.TABLE.TOOLTIP.PRESENTER"
+			// tooltipText="EVENTS.EVENTS.TABLE.TOOLTIP.PRESENTER"  // Disabled due to performance concerns
 		/>
 	);
 };

--- a/src/components/events/partials/EventsSeriesCell.tsx
+++ b/src/components/events/partials/EventsSeriesCell.tsx
@@ -38,7 +38,7 @@ const EventsSeriesCell = ({
 					: console.error("Tried to sort by a series, but the series did not exist.")
 				}
 				className={"crosslink"}
-				tooltipText={"EVENTS.EVENTS.TABLE.TOOLTIP.SERIES"}
+				// tooltipText={"EVENTS.EVENTS.TABLE.TOOLTIP.SERIES"} // Disabled due to performance concerns
 			>
 				{row.series.title}
 			</ButtonLikeAnchor>

--- a/src/components/events/partials/EventsStatusCell.tsx
+++ b/src/components/events/partials/EventsStatusCell.tsx
@@ -45,7 +45,7 @@ const EventsStatusCell = ({
 		<ButtonLikeAnchor
 			onClick={() => openStatusModal()}
 			className={"crosslink"}
-			tooltipText={"EVENTS.EVENTS.TABLE.TOOLTIP.STATUS"}
+			// tooltipText={"EVENTS.EVENTS.TABLE.TOOLTIP.STATUS"}  // Disabled due to performance concerns
 		>
 			{t(row.displayable_status as ParseKeys)}
 		</ButtonLikeAnchor>

--- a/src/components/events/partials/EventsTechnicalDateCell.tsx
+++ b/src/components/events/partials/EventsTechnicalDateCell.tsx
@@ -37,7 +37,7 @@ const EventsTechnicalDateCell = ({
 		<ButtonLikeAnchor
 			onClick={() => addFilter(row.date)}
 			className={"crosslink"}
-			tooltipText={"EVENTS.EVENTS.TABLE.TOOLTIP.START"}
+			// tooltipText={"EVENTS.EVENTS.TABLE.TOOLTIP.START"} // Disabled due to performance concerns
 		>
 			{t("dateFormats.date.short", { date: renderValidDate(row.technical_start) })}
 		</ButtonLikeAnchor>

--- a/src/components/events/partials/PublishedCell.tsx
+++ b/src/components/events/partials/PublishedCell.tsx
@@ -78,13 +78,13 @@ const PublishCell = ({
 	return (
 		<div className="popover-wrapper">
 			{onlyEngage && (
-				<Tooltip title={t("EVENTS.EVENTS.TABLE.TOOLTIP.PLAYER")}>
+				// <Tooltip title={t("EVENTS.EVENTS.TABLE.TOOLTIP.PLAYER")}> // Disabled due to performance concerns
 					<a href={publications[0].url} rel="noreferrer" target="_blank">
 						<ButtonLikeAnchor>
 							{t("YES")}
 						</ButtonLikeAnchor>
 					</a>
-				</Tooltip>
+				// </Tooltip>
 			)}
 			{!onlyEngage && publications.length > 0 && (
 				<>

--- a/src/components/events/partials/SeriesActionsCell.tsx
+++ b/src/components/events/partials/SeriesActionsCell.tsx
@@ -70,7 +70,7 @@ const SeriesActionsCell = ({
 				onClick={() => showSeriesDetailsModal()}
 				className={"more-series"}
 				editAccessRole={"ROLE_UI_SERIES_DETAILS_VIEW"}
-				tooltipText={"EVENTS.SERIES.TABLE.TOOLTIP.DETAILS"}
+				// tooltipText={"EVENTS.SERIES.TABLE.TOOLTIP.DETAILS"} // Disabled due to performance concerns
 			/>
 
 			<SeriesDetailsModal
@@ -84,7 +84,7 @@ const SeriesActionsCell = ({
 				onClick={() => showDeleteConfirmation()}
 				className={"remove"}
 				editAccessRole={"ROLE_UI_SERIES_DELETE"}
-				tooltipText={"EVENTS.SERIES.TABLE.TOOLTIP.DELETE"}
+				// tooltipText={"EVENTS.SERIES.TABLE.TOOLTIP.DELETE"} // Disabled due to performance concerns
 			/>
 
 			<ConfirmModal

--- a/src/components/events/partials/SeriesContributorsCell.tsx
+++ b/src/components/events/partials/SeriesContributorsCell.tsx
@@ -18,7 +18,7 @@ const SeriesContributorsCell = ({
 			filterName="contributors"
 			fetchResource={fetchSeries}
 			loadResourceIntoTable={loadSeriesIntoTable}
-			tooltipText="EVENTS.SERIES.TABLE.TOOLTIP.CONTRIBUTORS"
+			// tooltipText="EVENTS.SERIES.TABLE.TOOLTIP.CONTRIBUTORS" // Disabled due to performance concerns
 		/>
 	);
 };

--- a/src/components/events/partials/SeriesDateTimeCell.tsx
+++ b/src/components/events/partials/SeriesDateTimeCell.tsx
@@ -22,7 +22,7 @@ const SeriesDateTimeCell = ({
 						filterName="CreationDate"
 						fetchResource={fetchSeries}
 						loadResourceIntoTable={loadSeriesIntoTable}
-						tooltipText="EVENTS.SERIES.TABLE.TOOLTIP.CREATION"
+						// tooltipText="EVENTS.SERIES.TABLE.TOOLTIP.CREATION" // Disabled due to performance concerns
 					/>
 				);
 			})()}

--- a/src/components/events/partials/SeriesOrganizersCell.tsx
+++ b/src/components/events/partials/SeriesOrganizersCell.tsx
@@ -18,7 +18,7 @@ const SeriesOrganizersCell = ({
 				filterName="organizers"
 				fetchResource={fetchSeries}
 				loadResourceIntoTable={loadSeriesIntoTable}
-				tooltipText="EVENTS.SERIES.TABLE.TOOLTIP.ORGANIZER"
+				// tooltipText="EVENTS.SERIES.TABLE.TOOLTIP.ORGANIZER" // Disabled due to performance concerns
 			/>
 		);
 };

--- a/src/components/events/partials/SeriesTitleCell.tsx
+++ b/src/components/events/partials/SeriesTitleCell.tsx
@@ -25,7 +25,7 @@ const SeriesTitleCell = ({
 	return (
 		<BaseButton
 			className="button-like-anchor crosslink"
-			tooltipText={"EVENTS.SERIES.TABLE.TOOLTIP.SERIES"}
+			// tooltipText={"EVENTS.SERIES.TABLE.TOOLTIP.SERIES"} // Disabled due to performance concerns
 			onClick={() => redirectToEvents(row.id)}
 		>
 			{row.title}

--- a/src/components/recordings/partials/RecordingsActionCell.tsx
+++ b/src/components/recordings/partials/RecordingsActionCell.tsx
@@ -36,7 +36,7 @@ const RecordingsActionCell = ({
 				onClick={() => showRecordingDetails()}
 				className={"more"}
 				editAccessRole={"ROLE_UI_LOCATIONS_DETAILS_VIEW"}
-				tooltipText={"RECORDINGS.RECORDINGS.TABLE.TOOLTIP.DETAILS"}
+				// tooltipText={"RECORDINGS.RECORDINGS.TABLE.TOOLTIP.DETAILS"} // Disabled due to performance concerns
 			/>
 
 			<RecordingDetailsModal
@@ -47,7 +47,7 @@ const RecordingsActionCell = ({
 			{/* delete location/recording */}
 			<ActionCellDelete
 				editAccessRole={"ROLE_UI_LOCATIONS_DELETE"}
-				tooltipText={"RECORDINGS.RECORDINGS.TABLE.TOOLTIP.DELETE"}
+				// tooltipText={"RECORDINGS.RECORDINGS.TABLE.TOOLTIP.DELETE"} // Disabled due to performance concerns
 				resourceId={row.name}
 				resourceName={row.name}
 				resourceType={"LOCATION"}

--- a/src/components/recordings/partials/RecordingsNameCell.tsx
+++ b/src/components/recordings/partials/RecordingsNameCell.tsx
@@ -25,7 +25,7 @@ const RecordingsNameCell = ({
 	return (
 		<BaseButton
 			className="button-like-anchor crosslink"
-			tooltipText={"RECORDINGS.RECORDINGS.TABLE.TOOLTIP.NAME"}
+			// tooltipText={"RECORDINGS.RECORDINGS.TABLE.TOOLTIP.NAME"} // Disabled due to performance concerns
 			onClick={() => redirectToEvents(row.name)}
 		>
 			{row.name}

--- a/src/components/shared/ActionCellDelete.tsx
+++ b/src/components/shared/ActionCellDelete.tsx
@@ -17,7 +17,7 @@ export const ActionCellDelete = <T, >({
 	deleteWithCautionMessage,
 }: {
 	editAccessRole: string
-	tooltipText: ParseKeys
+	tooltipText?: ParseKeys
 	resourceId: T
 	resourceName: string
 	resourceType: ResourceType

--- a/src/components/shared/DateTimeCell.tsx
+++ b/src/components/shared/DateTimeCell.tsx
@@ -25,7 +25,7 @@ const DateTimeCell = ({
 	filterName: string
 	fetchResource: AsyncThunk<any, void, any>
 	loadResourceIntoTable: () => AppThunk
-	tooltipText: ParseKeys
+	tooltipText?: ParseKeys
 }) => {
 	const { t } = useTranslation();
 	const dispatch = useAppDispatch();

--- a/src/components/shared/MultiValueCell.tsx
+++ b/src/components/shared/MultiValueCell.tsx
@@ -23,7 +23,7 @@ const MultiValueCell = ({
 	filterName: string
 	fetchResource: AsyncThunk<any, void, any>
 	loadResourceIntoTable: () => AppThunk
-	tooltipText: ParseKeys,
+	tooltipText?: ParseKeys,
 }) => {
 	const dispatch = useAppDispatch();
 

--- a/src/components/systems/partials/ServicesActionsCell.tsx
+++ b/src/components/systems/partials/ServicesActionsCell.tsx
@@ -26,7 +26,7 @@ const ServicesActionCell = ({
 				onClick={() => onClickRestart()}
 				className={"sanitize fa fa-undo"}
 				editAccessRole={"ROLE_UI_SERVICES_STATUS_EDIT"}
-				tooltipText={"SYSTEMS.SERVICES.TABLE.SANITIZE"}
+				// tooltipText={"SYSTEMS.SERVICES.TABLE.SANITIZE"} // Disabled due to performance concerns
 			/>
 		) : <></>
 	);

--- a/src/components/users/partials/AclsActionsCell.tsx
+++ b/src/components/users/partials/AclsActionsCell.tsx
@@ -42,7 +42,7 @@ const AclsActionsCell = ({
 				onClick={showAclDetails}
 				className={"more"}
 				editAccessRole={"ROLE_UI_ACLS_EDIT"}
-				tooltipText={"USERS.ACLS.TABLE.TOOLTIP.DETAILS"}
+				// tooltipText={"USERS.ACLS.TABLE.TOOLTIP.DETAILS"} // Disabled due to performance concerns
 			/>
 
 			{/* ACL details modal */}
@@ -58,7 +58,7 @@ const AclsActionsCell = ({
 			{/* delete ACL */}
 			<ActionCellDelete
 				editAccessRole={"ROLE_UI_ACLS_DELETE"}
-				tooltipText={"USERS.ACLS.TABLE.TOOLTIP.DELETE"}
+				// tooltipText={"USERS.ACLS.TABLE.TOOLTIP.DELETE"} // Disabled due to performance concerns
 				resourceId={row.id}
 				resourceName={row.name}
 				resourceType={"ACL"}

--- a/src/components/users/partials/GroupsActionsCell.tsx
+++ b/src/components/users/partials/GroupsActionsCell.tsx
@@ -40,7 +40,7 @@ const GroupsActionsCell = ({
 				onClick={() => showGroupDetails()}
 				className={"more"}
 				editAccessRole={"ROLE_UI_GROUPS_EDIT"}
-				tooltipText={"USERS.GROUPS.TABLE.TOOLTIP.DETAILS"}
+				// tooltipText={"USERS.GROUPS.TABLE.TOOLTIP.DETAILS"} // Disabled due to performance concerns
 			/>
 			{/*modal displaying details about group*/}
 			<GroupDetailsModal
@@ -52,7 +52,7 @@ const GroupsActionsCell = ({
 			{/* delete group */}
 			<ActionCellDelete
 				editAccessRole={"ROLE_UI_GROUPS_DELETE"}
-				tooltipText={"USERS.GROUPS.TABLE.TOOLTIP.DELETE"}
+				// tooltipText={"USERS.GROUPS.TABLE.TOOLTIP.DELETE"} // Disabled due to performance concerns
 				resourceId={row.id}
 				resourceName={row.name}
 				resourceType={"GROUP"}

--- a/src/components/users/partials/UsersActionsCell.tsx
+++ b/src/components/users/partials/UsersActionsCell.tsx
@@ -42,7 +42,7 @@ const UsersActionCell = ({
 				onClick={() => showUserDetails()}
 				className={"more"}
 				editAccessRole={"ROLE_UI_USERS_EDIT"}
-				tooltipText={"USERS.USERS.TABLE.TOOLTIP.DETAILS"}
+				// tooltipText={"USERS.USERS.TABLE.TOOLTIP.DETAILS"} // Disabled due to performance concerns
 			/>
 
 			{/* user details modal */}
@@ -58,7 +58,7 @@ const UsersActionCell = ({
 			{(row.manageable || (row.provider !== "opencast" && row.provider !== "system")) &&
 				<ActionCellDelete
 					editAccessRole={"ROLE_UI_USERS_DELETE"}
-					tooltipText={"USERS.USERS.TABLE.TOOLTIP.DELETE"}
+					// tooltipText={"USERS.USERS.TABLE.TOOLTIP.DELETE"} // Disabled due to performance concerns
 					resourceId={row.username}
 					resourceName={row.name}
 					resourceType={"USER"}


### PR DESCRIPTION
This commit disables tooltips for all table cells. For example, when moving the mouse over the red X in the events table, there will no longer be a tooltip showing. This is done to improve performance.

It appears that the mui tooltip component is not performant when used in large quantities. According to this comment on github it is not supposed to be:
https://github.com/mui/material-ui/issues/27057#issuecomment-880236030

I locally tested performance by profiling the rendering of the rows of the series table. The table had 1000 entries which necessitated 4000 tooltip components. Rendering the table with tooltips took about 3,7 seconds. Rendering the table without tooltips took about 1,2 seconds. I think this is way too much time for tooltips.

The goal of this commit is to be a quick fix for quick gains. A more proper long term solution would let us keep the tooltips, by for example working around the issue somehow or replacing mui tooltips with a different library.

### How to test this

Have an Opencast backend that provides 1000 events or series to the admin interface. For series, you can currently also use develop.opencast.org as your Opencast backend. Then check how long the respective table takes to load with and without this PR. The difference should be noticable even without any time measurements.