### PR TITLE
Working radio buttons for workflow config

### DIFF
--- a/src/components/events/partials/wizards/RenderWorkflowConfig.tsx
+++ b/src/components/events/partials/wizards/RenderWorkflowConfig.tsx
@@ -102,8 +102,25 @@ const RenderCheckbox = <T extends RequiredFormProps>(
 };
 
 const RenderRadio = <T extends RequiredFormProps>(
-	{ field, formik } : { field: FieldSetField, formik: FormikProps<T> }) => {
-		return <RenderField field={field} formik={formik} />;
+	{ field } : { field: FieldSetField, formik: FormikProps<T> }) => {
+
+		return (
+			<li>
+				<div role="group" className="configField">
+					{field.options?.map(option =>
+						<label key={option.value}>
+							<Field
+								type="radio"
+								className="configField"
+								name={"configuration." + field.name}
+								value={option.value}
+							/>
+							{option.label}
+						</label>,
+					)}
+				</div>
+			</li>
+		);
 };
 
 const RenderNumber = <T extends RequiredFormProps>(

--- a/src/slices/workflowSlice.ts
+++ b/src/slices/workflowSlice.ts
@@ -15,6 +15,7 @@ export type FieldSetField = {
 	defaultValue?: unknown
 	max?: number // number field
 	min?: number // number field
+	options?: { value: string, label: string }[]
 	[key: string]: unknown
 }
 


### PR DESCRIPTION
Our code suggests that it supports radio buttons for workflow configuration parameters, but it does not actually work properly.
With this patch radio buttons should now work on a basic level.

Example wf config:
```yml
configuration_panel_json: |-
  [{
    "fieldset": [
      {
        "type": "radio",
        "name": "myRadio",
        "value": "b",
        "options": [
          {
            "value": "a",
            "label": "A"
          },
          {
            "value": "b",
            "label": "B"
          }
        ]
      }
    ]
  }]
```

<img width="943" height="273" alt="Bildschirmfoto vom 2026-01-08 10-36-15" src="https://github.com/user-attachments/assets/29731a3d-c607-46c0-8a9a-2d9d0b9711f2" />


### How to test this

Change the workflow config of a workflow in `/etc/workflows` in your Opencast installation, similar to the example provided above. Test if you can start the workflow over the admin ui and if the selected radio value is properly used in the workflow.