### PR TITLE
Feature Add next/previous tab hotkeys

### DIFF
--- a/src/components/events/partials/modals/EventDetails.tsx
+++ b/src/components/events/partials/modals/EventDetails.tsx
@@ -49,6 +49,9 @@ import ButtonLikeAnchor from "../../../shared/ButtonLikeAnchor";
 import { NOTIFICATION_CONTEXT } from "../../../../configs/modalConfig";
 import { unwrapResult } from "@reduxjs/toolkit";
 import { ParseKeys } from "i18next";
+import { useHotkeys } from "react-hotkeys-hook";
+import { availableHotkeys } from "../../../../configs/hotkeysConfig";
+
 
 export enum EventDetailsPage {
 	Metadata,
@@ -229,6 +232,46 @@ const EventDetails = ({
 		}
 	};
 
+	const wizardTabs = tabs.filter(tab =>
+	  !tab.hidden && tab.page !== EventDetailsPage.Tobira && tab.page !== EventDetailsPage.Statistics,
+	);
+
+	const goNextStep = () => {
+	  const currentIndex = wizardTabs.findIndex(tab => tab.page === page);
+	  if (currentIndex === -1) { return; } // not in wizard, do nothing
+	  const nextIndex = currentIndex + 1;
+	  if (nextIndex >= wizardTabs.length) { return; } // already at last step (Comments)
+	  openTab(wizardTabs[nextIndex].page);
+	};
+
+	const goPrevStep = () => {
+	  const currentIndex = wizardTabs.findIndex(tab => tab.page === page);
+	  if (currentIndex <= 0) { return; }
+	  openTab(wizardTabs[currentIndex - 1].page);
+	};
+	// NEXT STEP
+	useHotkeys(
+	  availableHotkeys.general.NEXT_STEP.sequence,
+	  event => {
+	    const target = event.target as HTMLElement;
+	    if (!["INPUT", "TEXTAREA"].includes(target.tagName)) {
+	      goNextStep();
+	    }
+	  },
+	  [goNextStep],
+	);
+
+	// PREVIOUS STEP
+	useHotkeys(
+	  availableHotkeys.general.PREVIOUS_STEP.sequence,
+	  event => {
+	    const target = event.target as HTMLElement;
+	    if (!["INPUT", "TEXTAREA"].includes(target.tagName)) {
+	      goPrevStep();
+	    }
+	  },
+	  [goPrevStep],
+	);
 	return (
 		<>
 			<nav className="modal-nav" id="modal-nav">

--- a/src/components/shared/DropDown.tsx
+++ b/src/components/shared/DropDown.tsx
@@ -4,7 +4,7 @@ import {
 	dropDownSpacingTheme,
 	dropDownStyle,
 } from "../../utils/componentStyles";
-import { GroupBase, MenuListProps, Props, SelectInstance, createFilter } from "react-select";
+import { GroupBase, MenuListProps, Props, SelectInstance } from "react-select";
 import { isJson } from "../../utils/utils";
 import { ParseKeys } from "i18next";
 import { FixedSizeList, ListChildComponentProps } from "react-window";
@@ -176,7 +176,7 @@ const DropDown = <T, >({
 	};
 
 	const loadOptions = (
-		_inputValue: string,
+		inputValue: string,
 		callback: (options: DropDownOption[]) => void,
 	) => {
 		callback(formatOptions(filterOptions(inputValue), required));

--- a/src/components/shared/modals/Modal.tsx
+++ b/src/components/shared/modals/Modal.tsx
@@ -66,17 +66,6 @@ export const Modal = forwardRef<ModalHandle, PropsWithChildren<ModalProps>>(
       },
       [ref],
     );
-    // const lastFocusedRef = useRef<HTMLElement | null>(null);
-    // 		const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    // 		   const active = document.activeElement as HTMLElement | null;
-    //   if (event.key === "Escape") {
-    //     if (active && event.currentTarget.contains(active)) {
-    //       lastFocusedRef.current = active; // store the last focused element
-    //       active.blur(); // remove focus
-    //       console.log(lastFocusedRef);
-    //     }
-    //   }
-    // 		};
 	return ReactDOM.createPortal(
 		isOpen &&
 			<FocusTrap

--- a/src/components/shared/modals/Modal.tsx
+++ b/src/components/shared/modals/Modal.tsx
@@ -66,10 +66,22 @@ export const Modal = forwardRef<ModalHandle, PropsWithChildren<ModalProps>>(
       },
       [ref],
     );
-
+    // const lastFocusedRef = useRef<HTMLElement | null>(null);
+    // 		const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    // 		   const active = document.activeElement as HTMLElement | null;
+    //   if (event.key === "Escape") {
+    //     if (active && event.currentTarget.contains(active)) {
+    //       lastFocusedRef.current = active; // store the last focused element
+    //       active.blur(); // remove focus
+    //       console.log(lastFocusedRef);
+    //     }
+    //   }
+    // 		};
 	return ReactDOM.createPortal(
 		isOpen &&
-			<FocusTrap>
+			<FocusTrap
+       focusTrapOptions={{
+        escapeDeactivates: false }}>
 				<div>
 					<div className="modal-animation modal-overlay" />
 					<section

--- a/src/components/shared/modals/ModalContentTable.tsx
+++ b/src/components/shared/modals/ModalContentTable.tsx
@@ -1,5 +1,5 @@
 import ModalContent from "./ModalContent";
-
+import { useRef } from "react";
 /**
  * This component
  */
@@ -14,7 +14,18 @@ const ModalContentTable = ({
 	modalBodyChildren?: React.ReactNode
 	children: React.ReactNode
 }) => {
-
+	 // Store the last blurred/focused element
+  	    const lastFocusedRef = useRef<HTMLElement | null>(null);
+    		const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    		   const active = document.activeElement as HTMLElement | null;
+      if (event.key === "Escape") {
+        if (active && event.currentTarget.contains(active)) {
+          lastFocusedRef.current = active; // store the last focused element
+          active.blur();
+          console.log(lastFocusedRef);
+        }
+      }
+    		};
 
   return (
 		<ModalContent
@@ -22,7 +33,7 @@ const ModalContentTable = ({
 			modalContentClassName={modalContentClassName}
 		>
 			{modalBodyChildren}
-			<div className="full-col">
+			<div className="full-col" onKeyDown={handleKeyDown}>
 				{children}
 			</div>
 		</ModalContent>

--- a/src/components/shared/modals/ModalContentTable.tsx
+++ b/src/components/shared/modals/ModalContentTable.tsx
@@ -22,7 +22,6 @@ const ModalContentTable = ({
         if (active && event.currentTarget.contains(active)) {
           lastFocusedRef.current = active; // store the last focused element
           active.blur();
-          console.log(lastFocusedRef);
         }
       }
     		};

--- a/src/configs/hotkeysConfig.ts
+++ b/src/configs/hotkeysConfig.ts
@@ -64,6 +64,16 @@ export const availableHotkeys: HotkeyMapType = {
 			description: "HOTKEYS.DESCRIPTIONS.GENERAL.REMOVE_FILTERS",
 			sequence: ["r"],
 		},
+		NEXT_STEP: {
+    		name: "next_step",
+    		description: "HOTKEYS.DESCRIPTIONS.GENERAL.NEXT_STEP",
+    		sequence: ["alt+enter"], // Alt + Enter moves forward
+  		},
+  		PREVIOUS_STEP: {
+    		name: "previous_step",
+    		description: "HOTKEYS.DESCRIPTIONS.GENERAL.PREVIOUS_STEP",
+    		sequence: ["alt+backspace"], // Alt + Backspace moves backward
+  		},
 		CLOSE_MODAL: {
 			name: "close_modal",
 			description: "HOTKEYS.DESCRIPTIONS.GENERAL.CLOSE_MODAL",

--- a/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
@@ -2076,6 +2076,8 @@
 				"SELECT_NEXT_DASHBOARD_FILTER": "Select next dashboard filter",
 				"SELECT_PREVIOUS_DASHBOARD_FILTER": "Select previous dashboard filter",
 				"REMOVE_FILTERS": "Clear all filters",
+				"NEXT_STEP": "Go to next step",
+        		"PREVIOUS_STEP": "Go to previous step",
 				"EVENT_VIEW": "Events",
 				"SERIES_VIEW": "Series",
 				"NEW_EVENT": "Add event",


### PR DESCRIPTION
Hello all,

as stated in the problem #984 , there was no possibility like the old version of admin user interface of open cast to navigate between different steps like ( edit event modal ) (eg, metadata to publications ) , 

by this PR i tried to suggest the solution which i would appreciate your view and opinions , if i am in the currect track or even close to it that i can continue my solution to other wizard modals inside the Admin UI , 

now it is possible to move forward whenever the focus is not on the input type fields by pressing: alt + Enter and back ward : alt + Backspace , to test this PR please first open the edit window modal , and change the focus by tabbing from the input field to the next one and then use the hotkeys as above i have mentioned them 


thank you all for your Time
Ensiyeh 
