### PR TITLE
Fixed multi-value field style

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -79,6 +79,7 @@ a.disabled, button.disabled, div.disabled {
 div.show-edit {
   display: flex;
   justify-content: space-between;
+  width: 98%;
 }
 
 div.editable {


### PR DESCRIPTION
The edit button is positioned too far to the right for multi-value input fields.

Before:
<img width="994" height="724" alt="before" src="https://github.com/user-attachments/assets/c34f2a79-49fc-4421-a8f2-cca4a71993d5" />

After:
<img width="990" height="723" alt="after" src="https://github.com/user-attachments/assets/957e3c8d-26a5-4023-8d86-adb0f87d44a9" />
