### PR TITLE
Fix workflow tab for recordings

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowDetails.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowDetails.tsx
@@ -49,9 +49,11 @@ const EventDetailsWorkflowDetails = ({
 		if (!workflowId) {
 			dispatch(fetchWorkflows(eventId)).unwrap()
 				.then(workflows => {
-					const currentWorkflow = workflows.entries[workflows.entries.length - 1];
-					dispatch(fetchWorkflowDetails({ eventId, workflowId: currentWorkflow.id }));
-					dispatch(setModalWorkflowId(currentWorkflow.id));
+					if (workflows.entries.length > 0) {
+						const currentWorkflow = workflows.entries[workflows.entries.length - 1];
+						dispatch(fetchWorkflowDetails({ eventId, workflowId: currentWorkflow.id }));
+						dispatch(setModalWorkflowId(currentWorkflow.id));
+					}
 				},
 			);
 		} else {

--- a/src/components/events/partials/modals/EventDetails.tsx
+++ b/src/components/events/partials/modals/EventDetails.tsx
@@ -26,6 +26,7 @@ import {
 	getModalPage,
 	getEventDetailsTobiraDataError,
 	getEventDetailsTobiraStatus,
+	getWorkflows,
 } from "../../../../selectors/eventDetailsSelectors";
 import { getUserInformation } from "../../../../selectors/userInfoSelectors";
 import EventDetailsStatisticsTab from "../ModalTabsAndPages/EventDetailsStatisticsTab";
@@ -134,6 +135,7 @@ const EventDetails = ({
 	const captureAgents = useAppSelector(state => getRecordings(state));
 	const tobiraStatus = useAppSelector(state => getEventDetailsTobiraStatus(state));
 	const tobiraError = useAppSelector(state => getEventDetailsTobiraDataError(state));
+	const workflows = useAppSelector(state => getWorkflows(state));
 
 	const tabs: {
 		tabNameTranslation: ParseKeys,
@@ -277,7 +279,7 @@ const EventDetails = ({
 						formikRef={formikRef}
 					/>
 				)}
-				{page === EventDetailsPage.Workflow && !hasSchedulingProperties &&
+				{page === EventDetailsPage.Workflow && !workflows.scheduling &&
 					((workflowTabHierarchy === "workflows" && (
 						<EventDetailsWorkflowTab
 							eventId={eventId}
@@ -301,7 +303,7 @@ const EventDetails = ({
 								eventId={eventId}
 							/>
 						)))}
-				{page === EventDetailsPage.Workflow && hasSchedulingProperties &&
+				{page === EventDetailsPage.Workflow && workflows.scheduling &&
 					<EventDetailsWorkflowSchedulingTab
 						eventId={eventId}
 						formikRef={formikRef}


### PR DESCRIPTION
During processing and after the publication of a recording, the event details tab does not show any information about running or completed workflows. With this PR the workflow tab shows again all workflow information for recordings, just as it does for manually uploaded videos.

fixes #1474