### PR TITLE
Go to first page when changing filters via Stats

### DIFF
--- a/src/components/shared/Stats.tsx
+++ b/src/components/shared/Stats.tsx
@@ -10,6 +10,7 @@ import {
 	removeTextFilter,
 } from "../../slices/tableFilterSlice";
 import { loadEventsIntoTable } from "../../thunks/tableThunks";
+import { setOffset, setPageActive } from "../../slices/tableSlice"
 import { useAppDispatch, useAppSelector } from "../../store";
 import { fetchEvents } from "../../slices/eventSlice";
 import { ParseKeys } from "i18next";
@@ -39,8 +40,14 @@ const Stats = () => {
 			}
 			let filter = filterMap.find(({ name }) => name === f.name);
 			filterValue = f.value;
+<<<<<<< HEAD
 			if (!!filter) {
 				dispatch(editFilterValue({filterName: filter.name, value: filterValue, resource: "events"}));
+=======				// go to first page without reloading all events
+        			dispatch(setOffset(0));
+        			dispatch(setPageActive(0));
+				dispatch(editFilterValue({ filterName: filter.name, value: filterValue, resource: "events" }));
+>>>>>>> be73635d4b (Go to first page when changing filters via Stats)
 			}
 		});
 		await dispatch(fetchEvents());

--- a/src/components/shared/Stats.tsx
+++ b/src/components/shared/Stats.tsx
@@ -41,7 +41,6 @@ const Stats = () => {
 			let filter = filterMap.find(({ name }) => name === f.name);
 			filterValue = f.value;
 			if (!!filter) {
-				dispatch(editFilterValue({filterName: filter.name, value: filterValue, resource: "events"}));
 				// go to first page without reloading all events
         		dispatch(setOffset(0));
         		dispatch(setPageActive(0));

--- a/src/components/shared/Stats.tsx
+++ b/src/components/shared/Stats.tsx
@@ -40,14 +40,12 @@ const Stats = () => {
 			}
 			let filter = filterMap.find(({ name }) => name === f.name);
 			filterValue = f.value;
-<<<<<<< HEAD
 			if (!!filter) {
 				dispatch(editFilterValue({filterName: filter.name, value: filterValue, resource: "events"}));
-=======				// go to first page without reloading all events
-        			dispatch(setOffset(0));
-        			dispatch(setPageActive(0));
+				// go to first page without reloading all events
+        		dispatch(setOffset(0));
+        		dispatch(setPageActive(0));
 				dispatch(editFilterValue({ filterName: filter.name, value: filterValue, resource: "events" }));
->>>>>>> be73635d4b (Go to first page when changing filters via Stats)
 			}
 		});
 		await dispatch(fetchEvents());

--- a/src/components/shared/Stats.tsx
+++ b/src/components/shared/Stats.tsx
@@ -10,7 +10,7 @@ import {
 	removeTextFilter,
 } from "../../slices/tableFilterSlice";
 import { loadEventsIntoTable } from "../../thunks/tableThunks";
-import { setOffset, setPageActive } from "../../slices/tableSlice"
+import { setOffset, setPageActive } from "../../slices/tableSlice";
 import { useAppDispatch, useAppSelector } from "../../store";
 import { fetchEvents } from "../../slices/eventSlice";
 import { ParseKeys } from "i18next";


### PR DESCRIPTION
Currently the Admin UI does not reset the offset and the page number when changing filters via the Stats bar. 

With this the offset and the page number is set to 0 when a filter is changed via the Stats bar, without reloading all events as `goToPage(0)`  would do.