### PR TITLE
Fix release related github actions scripts

### DIFF
--- a/.github/workflows/release-cut-tag.yml
+++ b/.github/workflows/release-cut-tag.yml
@@ -23,9 +23,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           #Translate 'develop' to 18.x or whatever is appropriate
-          if [ "develop" == "${{ github.ref_name }}" ]; then
+          if [ "develop" = "${{ github.ref_name }}" ]; then
             #NB normally we only clone just the head ref, but fetch-depth: 0 above gets *all* the history
-            export TEMP="$((`git branch -a | grep r/ | cut -f 4 -d '/' | cut -f 1 -d '.'` + 1)).x"
+            export TEMP="$((`git branch -a | grep r/ | cut -f 4 -d '/' | sort | tail -n 1 | cut -f 1 -d '.'` + 1)).x"
           else
             export TEMP=${{ github.ref_name }}
           fi

--- a/.github/workflows/release-cut-tag.yml
+++ b/.github/workflows/release-cut-tag.yml
@@ -33,4 +33,4 @@ jobs:
           git tag $TAG
           git push origin $TAG
           sleep 2
-          gh workflow run process-release.yml -r $TAG
+          gh workflow run release-build.yml -r $TAG


### PR DESCRIPTION
This PR corrects a couple of things I missed in #1466:

- **Correcting bash comparison, and sorting and tailing the branches so we get the right one**
- **Triggering the correct workflow**

This contains a fix derived from #1472, which went into develop, but upon further examination this would also apply to 17 and 18, so I'm putting it into 17 and merging it forward
