### PR TITLE
Avoid unnecessary table rerenders

### DIFF
--- a/src/components/events/Events.tsx
+++ b/src/components/events/Events.tsx
@@ -55,7 +55,6 @@ const Events = () => {
 	const editMetadataEventsModalRef = useRef<ModalHandle>(null);
 
 	const user = useAppSelector(state => getUserInformation(state));
-	const showActions = useAppSelector(state => isShowActions(state));
 	const events = useAppSelector(state => getTotalEvents(state));
 	const isFetchingAssetUploadOptions = useAppSelector(state => getIsFetchingAssetUploadOptions(state));
 
@@ -214,7 +213,7 @@ const Events = () => {
 									text: "BULK_ACTIONS.EDIT_EVENTS_METADATA.CAPTION",
 								}
 							]}
-							disabled={!showActions}
+							isShowActions={isShowActions}
 						/>
 						{/* Include filters component*/}
 						<TableFilters

--- a/src/components/events/Series.tsx
+++ b/src/components/events/Series.tsx
@@ -44,7 +44,6 @@ const Series = () => {
 	let location = useLocation();
 
 	const series = useAppSelector(state => getTotalSeries(state));
-	const showActions = useAppSelector(state => isShowActions(state));
 
 	useEffect(() => {
 		// State variable for interrupting the load function
@@ -139,7 +138,7 @@ const Series = () => {
 									text: "BULK_ACTIONS.DELETE.SERIES.CAPTION",
 								},
 							]}
-							disabled={!showActions}
+							isShowActions={isShowActions}
 						/>
 						{/* Include filters component */}
 						<TableFilters

--- a/src/components/shared/Table.tsx
+++ b/src/components/shared/Table.tsx
@@ -1,14 +1,15 @@
-import React, { JSX, useEffect, useRef, useState } from "react";
+import React, { JSX, Profiler, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
 	getMultiSelect,
 	getPageOffset,
-	getTable,
+	getTableColumns,
 	getTableDirection,
 	getTablePages,
 	getTablePagination,
 	getTableRows,
 	getTableSorting,
+	getTableStatus,
 } from "../../selectors/tableSelectors";
 import {
 	Row,
@@ -17,8 +18,11 @@ import {
 	setSortBy,
 	updatePageSize,
 	Page,
-	Pagination,
+	Pagination as PaginationType,
 	ReverseOptions,
+	selectRowIds,
+	selectRowById,
+	rowsSelectors,
 } from "../../slices/tableSlice";
 import {
 	changeAllSelected,
@@ -39,6 +43,7 @@ import { TableColumn } from "../../configs/tableConfigs/aclsTableConfig";
 import ButtonLikeAnchor from "./ButtonLikeAnchor";
 import { ModalHandle } from "./modals/Modal";
 import { ParseKeys } from "i18next";
+import { states } from "../../configs/adopterRegistrationConfig";
 
 const containerPageSize = React.createRef<HTMLDivElement>();
 
@@ -54,19 +59,8 @@ const Table = ({
 }: {
 	templateMap: TemplateMap
 }) => {
+	const { t } = useTranslation();
 	const dispatch = useAppDispatch();
-
-	const table = useAppSelector(state => getTable(state));
-	const pageOffset = useAppSelector(state => getPageOffset(state));
-	const pages = useAppSelector(state => getTablePages(state));
-	const pagination = useAppSelector(state => getTablePagination(state));
-	const rows = useAppSelector(state => getTableRows(state));
-	const sortBy = useAppSelector(state => getTableSorting(state));
-	const reverse = useAppSelector(state => getTableDirection(state));
-	const multiSelect = useAppSelector(state => getMultiSelect(state));
-
-	// Size options for pagination
-	const sizeOptions = [10, 20, 50, 100, 1000];
 
 	const lengthDivStyle = {
 		position: "absolute" as const,
@@ -75,71 +69,9 @@ const Table = ({
 		width: "auto",
 		whiteSpace: "nowrap" as const,
 	};
-	const loadingTdStyle = {
-		textAlign: "center" as const,
-	};
 
-	const directAccessible = getDirectAccessiblePages(pages, pagination);
-
-	const { t } = useTranslation();
-
-	// State of dropdown menu
-	const [showPageSizes, setShowPageSizes] = useState(false);
 	const editTableViewModalRef = useRef<ModalHandle>(null);
 	const selectAllCheckboxRef = useRef<HTMLInputElement>(null);
-
-	useEffect(() => {
-		// Function for handling clicks outside of an open dropdown menu
-		const handleClickOutside = (e: MouseEvent) => {
-			if (
-				e && containerPageSize.current && !containerPageSize.current.contains(e.target as Node)
-			) {
-				setShowPageSizes(false);
-			}
-		};
-
-		// Event listener for handle a click outside of dropdown menu
-		window.addEventListener("mousedown", handleClickOutside);
-
-		return () => {
-			window.removeEventListener("mousedown", handleClickOutside);
-		};
-	});
-
-	// Select or deselect all rows on a page
-	const onChangeAllSelected = (e: React.ChangeEvent<HTMLInputElement>) => {
-		const selected = e.target.checked;
-		dispatch(changeAllSelected(selected));
-	};
-
-	const changePageSize = (size: number) => {
-		forceDeselectAll();
-		dispatch(updatePageSize(size));
-		dispatch(setOffset(0));
-		dispatch(updatePages());
-	};
-
-	// Navigation to previous page possible?
-	const isNavigatePrevious = () => {
-		return pageOffset > 0;
-	};
-
-	// Navigation to next page possible?
-	const isNavigateNext = () => {
-		return pageOffset < pages.length - 1;
-	};
-
-	const sortByColumn = (colName: string) => {
-		// By sorting, any selected item has to be deselected!
-		forceDeselectAll();
-		dispatch(setSortBy(colName));
-		let direction: ReverseOptions = "ASC";
-		if (reverse && reverse === "ASC") {
-			direction = "DESC";
-		}
-		dispatch(reverseTable(direction));
-		dispatch(updatePages());
-	};
 
 	const forceDeselectAll = () => {
 		dispatch(changeAllSelected(false));
@@ -155,17 +87,6 @@ const Table = ({
 	const hideEditTableViewModal = () => {
 		editTableViewModalRef.current?.close?.()
 	};
-
-	const tryToGetValueForKeyFromRowAsString = (row: Row, key: string) => {
-		if (key in row) {
-			const value = row[key as keyof Row];
-			if (typeof value === "string") {
-				return value;
-			}
-		}
-
-		return "";
-	}
 
 	return (
 		<>
@@ -192,194 +113,387 @@ const Table = ({
 			<table className={"main-tbl highlight-hover"}>
 				<thead>
 					<tr>
-						{/* Only show if multiple selection is possible */}
-						{multiSelect ? (
-							<th className="small">
-								{/*Checkbox to select all rows*/}
-								<input
-									ref={selectAllCheckboxRef}
-									type="checkbox"
-									onChange={(e) => onChangeAllSelected(e)}
-									aria-label={t("EVENTS.EVENTS.TABLE.SELECT_ALL")}
-								/>
-							</th>
-						) : null}
-
-						{/* todo: if not column.deactivated*/}
-						{table.columns.map((column, key) =>
-							column.deactivated ? null : column.sortable ? ( // Check if column is sortable and render accordingly
-								<th
-									key={key}
-									className={cn({
-										"col-sort": !!sortBy && column.name === sortBy,
-										sortable: true,
-									})}
-									onClick={() => sortByColumn(column.name)}
-								>
-									<span>
-										<span>{t(column.label)}</span>
-										<i style={{
-											float: "right",
-											margin: "12px 0 0 5px",
-											top: "auto",
-											left: "auto",
-											width: 8,
-											height: 13,
-											backgroundImage: `url(${column.name === sortBy
-												? reverse === "ASC"
-													? sortUpIcon
-													: sortDownIcon
-												: sortIcon})`,
-										}} />
-									</span>
-								</th>
-							) : (
-								<th key={key} className={cn({ sortable: false })}>
-									<span>{t(column.label)}</span>
-								</th>
-							)
-						)}
+						<MultiSelect
+							selectAllCheckboxRef={selectAllCheckboxRef}
+						/>
+						<TableHeadRows
+							forceDeselectAll={forceDeselectAll}
+						/>
 					</tr>
 				</thead>
 				<tbody>
-					{table.status === 'loading' && rows.length === 0 ? (
-						<tr>
-							<td colSpan={table.columns.length} style={loadingTdStyle}>
-								<i className="fa fa-spinner fa-spin fa-2x fa-fw" />
-							</td>
-						</tr>
-					) : !(table.status === 'loading') && rows.length === 0 ? (
-						//Show if no results and table is not loading
-						<tr>
-							<td colSpan={table.columns.length}>{t("TABLE_NO_RESULT")}</td>
-						</tr>
-					) : (
-						!(table.status === 'loading') &&
-						//Repeat for each row in table.rows
-						rows.map((row, key) => (
-							<tr key={key}>
-								{/* Show if multi selection is possible */}
-								{/* Checkbox for selection of row */}
-								{multiSelect && "id" in row && (
-									<td>
-										<input
-											type="checkbox"
-											checked={row.selected}
-											onChange={() => dispatch(changeRowSelection(row.id, false))}
-											aria-label={t("EVENTS.EVENTS.TABLE.SELECT_EVENT", { title: "title" in row ? row.title : row.id })}
-										/>
-									</td>
-								)}
-								{/* Populate table */}
-								{table.columns.map((column, key) =>
-									!column.template &&
-									!column.translate &&
-									!column.deactivated ? (
-										<td key={key}>{column.name in row ? row[column.name as keyof Row] : ""}</td>
-									) : !column.template &&
-									  column.translate &&
-									  !column.deactivated ? (
-										//Show only if column not template, translate, not deactivated
-										<td key={key}>{t(tryToGetValueForKeyFromRowAsString(row, column.name) as ParseKeys)}</td>
-									) : !!column.template &&
-									  !column.deactivated &&
-									  !!templateMap[column.template] ? (
-										// if column has a template then apply it
-										<td key={key}>
-											<ColumnTemplate
-												row={row}
-												column={column}
-												templateMap={templateMap}
-											/>
-										</td>
-									) : !column.deactivated ? (
-										<td />
-									) : null
-								)}
-							</tr>
-						))
-					)}
+					<TableBody
+						templateMap={templateMap}
+					/>
 				</tbody>
 			</table>
 
-			{/* Selection of page size */}
 			<div id="tbl-view-controls-container">
-				<div
-					className="drop-down-container small flipped"
-					onClick={() => setShowPageSizes(!showPageSizes)}
-					ref={containerPageSize}
-					role="button"
-					tabIndex={0}
-				>
-					<span>{pagination.limit}</span>
-					{/* Drop down menu for selection of page size */}
-					{showPageSizes && (
-						<ul className="dropdown-ul">
-							{sizeOptions.map((size, key) => (
-								<li key={key}>
-									<ButtonLikeAnchor
-										onClick={() => changePageSize(size)}
-									>
-										{size}
-									</ButtonLikeAnchor>
-								</li>
-							))}
-						</ul>
-					)}
-				</div>
-
+				{/* Selection of page size */}
+				<PageSize
+					forceDeselectAll={forceDeselectAll}
+				/>
 				{/* Pagination and navigation trough pages */}
-				<div className="pagination">
-					<ButtonLikeAnchor
-						className={cn("prev", { disabled: !isNavigatePrevious() })}
-						aria-disabled={!isNavigatePrevious()}
-						onClick={() => {
-							dispatch(goToPage(pageOffset - 1));
-							forceDeselectAll();
-						}}
-					>
-						<span className="sr-only">{t("TABLE_PREVIOUS")}</span>
-					</ButtonLikeAnchor>
-					{directAccessible.map((page, key) =>
-						page.active ? (
-							<ButtonLikeAnchor key={key}
-								className="active"
-								aria-label={t("TABLE_CURRENT", { pageNumber: page.label })}
-							>
-								{page.label}
-							</ButtonLikeAnchor>
-						) : (
-							<ButtonLikeAnchor key={key}
-								aria-label={t("TABLE_NUMBERED", { pageNumber: page.label })}
-								onClick={() => {
-									dispatch(goToPage(page.number));
-									forceDeselectAll();
-								}}
-							>
-								{page.label}
-							</ButtonLikeAnchor>
-						)
-					)}
-
-					<ButtonLikeAnchor
-						className={cn("next", { disabled: !isNavigateNext() })}
-						aria-disabled={!isNavigateNext()}
-						onClick={() => {
-							dispatch(goToPage(pageOffset + 1));
-							forceDeselectAll();
-						}}
-					>
-						<span className="sr-only">{t("TABLE_NEXT")}</span>
-					</ButtonLikeAnchor>
-				</div>
+				<Pagination
+					forceDeselectAll={forceDeselectAll}
+				/>
 			</div>
 		</>
 	);
 };
 
-// get all pages directly accessible from current page
+// Only show if multiple selection is possible
+const MultiSelect = ({ selectAllCheckboxRef }: { selectAllCheckboxRef: React.RefObject<HTMLInputElement | null> }) => {
+	const { t } = useTranslation();
+	const dispatch = useAppDispatch();
 
-const getDirectAccessiblePages = (pages: Page[], pagination: Pagination) => {
+	const multiSelect = useAppSelector(state => getMultiSelect(state));
+
+	// Select or deselect all rows on a page
+	const onChangeAllSelected = (e: React.ChangeEvent<HTMLInputElement>) => {
+		const selected = e.target.checked;
+		dispatch(changeAllSelected(selected));
+	};
+
+	return (
+		<>
+			{multiSelect &&
+				<th className="small">
+					{/*Checkbox to select all rows*/}
+					<input
+						ref={selectAllCheckboxRef}
+						type="checkbox"
+						onChange={(e) => onChangeAllSelected(e)}
+						aria-label={t("EVENTS.EVENTS.TABLE.SELECT_ALL")}
+					/>
+				</th>
+			}
+		</>
+	);
+}
+
+const TableHeadRows = ({ forceDeselectAll }: { forceDeselectAll: () => unknown }) => {
+	const { t } = useTranslation();
+	const dispatch = useAppDispatch();
+
+	const columns = useAppSelector(state => getTableColumns(state));
+	const sortBy = useAppSelector(state => getTableSorting(state));
+	const reverse = useAppSelector(state => getTableDirection(state));
+
+	const sortByColumn = (colName: string) => {
+		// By sorting, any selected item has to be deselected!
+		forceDeselectAll();
+		dispatch(setSortBy(colName));
+		let direction: ReverseOptions = "ASC";
+		if (reverse && reverse === "ASC") {
+			direction = "DESC";
+		}
+		dispatch(reverseTable(direction));
+		dispatch(updatePages());
+	};
+
+	return (
+		<>
+			{columns.map((column, key) =>
+				column.deactivated ? null : column.sortable ? ( // Check if column is sortable and render accordingly
+					<th
+						key={key}
+						className={cn({
+							"col-sort": !!sortBy && column.name === sortBy,
+							sortable: true,
+						})}
+						onClick={() => sortByColumn(column.name)}
+					>
+						<span>
+							<span>{t(column.label)}</span>
+							<i style={{
+								float: "right",
+								margin: "12px 0 0 5px",
+								top: "auto",
+								left: "auto",
+								width: 8,
+								height: 13,
+								backgroundImage: `url(${column.name === sortBy
+									? reverse === "ASC"
+										? sortUpIcon
+										: sortDownIcon
+									: sortIcon})`,
+							}} />
+						</span>
+					</th>
+				) : (
+					<th key={key} className={cn({ sortable: false })}>
+						<span>{t(column.label)}</span>
+					</th>
+				)
+			)}
+		</>
+	);
+}
+
+const TableBody = ({ templateMap }: { templateMap: TemplateMap }) => {
+	const { t } = useTranslation();
+
+	const columnCount = useAppSelector(state => getTableColumns(state).length);
+	const rowCount = useAppSelector(rowsSelectors.selectTotal);
+	const status = useAppSelector(state => getTableStatus(state));
+
+	const loadingTdStyle = {
+		textAlign: "center" as const,
+	};
+
+	return (
+		<>
+			{status === 'loading' && rowCount === 0 ? (
+				<tr>
+					<td colSpan={columnCount} style={loadingTdStyle}>
+						<i className="fa fa-spinner fa-spin fa-2x fa-fw" />
+					</td>
+				</tr>
+			) : !(status === 'loading') && rowCount === 0 ? (
+				//Show if no results and table is not loading
+				<tr>
+					<td colSpan={columnCount}>{t("TABLE_NO_RESULT")}</td>
+				</tr>
+			) : (
+				!(status === 'loading') &&
+				//Repeat for each row in table.rows
+				<TableRows
+					templateMap={templateMap}
+				/>
+			)}
+		</>
+	);
+}
+
+const TableRows = ({ templateMap }: { templateMap: TemplateMap }) => {
+	const rowKeys = useAppSelector(selectRowIds);
+
+	return (
+		<>
+			{rowKeys.map((rowKey) => (
+				<TableRow
+					key={rowKey}
+					rowKey={rowKey}
+					templateMap={templateMap}
+				/>
+			))}
+		</>
+	);
+}
+
+const TableRow = ({ rowKey, templateMap }: { rowKey: string, templateMap: TemplateMap }) => {
+	const { t } = useTranslation();
+	const dispatch = useAppDispatch();
+
+	const row = useAppSelector(state => selectRowById(state, rowKey));
+
+	const columns = useAppSelector(state => getTableColumns(state));
+	const multiSelect = useAppSelector(state => getMultiSelect(state));
+
+	const tryToGetValueForKeyFromRowAsString = (row: Row, key: string) => {
+		if (key in row) {
+			const value = row[key as keyof Row];
+			if (typeof value === "string") {
+				return value;
+			}
+		}
+
+		return "";
+	}
+
+	const renderCell = (column: TableColumn, index: number) => {
+		if (column.deactivated) {
+			return null;
+		}
+
+		// Column template available
+		if (column.template && templateMap[column.template]) {
+			return (
+				<td key={index}>
+					<ColumnTemplate row={row} column={column} templateMap={templateMap} />
+				</td>
+			);
+		}
+
+		// Nothing available
+		if (!column.template && !column.translate) {
+			return <td key={index}>{column.name in row ? row[column.name as keyof Row] : ""}</td>;
+		}
+
+		// Translation available
+		if (!column.template && column.translate) {
+			return <td key={index}>{t(tryToGetValueForKeyFromRowAsString(row, column.name) as ParseKeys)}</td>;
+		}
+
+
+
+		return <td key={index} />;
+	};
+
+	return (
+		<tr>
+			{/* Show if multi selection is possible */}
+			{/* Checkbox for selection of row */}
+			{multiSelect && (
+				<td>
+					<input
+						type="checkbox"
+						checked={row.selected}
+						onChange={() => dispatch(changeRowSelection(row.id, false))}
+						aria-label={t("EVENTS.EVENTS.TABLE.SELECT_EVENT", { title: "title" in row ? row.title : row.id })}
+					/>
+				</td>
+			)}
+			{/* Populate table */}
+			{columns.map(renderCell)}
+		</tr>
+	);
+}
+
+// Apply a column template and render corresponding components
+const ColumnTemplate = ({ row, column, templateMap }: {row: Row, column: TableColumn, templateMap: TemplateMap}) => {
+	if (!column.template) {
+		return <></>;
+	}
+	let Template = templateMap[column.template];
+	return <Template row={row} />;
+};
+
+/**
+ * Change amount of rows displayed in the table
+ */
+const PageSize = ({ forceDeselectAll }: { forceDeselectAll: () => unknown }) => {
+	const dispatch = useAppDispatch();
+	const pagination = useAppSelector(state => getTablePagination(state));
+
+	const sizeOptions = [10, 20, 50, 100, 1000]; // Size options for pagination
+	const [showPageSizes, setShowPageSizes] = useState(false);
+
+	useEffect(() => {
+		// Function for handling clicks outside of an open dropdown menu
+		const handleClickOutside = (e: MouseEvent) => {
+			if (
+				e && containerPageSize.current && !containerPageSize.current.contains(e.target as Node)
+			) {
+				setShowPageSizes(false);
+			}
+		};
+
+		// Event listener for handle a click outside of dropdown menu
+		window.addEventListener("mousedown", handleClickOutside);
+
+		return () => {
+			window.removeEventListener("mousedown", handleClickOutside);
+		};
+	});
+
+	const changePageSize = (size: number) => {
+		forceDeselectAll();
+		dispatch(updatePageSize(size));
+		dispatch(setOffset(0));
+		dispatch(updatePages());
+	};
+
+	return (
+		<div
+			className="drop-down-container small flipped"
+			onClick={() => setShowPageSizes(!showPageSizes)}
+			ref={containerPageSize}
+			role="button"
+			tabIndex={0}
+		>
+			<span>{pagination.limit}</span>
+			{/* Drop down menu for selection of page size */}
+			{showPageSizes && (
+				<ul className="dropdown-ul">
+					{sizeOptions.map((size, key) => (
+						<li key={key}>
+							<ButtonLikeAnchor
+								onClick={() => changePageSize(size)}
+							>
+								{size}
+							</ButtonLikeAnchor>
+						</li>
+					))}
+				</ul>
+			)}
+		</div>
+	);
+}
+
+/**
+ * Switch between table pages
+ */
+const Pagination = ({ forceDeselectAll }: { forceDeselectAll: () => unknown }) => {
+	const { t } = useTranslation();
+	const dispatch = useAppDispatch();
+
+	const pageOffset = useAppSelector(state => getPageOffset(state));
+	const pages = useAppSelector(state => getTablePages(state));
+	const pagination = useAppSelector(state => getTablePagination(state));
+
+	const directAccessible = getDirectAccessiblePages(pages, pagination);
+
+	// Navigation to previous page possible?
+	const isNavigatePrevious = () => {
+		return pageOffset > 0;
+	};
+
+	// Navigation to next page possible?
+	const isNavigateNext = () => {
+		return pageOffset < pages.length - 1;
+	};
+
+	return (
+		<div className="pagination">
+			<ButtonLikeAnchor
+				className={cn("prev", { disabled: !isNavigatePrevious() })}
+				aria-disabled={!isNavigatePrevious()}
+				onClick={() => {
+					dispatch(goToPage(pageOffset - 1));
+					forceDeselectAll();
+				}}
+			>
+				<span className="sr-only">{t("TABLE_PREVIOUS")}</span>
+			</ButtonLikeAnchor>
+			{directAccessible.map((page, key) =>
+				page.active ? (
+					<ButtonLikeAnchor key={key}
+						className="active"
+						aria-label={t("TABLE_CURRENT", { pageNumber: page.label })}
+					>
+						{page.label}
+					</ButtonLikeAnchor>
+				) : (
+					<ButtonLikeAnchor key={key}
+						aria-label={t("TABLE_NUMBERED", { pageNumber: page.label })}
+						onClick={() => {
+							dispatch(goToPage(page.number));
+							forceDeselectAll();
+						}}
+					>
+						{page.label}
+					</ButtonLikeAnchor>
+				)
+			)}
+
+			<ButtonLikeAnchor
+				className={cn("next", { disabled: !isNavigateNext() })}
+				aria-disabled={!isNavigateNext()}
+				onClick={() => {
+					dispatch(goToPage(pageOffset + 1));
+					forceDeselectAll();
+				}}
+			>
+				<span className="sr-only">{t("TABLE_NEXT")}</span>
+			</ButtonLikeAnchor>
+		</div>
+	);
+}
+
+// get all pages directly accessible from current page
+const getDirectAccessiblePages = (pages: Page[], pagination: PaginationType) => {
 	let startIndex = pagination.offset - pagination.directAccessibleNo,
 		endIndex = pagination.offset + pagination.directAccessibleNo,
 		directAccessible = [],
@@ -426,15 +540,6 @@ const getDirectAccessiblePages = (pages: Page[], pagination: Pagination) => {
 	}
 
 	return directAccessible;
-};
-
-// Apply a column template and render corresponding components
-const ColumnTemplate = ({ row, column, templateMap }: {row: Row, column: TableColumn, templateMap: TemplateMap}) => {
-	if (!column.template) {
-		return <></>;
-	}
-	let Template = templateMap[column.template];
-	return <Template row={row} />;
 };
 
 export default Table;

--- a/src/components/shared/TableActionDropdown.tsx
+++ b/src/components/shared/TableActionDropdown.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import cn from "classnames";
 import { hasAccess } from "../../utils/utils";
 import { useTranslation } from "react-i18next";
-import { useAppSelector } from "../../store";
+import { RootState, useAppSelector } from "../../store";
 import { getUserInformation } from "../../selectors/userInfoSelectors";
 import { ParseKeys } from "i18next";
 import ButtonLikeAnchor from "./ButtonLikeAnchor";
@@ -16,14 +16,15 @@ const containerAction = React.createRef<HTMLDivElement>();
  */
 const TableActionDropdown = ({
 	actions,
-	disabled = true,
+	isShowActions,
 }: {
 	actions: React.ComponentProps<typeof Action>[]
-	disabled: boolean
+	isShowActions: (state: RootState) => boolean
 }) => {
 	const { t } = useTranslation();
 
 	const [displayActionMenu, setActionMenu] = useState(false);
+	const disabled = !useAppSelector(state => isShowActions(state));
 
 	useEffect(() => {
 		// Function for handling clicks outside of an open dropdown menu

--- a/src/selectors/tableSelectors.ts
+++ b/src/selectors/tableSelectors.ts
@@ -1,6 +1,6 @@
 import { createSelector } from "reselect";
 import { RootState } from "../store";
-import { TableState } from "../slices/tableSlice";
+import { rowsSelectors, TableState } from "../slices/tableSlice";
 
 /**
  * This file contains selectors regarding the table view
@@ -21,11 +21,13 @@ export const getTableDirection = (state: RootState) => state.table.reverse[state
 export const getTableDirectionForResource = (state: RootState, resource: TableState["resource"]) => state.table.reverse[resource];
 export const getMultiSelect = (state: RootState) => state.table.multiSelect[state.table.resource];
 export const getTable = (state: RootState) => state.table;
+export const getTableStatus = (state: RootState) => state.table.status;
 export const getDeactivatedColumns = (state: RootState) =>
 	state.table.columns.filter((column) => column.deactivated);
 export const getActivatedColumns = (state: RootState) =>
 	state.table.columns.filter((column) => !column.deactivated);
 
-export const getSelectedRows = createSelector(getTableRows, (rows) =>
-	rows.filter((row) => row.selected)
+export const getSelectedRows = createSelector(
+	rowsSelectors.selectAll,
+	rows => rows.filter(row => row.selected)
 );

--- a/src/slices/tableSlice.ts
+++ b/src/slices/tableSlice.ts
@@ -1,4 +1,4 @@
-import { PayloadAction, SerializedError, createSlice } from '@reduxjs/toolkit'
+import { EntityState, PayloadAction, SerializedError, createEntityAdapter, createSlice, nanoid } from '@reduxjs/toolkit'
 import { aclsTableConfig, TableConfig } from '../configs/tableConfigs/aclsTableConfig';
 import { Server } from './serverSlice';
 import { Recording } from './recordingSlice';
@@ -19,6 +19,7 @@ import { servicesTableConfig } from '../configs/tableConfigs/servicesTableConfig
 import { usersTableConfig } from '../configs/tableConfigs/usersTableConfig';
 import { groupsTableConfig } from '../configs/tableConfigs/groupsTableConfig';
 import { themesTableConfig } from '../configs/tableConfigs/themesTableConfig';
+import { RootState } from '../store';
 
 /*
 Overview of the structure of the data in arrays in state
@@ -77,7 +78,14 @@ export function isSeries(row: Row | Event | Series | Recording | Server | Job | 
 }
 
 // TODO: Improve row typing. While this somewhat correctly reflects the current state of our code, it is rather annoying to work with.
-export type Row = { selected: boolean } & (Event | Series | Recording | Server | Job | Service | User | Group | AclResult | ThemeDetailsType)
+export type Row = {
+	id: string, // For use with entityAdapter. Directly taken from event/series etc. if available
+	selected: boolean // If the row was marked in the ui by the user
+} & (Event | Series | Recording | Server | Job | Service | User | Group | AclResult | ThemeDetailsType)
+
+export type SubmitRow = {
+	selected: boolean
+} & (Event | Series | Recording | Server | Job | Service | User | Group | AclResult | ThemeDetailsType)
 
 export type Resource = "events" | "series" | "recordings" | "jobs" | "servers" | "services" | "users" | "groups" | "acls" | "themes"
 
@@ -93,9 +101,30 @@ export type TableState = {
 	sortBy: { [key in Resource]: string },  // Key is resource, value is actual sorting parameter
 	predicate: string,
 	reverse: { [key in Resource]: ReverseOptions },  // Key is resource, value is actual sorting parameter
-	rows: Row[],
+	rows: EntityState<Row, string>,
 	maxLabel: string,
 	pagination: Pagination,
+}
+
+const rowsAdapter = createEntityAdapter<Row>();
+
+// Since not all rows are guaranteed to have an id: string, this computes one
+function getRowKey(row: SubmitRow): string {
+	if ("id" in row && row.id != null) {
+		return `${row.id}`; // works for Event, Series, Recording, etc.
+	}
+	if ("cores" in row) { // Server
+		return `${row.hostname}`;
+	}
+	if ("completed" in row) { // Service
+		return `${row.name}`;
+	}
+	if ("username" in row) { // User
+		return `${row.username}`;
+	}
+
+	// Fallback
+	return nanoid();
 }
 
 // initial redux state
@@ -142,7 +171,7 @@ const initialState: TableState = {
 		acls: "ASC",
 		themes: "ASC",
 	},
-	rows: [],
+	rows: rowsAdapter.getInitialState(),
 	maxLabel: "",
 	pagination: {
 		limit: 10,
@@ -161,7 +190,7 @@ const tableSlice = createSlice({
 			columns: TableConfig["columns"],
 			resource: TableState["resource"],
 			pages: TableState["pages"],
-			rows: TableState["rows"],
+			rows: SubmitRow[],
 			sortBy: TableState["sortBy"][Resource],
 			reverse: TableState["reverse"][Resource],
 			totalItems: TableState["pagination"]["totalItems"],
@@ -170,13 +199,29 @@ const tableSlice = createSlice({
 			state.columns = action.payload.columns;
 			state.resource = action.payload.resource;
 			state.pages = action.payload.pages;
-			state.rows = action.payload.rows;
 			state.sortBy[action.payload.resource] = action.payload.sortBy;
 			state.reverse[action.payload.resource] = action.payload.reverse;
 			state.pagination = {
 				...state.pagination,
 				totalItems: action.payload.totalItems,
 			};
+
+			// Entity Adapter preparations
+			const rows: Row[] = [];
+
+			action.payload.rows.forEach(row => {
+				const rowId = getRowKey(row);                // new stable id
+
+				//@ts-expect-error: Id will not be number
+				rows.push({
+					...row,
+					id: rowId,
+				});
+			});
+
+			// Replace state with the fetched entities
+			rowsAdapter.setAll(state.rows, rows);
+
 		},
 		loadColumns(state, action: PayloadAction<
 			TableState["columns"]
@@ -184,34 +229,28 @@ const tableSlice = createSlice({
 			state.columns = action.payload;
 		},
 		selectRow(state, action: PayloadAction<
-			number | string
+			string
 		>) {
 			const id = action.payload;
-			state.rows = state.rows.map((row) => {
-				if ("id" in row && row.id === id) {
-					return {
-						...row,
-						selected: !row.selected,
-					};
-				}
-				return row;
-			})
+			const row = state.rows.entities[id];
+			if (row) {
+				rowsAdapter.updateOne(state.rows, {
+					id,
+					changes: { selected: !row.selected },
+				});
+			}
 		},
 		selectAll(state) {
-			state.rows = state.rows.map((row) => {
-				return {
-					...row,
-					selected: true,
-				};
-			})
+			rowsAdapter.updateMany(
+				state.rows,
+				state.rows.ids.map(id => ({ id, changes: { selected: true } }))
+			);
 		},
 		deselectAll(state) {
-			state.rows = state.rows.map((row) => {
-				return {
-					...row,
-					selected: false,
-				};
-			})
+			rowsAdapter.updateMany(
+				state.rows,
+				state.rows.ids.map(id => ({ id, changes: { selected: false } }))
+			);
 		},
 		reverseTable(state, action: PayloadAction<
 			TableState["reverse"][Resource]
@@ -291,6 +330,15 @@ const tableSlice = createSlice({
 		},
 	},
 });
+
+export const {
+	selectIds: selectRowIds,
+	selectById: selectRowById,
+} = rowsAdapter.getSelectors<RootState>(s => s.table.rows);
+
+export const rowsSelectors = rowsAdapter.getSelectors<RootState>(
+	s => s.table.rows
+);
 
 export const {
 	loadResourceIntoTable,

--- a/src/thunks/tableThunks.ts
+++ b/src/thunks/tableThunks.ts
@@ -44,11 +44,10 @@ import { AppDispatch, AppThunk, RootState } from "../store";
 export const loadEventsIntoTable = (): AppThunk => async (dispatch, getState) => {
 	const { events, table } = getState();
 	const total = events.total;
-
 	const pagination = table.pagination;
 	// check which events are currently selected
 	const resource = events.results.map((result) => {
-		const current = table.rows.find((row) => "id" in row && row.id === result.id);
+		const current = table.rows.entities[result.id];
 
 		if (!!current && table.resource === "events") {
 			return {
@@ -84,10 +83,9 @@ export const loadSeriesIntoTable = (): AppThunk => (dispatch, getState) => {
 	const { series, table } = getState();
 	const total = series.total;
 	const pagination = table.pagination;
-
 	// check which events are currently selected
 	const resource = series.results.map((result) => {
-		const current = table.rows.find((row) => "id" in row && row.id === result.id);
+		const current = table.rows.entities[result.id];
 
 		if (!!current && table.resource === "series") {
 			return {
@@ -100,7 +98,7 @@ export const loadSeriesIntoTable = (): AppThunk => (dispatch, getState) => {
 				selected: false,
 			};
 		}
-	});
+	})
 
 	const pages = calculatePages(total / pagination.limit, pagination.offset);
 
@@ -556,7 +554,7 @@ export const changeColumnSelection = (updatedColumns: TableConfig["columns"]) =>
 };
 
 // Select certain row
-export const changeRowSelection = (id: number | string, selected: boolean): AppThunk => (dispatch, getState) => {
+export const changeRowSelection = (id: string, selected: boolean): AppThunk => (dispatch, getState) => {
 	dispatch(selectRow(id));
 
 	const state = getState();


### PR DESCRIPTION
This patch prevents certain actions from causing all table rows to rerender, if the actions did not actually affect the table rows. It does this by refactoring the table component so that redux state updates only trigger rerenders in the
components that actually use the update data.

Actions include:
- Selecting a single row.
- Opening the page size dropdown.
- Displaying a tooltip by hovering over a hoverable table element.

This should not affect inital table load times.

### How to test this

This patch changes our logic on how we access row information a bit, so make sure that all table functionality still works as expected.