### PR TITLE
Download correct crowdin translation branch

### DIFF
--- a/.github/workflows/crowdin-download-translations.yml
+++ b/.github/workflows/crowdin-download-translations.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           CROWDIN_TOKEN: ${{ secrets.CROWDIN_TOKEN }}
         run: |
-          crowdin download --config .crowdin.yaml -b main
+          crowdin download --config .crowdin.yaml -b "${GITHUB_REF##*/}"
 
       - name: Add new translations
         run: |


### PR DESCRIPTION
This PR causes GHA to download and apply the correct translations from crowdin.  Previously *all* branches applied the translations from `main`, which is both defunct and no longer updating with new keys.
