### PR TITLE
Don´t run corrupt state check on state change

### DIFF
--- a/src/hooks/useTableFilterStateValidation.ts
+++ b/src/hooks/useTableFilterStateValidation.ts
@@ -22,5 +22,6 @@ export const useTableFilterStateValidation = () => {
 			console.warn("Detected corrupted table filter state, resetting to defaults");
 			dispatch(resetCorruptedState());
 		}
-	}, [dispatch, tableFilters.data, tableFilters.textFilter, tableFilters.stats]);
+	// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
 };


### PR DESCRIPTION
Fixes #1432.

The goal of useTableFilterStateValidation is to fix state when switching between ui versions. We do not need to fix state while the app is running, Therefore I think it is reasonable to run it only once on load, in order to reduce rerenders.

### How to test this

Run version 17 and set a filter. Shut down the app. Then run this branch. 