### PR TITLE
Fix series dropdown not displaying "No options selected"

### DIFF
--- a/src/components/shared/wizard/RenderField.tsx
+++ b/src/components/shared/wizard/RenderField.tsx
@@ -354,6 +354,8 @@ const EditableSingleSelectSeries = ({
 				if (transformedData.length > 0) {
 					setLabel(transformedData[0].label);
 				}
+			} else {
+				setLabel("");
 			}
 		};
 		fetchLabelById();


### PR DESCRIPTION
In the metadata of the event details, if a series was already selected and then "No option selected" would be selected, it would still display the previously selected series. It would technically still work, it was just the display that was wrong. This fixes that.

[Bildschirmaufzeichnung vom 2026-01-09 12-26-55.webm](https://github.com/user-attachments/assets/fc045ce6-b7ac-4d82-9bbb-1c08121ac11e)

### How to test this

Can be tested as usual.