### PR TITLE
Fix cutting a release on develop

### DIFF
--- a/.github/workflows/release-cut-tag.yml
+++ b/.github/workflows/release-cut-tag.yml
@@ -25,7 +25,7 @@ jobs:
           #Translate 'develop' to 18.x or whatever is appropriate
           if [ "develop" == "${{ github.ref_name }}" ]; then
             #NB normally we only clone just the head ref, but fetch-depth: 0 above gets *all* the history
-            export TEMP="$((`git branch -a | grep r/ | cut -f 4 -d '/' | cut -f 1 -d '.'` + 1)).x"
+            export TEMP="$((`git branch -a | grep r/ | cut -f 4 -d '/' | head -n 1 | cut -f 1 -d '.'` + 1)).x"
           else
             export TEMP=${{ github.ref_name }}
           fi


### PR DESCRIPTION
The release tag cutting script fails when attempting to cut a release on develop since the special handling in that case did not anticipate the presence of multiple release branches already...
