### PR TITLE
Fix the 'Read/Write' column heading in ACL modal

### DIFF
--- a/src/components/shared/modals/ResourceDetailsAccessPolicyTab.tsx
+++ b/src/components/shared/modals/ResourceDetailsAccessPolicyTab.tsx
@@ -488,15 +488,15 @@ export const AccessPolicyTable = <T extends AccessPolicyTabFormikProps>({
 									<th>
 										{
 											t(
-												"EVENTS.EVENTS.DETAILS.ACCESS.ACCESS_POLICY.WRITE",
-											) /* <!-- Write --> */
+												"EVENTS.EVENTS.DETAILS.ACCESS.ACCESS_POLICY.READ",
+											) /* <!-- Read --> */
 										}
 									</th>
 									<th>
 										{
 											t(
-												"EVENTS.EVENTS.DETAILS.ACCESS.ACCESS_POLICY.READ",
-											) /* <!-- Read --> */
+												"EVENTS.EVENTS.DETAILS.ACCESS.ACCESS_POLICY.WRITE",
+											) /* <!-- Write --> */
 										}
 									</th>
 									{hasActions && (


### PR DESCRIPTION
The heading was in wrong order.

Before:
<img width="977" height="654" alt="image" src="https://github.com/user-attachments/assets/3ea54d8e-7521-4b26-83d1-7035786bd252" />

After:
<img width="987" height="674" alt="image" src="https://github.com/user-attachments/assets/bd577667-c284-40f7-a2f8-4d1ecc9e0755" />
