### PR TITLE
Refactor dropdown components and fix width in metadata modals

### DIFF
--- a/src/components/shared/wizard/RenderField.tsx
+++ b/src/components/shared/wizard/RenderField.tsx
@@ -213,7 +213,7 @@ const EditableSingleSelect = (props: EditableSingleSelectProps) => {
 		field,
 		metadataField,
 		text,
-		form: { setFieldValue },
+		form,
 		isFirstField,
 		focused,
 		setFocused,
@@ -224,26 +224,16 @@ const EditableSingleSelect = (props: EditableSingleSelectProps) => {
 		return <EditableSingleSelectSeries {...props} />;
 	}
 
-	return (
-		<DropDown
-			ref={ref}
-			value={field.value as string}
-			text={text}
-			options={metadataField.collection
-				? metadataField.collection.map(item => ({ label: item.label ?? item.name, value: item.value, order: item.order }))
-				: []}
-			required={metadataField.required}
-			handleChange={element => element && setFieldValue(field.name, element.value)}
-			placeholder={focused
-				? `-- ${t("SELECT_NO_OPTION_SELECTED")} --`
-				: `${t("SELECT_NO_OPTION_SELECTED")}`
-			}
-			customCSS={{ isMetadataStyle: focused ? false : true, width: "100%" }}
-			handleMenuIsOpen={(open: boolean) => setFocused(open)}
-			openMenuOnFocus
-			autoFocus={isFirstField}
-		/>
-	);
+	return <EditableSingleSelectDropDown
+		field={field}
+		metadataField={metadataField}
+		text={text}
+		form={form}
+		isFirstField={isFirstField}
+		focused={focused}
+		setFocused={setFocused}
+		ref={ref}
+	/>;
 };
 
 // Renders editable text area
@@ -338,8 +328,7 @@ const EditableSingleValueTime = ({
 const EditableSingleSelectSeries = ({
 	field,
 	metadataField,
-	text,
-	form: { setFieldValue },
+	form,
 	isFirstField,
 	focused,
 	setFocused,
@@ -371,11 +360,42 @@ const EditableSingleSelectSeries = ({
 		return transformListProvider(data);
 	};
 
+	return <EditableSingleSelectDropDown
+		field={field}
+		metadataField={metadataField}
+		text={label}
+		form={form}
+		isFirstField={isFirstField}
+		focused={focused}
+		setFocused={setFocused}
+		ref={ref}
+		fetchOptions={fetchOptions}
+	/>;
+};
+
+const EditableSingleSelectDropDown = ({
+	field,
+	metadataField,
+	text,
+	form: { setFieldValue },
+	options,
+	fetchOptions,
+	isFirstField,
+	focused,
+	setFocused,
+	ref,
+}: EditableSingleSelectProps & Pick<
+	Parameters<typeof DropDown>[0],
+	"options" | "fetchOptions"
+>) => {
+	const { t } = useTranslation();
+
 	return (
 		<DropDown
 			ref={ref}
 			value={field.value as string}
-			text={label}
+			text={text}
+			options={options}
 			fetchOptions={fetchOptions}
 			required={metadataField.required}
 			handleChange={element => element && setFieldValue(field.name, element.value)}
@@ -383,7 +403,7 @@ const EditableSingleSelectSeries = ({
 				? `-- ${t("SELECT_NO_OPTION_SELECTED")} --`
 				: `${t("SELECT_NO_OPTION_SELECTED")}`
 			}
-			customCSS={{ isMetadataStyle: focused ? false : true }}
+			customCSS={{ isMetadataStyle: focused ? false : true, width: "100%" }}
 			handleMenuIsOpen={(open: boolean) => setFocused(open)}
 			openMenuOnFocus
 			autoFocus={isFirstField}

--- a/src/components/shared/wizard/RenderField.tsx
+++ b/src/components/shared/wizard/RenderField.tsx
@@ -238,7 +238,7 @@ const EditableSingleSelect = (props: EditableSingleSelectProps) => {
 				? `-- ${t("SELECT_NO_OPTION_SELECTED")} --`
 				: `${t("SELECT_NO_OPTION_SELECTED")}`
 			}
-			customCSS={{ isMetadataStyle: focused ? false : true }}
+			customCSS={{ isMetadataStyle: focused ? false : true, width: "100%" }}
 			handleMenuIsOpen={(open: boolean) => setFocused(open)}
 			openMenuOnFocus
 			autoFocus={isFirstField}


### PR DESCRIPTION
This is a follow-up to #1444 where we fixed dropdown width for r/17.x. Due to the refactoring in #1375, we need to apply the same fix for r/18.x.