### PR TITLE
Fix language and licence selection in EventDetails tab

### DIFF
--- a/src/components/shared/wizard/RenderField.tsx
+++ b/src/components/shared/wizard/RenderField.tsx
@@ -230,14 +230,14 @@ const EditableSingleSelect = (props: EditableSingleSelectProps) => {
 		text={text}
 		form={form}
 		options={
-		metadataField.collection
-			? metadataField.collection.map(item => ({
-				label: item.label ?? item.name,
-				value: item.value,
-				order: item.order,
-			}))
-			: []
-		}
+			metadataField.collection
+				? metadataField.collection.map(item => ({
+					label: item.label ?? item.name,
+					value: item.value,
+					order: item.order,
+				}))
+				: []
+			}
 		isFirstField={isFirstField}
 		focused={focused}
 		setFocused={setFocused}

--- a/src/components/shared/wizard/RenderField.tsx
+++ b/src/components/shared/wizard/RenderField.tsx
@@ -229,6 +229,15 @@ const EditableSingleSelect = (props: EditableSingleSelectProps) => {
 		metadataField={metadataField}
 		text={text}
 		form={form}
+		options={
+		metadataField.collection
+			? metadataField.collection.map(item => ({
+				label: item.label ?? item.name,
+				value: item.value,
+				order: item.order,
+			}))
+			: []
+		}
 		isFirstField={isFirstField}
 		focused={focused}
 		setFocused={setFocused}


### PR DESCRIPTION
Fixes https://github.com/opencast/opencast-admin-interface/issues/1471 . 

I think in https://github.com/opencast/opencast-admin-interface/pull/1375 the options field for non series fields has been missed and wasn't parsed at all. This resulted in no language or licence options showing up in the dropdown. 

This patch reintroduces the parsing of the options for those fields.

### How to test this patch

With the patch installed, open the event details / new event tab and check if you can see and select language, licence and series options in the dropdown selection. 