### PR TITLE
Remove unnecessary html tags from table cells

### DIFF
--- a/src/components/configuration/partials/ThemesDateTimeCell.tsx
+++ b/src/components/configuration/partials/ThemesDateTimeCell.tsx
@@ -15,11 +15,11 @@ const ThemesDateTimeCell = ({
 
 	return (
 		// Link template for creation date of themes
-		<span>
+		<>
 			{t("dateFormats.date.short", {
 				date: row.creationDate ? renderValidDate(row.creationDate) : "",
 			})}
-		</span>
+		</>
 	);
 };
 

--- a/src/components/events/partials/EventsEndCell.tsx
+++ b/src/components/events/partials/EventsEndCell.tsx
@@ -15,7 +15,7 @@ const EventsEndCell = ({
 
 	return (
 		// Link template for start date of event
-		<span>{t("dateFormats.time.short", { time: renderValidDate(row.end_date) })}</span>
+		<>{t("dateFormats.time.short", { time: renderValidDate(row.end_date) })}</>
 	);
 };
 export default EventsEndCell;

--- a/src/components/events/partials/EventsLocationCell.tsx
+++ b/src/components/events/partials/EventsLocationCell.tsx
@@ -30,14 +30,18 @@ const EventsLocationCell = ({
 	};
 
 	return (
-		// Link template for location of event
-		<ButtonLikeAnchor
-			onClick={() => addFilter(row.location)}
-			className={"crosslink"}
-			// tooltipText={"EVENTS.EVENTS.TABLE.TOOLTIP.LOCATION"} // Disabled due to performance concerns
-		>
-			{row.location}
-		</ButtonLikeAnchor>
+		<>
+			{ row.location &&
+				// Link template for location of event
+				<ButtonLikeAnchor
+					onClick={() => addFilter(row.location)}
+					className={"crosslink"}
+					// tooltipText={"EVENTS.EVENTS.TABLE.TOOLTIP.LOCATION"} // Disabled due to performance concerns
+				>
+					{row.location}
+				</ButtonLikeAnchor>
+			}
+		</>
 	);
 };
 

--- a/src/components/events/partials/EventsStartCell.tsx
+++ b/src/components/events/partials/EventsStartCell.tsx
@@ -15,9 +15,7 @@ const EventsStartCell = ({
 
 	return (
 		// Link template for start date of event
-		<span>
-			{t("dateFormats.time.short", { time: renderValidDate(row.start_date) })}
-		</span>
+		<>{t("dateFormats.time.short", { time: renderValidDate(row.start_date) })}</>
 	);
 };
 

--- a/src/components/events/partials/PublishedCell.tsx
+++ b/src/components/events/partials/PublishedCell.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Event } from "../../../slices/eventSlice";
-import { Tooltip } from "../../shared/Tooltip";
 import ButtonLikeAnchor from "../../shared/ButtonLikeAnchor";
 import { enrichPublications } from "../../../thunks/assetsThunks";
 import { useAppDispatch } from "../../../store";
@@ -76,52 +75,54 @@ const PublishCell = ({
 		&& publications[0].id === 'engage-player';
 
 	return (
-		<div className="popover-wrapper">
-			{onlyEngage && (
-				// <Tooltip title={t("EVENTS.EVENTS.TABLE.TOOLTIP.PLAYER")}> // Disabled due to performance concerns
-					<a href={publications[0].url} rel="noreferrer" target="_blank">
-						<ButtonLikeAnchor>
-							{t("YES")}
-						</ButtonLikeAnchor>
-					</a>
-				// </Tooltip>
-			)}
-			{!onlyEngage && publications.length > 0 && (
-				<>
-					<ButtonLikeAnchor className="popover-wrapper__trigger">
-						<span onClick={() => setShowPopup(!showPopup)}>{t("YES")}</span>
-					</ButtonLikeAnchor>
-					{showPopup && (
-						<div className="js-popover popover" ref={containerPublications}>
-							<div className="popover__header" />
-							<div className="popover__content">
-								{/* Show a list item for each publication of an event that isn't hidden*/}
-								{publications.map((publication, key) =>
-									!publication.hide ? (
-										// Check if publications is enabled and choose icon according
-										publication.enabled ? (
-											<a
-												href={publication.url}
-												className="popover__list-item"
-												target="_blank"
-												rel="noreferrer"
-												key={key}
-											>
-												<span>{publication.label ? t(publication.label as ParseKeys) : t(publication.name as ParseKeys)}</span>
-											</a>
-										) : (
-											<ButtonLikeAnchor key={key} className="popover__list-item">
-												<span>{publication.label ? t(publication.label as ParseKeys) : t(publication.name as ParseKeys)}</span>
-											</ButtonLikeAnchor>
-										)
-									) : null
-								)}
-							</div>
-						</div>
+		<>
+			{ publications.length > 0 &&
+				<div className="popover-wrapper">
+					{onlyEngage && (
+						// <Tooltip title={t("EVENTS.EVENTS.TABLE.TOOLTIP.PLAYER")}> // Disabled due to performance concerns
+							<a className="crosslink" href={publications[0].url} rel="noreferrer" target="_blank">
+								{t("YES")}
+							</a>
+						// </Tooltip>
 					)}
-				</>
-			)}
-		</div>
+					{!onlyEngage &&
+						<>
+							<ButtonLikeAnchor className="popover-wrapper__trigger">
+								<span onClick={() => setShowPopup(!showPopup)}>{t("YES")}</span>
+							</ButtonLikeAnchor>
+							{showPopup && (
+								<div className="js-popover popover" ref={containerPublications}>
+									<div className="popover__header" />
+									<div className="popover__content">
+										{/* Show a list item for each publication of an event that isn't hidden*/}
+										{publications.map((publication, key) =>
+											!publication.hide ? (
+												// Check if publications is enabled and choose icon according
+												publication.enabled ? (
+													<a
+														href={publication.url}
+														className="popover__list-item"
+														target="_blank"
+														rel="noreferrer"
+														key={key}
+													>
+														<span>{publication.label ? t(publication.label as ParseKeys) : t(publication.name as ParseKeys)}</span>
+													</a>
+												) : (
+													<ButtonLikeAnchor key={key} className="popover__list-item">
+														<span>{publication.label ? t(publication.label as ParseKeys) : t(publication.name as ParseKeys)}</span>
+													</ButtonLikeAnchor>
+												)
+											) : null
+										)}
+									</div>
+								</div>
+							)}
+						</>
+					}
+				</div>
+			}
+		</>
 	);
 };
 

--- a/src/components/events/partials/SeriesDateTimeCell.tsx
+++ b/src/components/events/partials/SeriesDateTimeCell.tsx
@@ -13,19 +13,16 @@ const SeriesDateTimeCell = ({
 }) => {
 	return (
 		<>
-			{row.creation_date !== undefined && (() => {
-				const creationDate = row.creation_date;
-				return (
-					<DateTimeCell
-						resource="series"
-						date={creationDate}
-						filterName="CreationDate"
-						fetchResource={fetchSeries}
-						loadResourceIntoTable={loadSeriesIntoTable}
-						// tooltipText="EVENTS.SERIES.TABLE.TOOLTIP.CREATION" // Disabled due to performance concerns
-					/>
-				);
-			})()}
+			{row.creation_date !== undefined &&
+				<DateTimeCell
+					resource="series"
+					date={row.creation_date}
+					filterName="CreationDate"
+					fetchResource={fetchSeries}
+					loadResourceIntoTable={loadSeriesIntoTable}
+					// tooltipText="EVENTS.SERIES.TABLE.TOOLTIP.CREATION" // Disabled due to performance concerns
+				/>
+			}
 		</>
 	);
 };

--- a/src/components/users/partials/UsersRolesCell.tsx
+++ b/src/components/users/partials/UsersRolesCell.tsx
@@ -46,7 +46,7 @@ const UsersRolesCell = ({
 		return displayRoles.join(', ');
 	};
 
-	return <span>{getRoleString()}</span>;
+	return <>{getRoleString()}</>;
 };
 
 export default UsersRolesCell;


### PR DESCRIPTION
Removes html tags that are not needed from table cell components. This won't really make any sort of noticable dent performance wise, but it still results in a cleaner dom, so why not.

### How to test this

Check that the tables look exactly like before.