### PR TITLE
Do not filter selected role from ACL dropdown

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/NewAccessPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewAccessPage.tsx
@@ -9,7 +9,7 @@ import {
 	fetchRolesWithTarget,
 } from "../../../../slices/aclSlice";
 import { FormikProps } from "formik";
-import { filterRoles, policiesFiltered, rolesFilteredbyPolicies } from "../../../../utils/aclUtils";
+import { policiesFiltered, rolesFiltered } from "../../../../utils/aclUtils";
 import { useAppDispatch, useAppSelector } from "../../../../store";
 import { fetchSeriesDetailsAcls } from "../../../../slices/seriesDetailsSlice";
 import { getSeriesDetailsAcl } from "../../../../selectors/seriesDetailsSelectors";
@@ -122,7 +122,7 @@ const NewAccessPage = <T extends RequiredFormProps>({
 											<AccessPolicyTable
 												isUserTable={true}
 												policiesFiltered={policiesFiltered(formik.values.policies, true)}
-												rolesFilteredbyPolicies={rolesFilteredbyPolicies(roles, formik.values.policies, true)}
+												rolesFilteredbyPolicies={rolesFiltered(roles, true)}
 												header={"EVENTS.EVENTS.DETAILS.ACCESS.ACCESS_POLICY.USERS"}
 												firstColumnHeader={"EVENTS.EVENTS.DETAILS.ACCESS.ACCESS_POLICY.USER"}
 												createLabel={"EVENTS.EVENTS.DETAILS.ACCESS.ACCESS_POLICY.NEW_USER"}
@@ -139,7 +139,7 @@ const NewAccessPage = <T extends RequiredFormProps>({
 											<AccessPolicyTable
 												isUserTable={false}
 												policiesFiltered={policiesFiltered(formik.values.policies, false)}
-												rolesFilteredbyPolicies={rolesFilteredbyPolicies(roles, formik.values.policies, false)}
+												rolesFilteredbyPolicies={rolesFiltered(roles, false)}
 												header={"USERS.ACLS.NEW.ACCESS.ACCESS_POLICY.NON_USER_ROLES"}
 												firstColumnHeader={"EVENTS.EVENTS.DETAILS.ACCESS.ACCESS_POLICY.ROLE"}
 												createLabel={"EVENTS.EVENTS.DETAILS.ACCESS.ACCESS_POLICY.NEW"}
@@ -159,7 +159,7 @@ const NewAccessPage = <T extends RequiredFormProps>({
 										<AccessPolicyTable
 											isUserTable={false}
 											policiesFiltered={formik.values.policies}
-											rolesFilteredbyPolicies={filterRoles(roles, formik.values.policies)}
+											rolesFilteredbyPolicies={roles}
 											firstColumnHeader={"EVENTS.EVENTS.DETAILS.ACCESS.ACCESS_POLICY.ROLE"}
 											createLabel={"EVENTS.EVENTS.DETAILS.ACCESS.ACCESS_POLICY.NEW"}
 											formik={formik}

--- a/src/components/shared/modals/ResourceDetailsAccessPolicyTab.tsx
+++ b/src/components/shared/modals/ResourceDetailsAccessPolicyTab.tsx
@@ -18,7 +18,7 @@ import {
 import { getUserInformation } from "../../../selectors/userInfoSelectors";
 import { hasAccess } from "../../../utils/utils";
 import DropDown from "../DropDown";
-import { filterRoles, getAclTemplateText, handleTemplateChange, policiesFiltered, rolesFilteredbyPolicies } from "../../../utils/aclUtils";
+import { getAclTemplateText, handleTemplateChange, policiesFiltered, rolesFiltered } from "../../../utils/aclUtils";
 import { useAppDispatch, useAppSelector } from "../../../store";
 import { removeNotificationWizardForm, addNotification } from "../../../slices/notificationSlice";
 import { useTranslation } from "react-i18next";
@@ -311,7 +311,7 @@ const ResourceDetailsAccessPolicyTab = ({
 												<AccessPolicyTable
 													isUserTable={true}
 													policiesFiltered={policiesFiltered(formik.values.policies, true)}
-													rolesFilteredbyPolicies={rolesFilteredbyPolicies(roles, formik.values.policies, true)}
+													rolesFilteredbyPolicies={rolesFiltered(roles, true)}
 													header={userPolicyTableHeaderText}
 													firstColumnHeader={userPolicyTableRoleText}
 													createLabel={userPolicyTableNewText}
@@ -328,7 +328,7 @@ const ResourceDetailsAccessPolicyTab = ({
 											<AccessPolicyTable
 												isUserTable={false}
 												policiesFiltered={policiesFiltered(formik.values.policies, false)}
-												rolesFilteredbyPolicies={rolesFilteredbyPolicies(roles, formik.values.policies, false)}
+												rolesFilteredbyPolicies={rolesFiltered(roles, false)}
 												header={policyTableHeaderText}
 												firstColumnHeader={policyTableRoleText}
 												createLabel={policyTableNewText}
@@ -348,7 +348,7 @@ const ResourceDetailsAccessPolicyTab = ({
 											<AccessPolicyTable
 												isUserTable={false}
 												policiesFiltered={formik.values.policies}
-												rolesFilteredbyPolicies={filterRoles(roles, formik.values.policies)}
+												rolesFilteredbyPolicies={roles}
 												header={policyTableHeaderText}
 												firstColumnHeader={policyTableRoleText}
 												createLabel={policyTableNewText}

--- a/src/components/users/partials/wizard/AclAccessPage.tsx
+++ b/src/components/users/partials/wizard/AclAccessPage.tsx
@@ -9,7 +9,7 @@ import {
 	fetchAclTemplates,
 	fetchRolesWithTarget,
 } from "../../../../slices/aclSlice";
-import { filterRoles, policiesFiltered, rolesFilteredbyPolicies } from "../../../../utils/aclUtils";
+import { policiesFiltered, rolesFiltered } from "../../../../utils/aclUtils";
 import { useAppDispatch } from "../../../../store";
 import { TransformedAcl } from "../../../../slices/aclDetailsSlice";
 import { AccessPolicyTable, TemplateSelector } from "../../../shared/modals/ResourceDetailsAccessPolicyTab";
@@ -88,7 +88,7 @@ const AclAccessPage = <T extends RequiredFormProps>({
 										<AccessPolicyTable
 											isUserTable={true}
 											policiesFiltered={policiesFiltered(formik.values.policies, true)}
-											rolesFilteredbyPolicies={rolesFilteredbyPolicies(roles, formik.values.policies, true)}
+											rolesFilteredbyPolicies={rolesFiltered(roles, true)}
 											header={"USERS.ACLS.NEW.ACCESS.ACCESS_POLICY.USERS"}
 											firstColumnHeader={"USERS.ACLS.NEW.ACCESS.ACCESS_POLICY.USER"}
 											createLabel={"USERS.ACLS.NEW.ACCESS.ACCESS_POLICY.NEW_USER"}
@@ -103,7 +103,7 @@ const AclAccessPage = <T extends RequiredFormProps>({
 										<AccessPolicyTable
 											isUserTable={false}
 											policiesFiltered={policiesFiltered(formik.values.policies, false)}
-											rolesFilteredbyPolicies={rolesFilteredbyPolicies(roles, formik.values.policies, false)}
+											rolesFilteredbyPolicies={rolesFiltered(roles, false)}
 											header={"USERS.ACLS.NEW.ACCESS.ACCESS_POLICY.NON_USER_ROLES"}
 											firstColumnHeader={"USERS.ACLS.NEW.ACCESS.ACCESS_POLICY.ROLE"}
 											createLabel={"USERS.ACLS.NEW.ACCESS.ACCESS_POLICY.NEW"}
@@ -122,7 +122,7 @@ const AclAccessPage = <T extends RequiredFormProps>({
 										<AccessPolicyTable
 											isUserTable={false}
 											policiesFiltered={formik.values.policies}
-											rolesFilteredbyPolicies={filterRoles(roles, formik.values.policies)}
+											rolesFilteredbyPolicies={roles}
 											firstColumnHeader={"USERS.ACLS.NEW.ACCESS.ACCESS_POLICY.ROLE"}
 											createLabel={"USERS.ACLS.NEW.ACCESS.ACCESS_POLICY.NEW"}
 											formik={formik}

--- a/src/utils/aclUtils.ts
+++ b/src/utils/aclUtils.ts
@@ -24,12 +24,6 @@ export const getAclTemplateText = (
 	}
 };
 
-export const filterRoles = (roles: Role[], policies: TransformedAcl[]) => {
-	return roles.filter(
-		role => !policies.find(policy => policy.role === role.name),
-	);
-};
-
 // Get all policies that have user information, or all policies that do not have user information
 export const policiesFiltered = (
 	policies: TransformedAcl[],
@@ -43,12 +37,10 @@ export const policiesFiltered = (
 };
 
 // Get all roles that have user information, or all policies that do not have user information
-export const rolesFilteredbyPolicies = (
-roles: Role[],
-policies: TransformedAcl[],
-byUser: boolean,
+export const rolesFiltered = (
+	roles: Role[],
+	byUser: boolean,
 ) => {
-	roles = filterRoles(roles, policies);
 	if (byUser) {
 		return roles.filter(role => role.user !== undefined);
 	} else {


### PR DESCRIPTION
In the ACL tab in e.g. the event details, if you open the dropdown for a selected role like ROLE_USER_ADMIN, the selected role does not appear in the dropdown. This in confusing, as our dropdowns do not behave in this manner.
This patch makes it so that the role *does* appear in the dropdown.

<img width="1168" height="436" alt="Bildschirmfoto vom 2026-01-09 11-39-36" src="https://github.com/user-attachments/assets/becdb41f-a8b8-4765-9770-50bca12b44d2" />

### How to test this

Can be tested as is. Check that the acl dropdowns still work.