### PR TITLE
Remove useEffect hook validation from create modals

### DIFF
--- a/src/components/configuration/partials/wizard/NewThemeWizard.tsx
+++ b/src/components/configuration/partials/wizard/NewThemeWizard.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import { Formik } from "formik";
 import GeneralPage from "./GeneralPage";
 import BumperPage from "./BumperPage";
@@ -83,12 +82,6 @@ const NewThemeWizard = ({
 			>
 				{/* Render wizard pages depending on current value of page variable */}
 				{formik => {
-					// eslint-disable-next-line react-hooks/rules-of-hooks
-					useEffect(() => {
-						formik.validateForm();
-						// eslint-disable-next-line react-hooks/exhaustive-deps
-					}, [page]);
-
 					return (
 						<>
 							{/* Stepper that shows each step of wizard as header */}

--- a/src/components/events/partials/modals/EditScheduledEventsModal.tsx
+++ b/src/components/events/partials/modals/EditScheduledEventsModal.tsx
@@ -125,12 +125,6 @@ const EditScheduledEventsModal = ({
 			>
 				{/* Render wizard pages depending on current value of page variable */}
 				{formik => {
-					// eslint-disable-next-line react-hooks/rules-of-hooks
-					useEffect(() => {
-						formik.validateForm().then();
-						// eslint-disable-next-line react-hooks/exhaustive-deps
-					}, [page]);
-
 					return (
 						<>
 							{/* Stepper that shows each step of wizard as header */}

--- a/src/components/events/partials/modals/StartTaskModal.tsx
+++ b/src/components/events/partials/modals/StartTaskModal.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import { Formik } from "formik";
 import { initialFormValuesStartTask } from "../../../../configs/modalConfig";
 import WizardStepper, { WizardStep } from "../../../shared/wizard/WizardStepper";
@@ -92,12 +91,6 @@ const StartTaskModal = ({
 			>
 				{/* Render wizard pages depending on current value of page variable */}
 				{formik => {
-					// eslint-disable-next-line react-hooks/rules-of-hooks
-					useEffect(() => {
-						formik.validateForm().then();
-					// eslint-disable-next-line react-hooks/exhaustive-deps
-					}, [page]);
-
 					return (
 						<>
 							{/* Stepper that shows each step of wizard as header */}

--- a/src/components/events/partials/wizards/NewEventWizard.tsx
+++ b/src/components/events/partials/wizards/NewEventWizard.tsx
@@ -173,12 +173,6 @@ const NewEventWizard = ({
 			>
 				{/* Render wizard pages depending on current value of page variable */}
 				{formik => {
-					// eslint-disable-next-line react-hooks/rules-of-hooks
-					useEffect(() => {
-						formik.validateForm();
-						// eslint-disable-next-line react-hooks/exhaustive-deps
-					}, [page]);
-
 					return (
 						<>
 							{/* Stepper that shows each step of wizard as header */}

--- a/src/components/events/partials/wizards/NewSeriesWizard.tsx
+++ b/src/components/events/partials/wizards/NewSeriesWizard.tsx
@@ -162,12 +162,6 @@ const NewSeriesWizard = ({
 			>
 				{/* Render wizard pages depending on current value of page variable */}
 				{formik => {
-					// eslint-disable-next-line react-hooks/rules-of-hooks
-					useEffect(() => {
-						formik.validateForm().then();
-						// eslint-disable-next-line react-hooks/exhaustive-deps
-					}, [page]);
-
 					return (
 						<>
 							{/* Stepper that shows each step of wizard as header */}

--- a/src/components/users/partials/wizard/NewAclWizard.tsx
+++ b/src/components/users/partials/wizard/NewAclWizard.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import { Formik } from "formik";
 import WizardStepper, { WizardStep } from "../../../shared/wizard/WizardStepper";
 import AclMetadataPage from "./AclMetadataPage";
@@ -72,12 +71,6 @@ const NewAclWizard = ({
 			>
 				{/* Render wizard pages depending on current value of page variable */}
 				{formik => {
-					// eslint-disable-next-line react-hooks/rules-of-hooks
-					useEffect(() => {
-						formik.validateForm();
-						// eslint-disable-next-line react-hooks/exhaustive-deps
-					}, [page]);
-
 					return (
 						<>
 							{/* Stepper that shows each step of wizard as header */}

--- a/src/components/users/partials/wizard/NewGroupWizard.tsx
+++ b/src/components/users/partials/wizard/NewGroupWizard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { Formik } from "formik";
 import { initialFormValuesNewGroup } from "../../../../configs/modalConfig";
 import WizardStepper, { WizardStep } from "../../../shared/wizard/WizardStepper";
@@ -75,12 +75,6 @@ const NewGroupWizard: React.FC<{
 			>
 				{/* Render wizard pages depending on current value of page variable */}
 				{formik => {
-					// eslint-disable-next-line react-hooks/rules-of-hooks
-					useEffect(() => {
-						formik.validateForm();
-						// eslint-disable-next-line react-hooks/exhaustive-deps
-					}, [page]);
-
 					return (
 						<>
 							{/* Stepper that shows each step of wizard as header */}

--- a/src/components/users/partials/wizard/NewUserWizard.tsx
+++ b/src/components/users/partials/wizard/NewUserWizard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Formik } from "formik";
 import { useTranslation } from "react-i18next";
 import cn from "classnames";
@@ -79,12 +79,6 @@ const NewUserWizard = ({
 			>
 				{/* Render wizard tabs depending on current value of tab variable */}
 				{formik => {
-					// eslint-disable-next-line react-hooks/rules-of-hooks
-					useEffect(() => {
-						formik.validateForm();
-					// eslint-disable-next-line react-hooks/exhaustive-deps
-					}, [tab]);
-
 					return (
 						<>
 							{tab === 0 && <NewUserGeneralTab formik={formik} />}


### PR DESCRIPTION
This hook would call upon the formik validation when the user switched to a different tab in the create modal. This is pointless because A. validation will automatically have been called by formik before then and B. this hook would only trigger after the tab has changed, which would be too late anyway.