### PR TITLE
Improvement: Update the submitter display in the event details tab

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowTab.tsx
@@ -32,6 +32,7 @@ import ButtonLikeAnchor from "../../../shared/ButtonLikeAnchor";
 import { formatWorkflowsForDropdown } from "../../../../utils/dropDownUtils";
 import { ParseKeys } from "i18next";
 import BaseButton from "../../../shared/BaseButton";
+import { Tooltip } from "../../../shared/Tooltip";
 
 type InitialValues = {
 	workflowDefinition: string;
@@ -203,9 +204,9 @@ const EventDetailsWorkflowTab = ({
 															<td>{item.id}</td>
 															<td>{item.title}</td>
 															<td>
-																{item.submitterName}
-																{item.submitterEmail && (<>&lt;{item.submitterEmail}&gt;</>)}
-																&nbsp;({item.submitter})
+																<Tooltip title={item.submitterName}>
+																	<span>{item.submitter}</span>
+																</Tooltip>
 															</td>
 															<td>
 																{t("dateFormats.dateTime.medium", {

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowTab.tsx
@@ -202,7 +202,11 @@ const EventDetailsWorkflowTab = ({
 														<tr key={key}>
 															<td>{item.id}</td>
 															<td>{item.title}</td>
-															<td>{item.submitter}</td>
+															<td>
+																{item.submitterName}
+																{item.submitterEmail && (<>&lt;{item.submitterEmail}&gt;</>)}
+																&nbsp;({item.submitter})
+															</td>
 															<td>
 																{t("dateFormats.dateTime.medium", {
 																	dateTime: renderValidDate(item.submitted),


### PR DESCRIPTION
This PR adds the submitter name in the events details tab.
<img width="961" height="130" alt="Captura de pantalla 2025-09-19 a las 11 48 00" src="https://github.com/user-attachments/assets/af5698bc-06f4-43d2-83c8-5b7dda0cf097" />

I've made this PR to r/17.x. If it's not correct, please let me know and I'll change it.