### PR TITLE
Take advantage of all available space for dropdowns in metadata modals

### DIFF
--- a/src/components/shared/wizard/RenderField.tsx
+++ b/src/components/shared/wizard/RenderField.tsx
@@ -221,7 +221,7 @@ const EditableSingleSelect = ({
 				? `-- ${t("SELECT_NO_OPTION_SELECTED")} --`
 				: `${t("SELECT_NO_OPTION_SELECTED")}`
 			}
-			customCSS={{ isMetadataStyle: focused ? false : true }}
+			customCSS={{ isMetadataStyle: focused ? false : true, width: "100%" }}
 			handleMenuIsOpen={(open: boolean) => setFocused(open)}
 			openMenuOnFocus
 			autoFocus={isFirstField}


### PR DESCRIPTION
Dropdowns now use the full available width in metadata modals.