### PR TITLE
Fix overlapping buttons in “Series details → Access policy” dialog #1426

### DIFF
--- a/src/styles/components/modals/_footer.scss
+++ b/src/styles/components/modals/_footer.scss
@@ -31,6 +31,8 @@
     border-bottom-right-radius: variables.$main-border-radius;
     background: color.adjust(variables.$body-background, $lightness: -3%);
     border-top: 1px solid variables.$main-border-color;
+    display: flex;
+    flex-direction: row-reverse;
 
     button {
         @include button.btn(green);

--- a/src/styles/components/modals/_footer.scss
+++ b/src/styles/components/modals/_footer.scss
@@ -31,8 +31,11 @@
     border-bottom-right-radius: variables.$main-border-radius;
     background: color.adjust(variables.$body-background, $lightness: -3%);
     border-top: 1px solid variables.$main-border-color;
-    display: flex;
-    flex-direction: row-reverse;
+    div {
+        &.pull-right{
+            float:right;
+        }
+    }
 
     button {
         @include button.btn(green);


### PR DESCRIPTION
This patch fixes the problem that in the “Series details → Access policy” dialog, the “Save” and “Update series permissions” buttons appear merged together without any space in between.

This fixes #1422