### PR TITLE
Fix series ACLs not being applied to new events

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/NewAccessPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewAccessPage.tsx
@@ -85,7 +85,7 @@ const NewAccessPage = <T extends RequiredFormProps>({
 	// If we have to use series ACL, overwrite existing rules
 	useEffect(() => {
 		if (initEventAclWithSeriesAcl && formik.values["dublincore/episode_isPartOf"] && seriesAcl) {
-			formik.setFieldValue("acls", seriesAcl);
+			formik.setFieldValue("policies", seriesAcl);
 		}
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [initEventAclWithSeriesAcl, seriesAcl]);


### PR DESCRIPTION
#1006 renamed the value and this part was missed.

How to test: Create a series with at least one role in the ACL, start to create an event and select that series, check if the roles from the series show up in the ACL tab during event creation.

Sponsored by the University of Jena :white_flower: 