### PR TITLE
Render date field in scheduling tab as input field

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsSchedulingTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsSchedulingTab.tsx
@@ -305,7 +305,6 @@ const EventDetailsSchedulingTab = ({
 															yearDropdownItemNumber={2}
 															dateFormat="P"
 															popperClassName="datepicker-custom"
-															className="datepicker-custom-input"
 															wrapperClassName="datepicker-custom-wrapper"
 															locale={currentLanguage?.dateLocale}
 															strictParsing

--- a/src/components/events/partials/ModalTabsAndPages/NewSourcePage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewSourcePage.tsx
@@ -422,7 +422,6 @@ const Schedule = <T extends {
 									yearDropdownItemNumber={2}
 									dateFormat="P"
 									popperClassName="datepicker-custom"
-									className="datepicker-custom-input"
 									wrapperClassName="datepicker-custom-wrapper"
 									locale={currentLanguage?.dateLocale}
 									strictParsing


### PR DESCRIPTION
Fixes #1374.

The start date field in the scheduling tab of the event modals is rendering like a metadata field. This makes it look like it cannot be edited. This changes it so that the date field always looks like an input field, which is the way it was before.

### How to test this

Create a dummy capture agent at `/docs.html?path=/capture-admin#setAgentState-3` so you can schedule an event and see the changes.