### PR TITLE
Add new language column to events table

### DIFF
--- a/src/components/events/partials/EventsLanguageCell.tsx
+++ b/src/components/events/partials/EventsLanguageCell.tsx
@@ -1,0 +1,37 @@
+import { loadEventsIntoTable } from "../../../thunks/tableThunks";
+import { fetchEvents } from "../../../slices/eventSlice";
+import { Event } from "../../../slices/eventSlice";
+import FilterCell from "../../shared/FilterCell";
+import { useTranslation } from "react-i18next";
+import { ParseKeys } from "i18next";
+
+/**
+ * This component renders the language cells of events in the table view
+ */
+const EventsLanguageCell = ({
+	row,
+}: {
+	row: Event
+}) => {
+	const { t } = useTranslation();
+
+	return (
+		<>
+			{ row.language &&
+				<FilterCell
+					resource={"events"}
+					filterName={"language"}
+					filterItems={[{
+						filterValue: row.language,
+						children: t(row.language_translation_key as ParseKeys),
+						// cellTooltipText: "EVENTS.EVENTS.TABLE.TOOLTIP.LANGUAGE", // Disabled due to performance concerns
+					}]}
+					fetchResource={fetchEvents}
+					loadResourceIntoTable={loadEventsIntoTable}
+				/>
+			}
+		</>
+	);
+};
+
+export default EventsLanguageCell;

--- a/src/configs/tableConfigs/eventsTableConfig.ts
+++ b/src/configs/tableConfigs/eventsTableConfig.ts
@@ -86,6 +86,13 @@ export const eventsTableConfig: TableConfig = {
 			translate: false,
 			deactivated: true,
 		},
+		{
+			name: "language",
+			template: "EventsLanguageCell",
+			label: "EVENTS.EVENTS.TABLE.LANGUAGE",
+			translate: true,
+			deactivated: true,
+		},
 	],
 	caption: "EVENTS.EVENTS.TABLE.CAPTION",
 	resource: "events",

--- a/src/configs/tableConfigs/eventsTableMap.ts
+++ b/src/configs/tableConfigs/eventsTableMap.ts
@@ -8,6 +8,7 @@ import EventsLocationCell from "../../components/events/partials/EventsLocationC
 import EventsEndCell from "../../components/events/partials/EventsEndCell";
 import EventsStartCell from "../../components/events/partials/EventsStartCell";
 import EventsNotesCell from "../../components/events/partials/EventsNotesCell";
+import EventsLanguageCell from "../../components/events/partials/EventsLanguageCell";
 
 /**
  * This map contains the mapping between the template strings above and the corresponding react component.
@@ -24,4 +25,5 @@ export const eventsTemplateMap = {
 	EventsStatusCell: EventsStatusCell,
 	PublishedCell: PublishedCell,
 	EventsNotesCell: EventsNotesCell,
+	EventsLanguageCell: EventsLanguageCell,
 };

--- a/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
@@ -650,6 +650,7 @@
 				"PUBLISHED": "Published",
 				"WEEKDAY": "Weekday",
 				"ADMINUI_NOTES": "Notes",
+				"LANGUAGE": "Language",
 				"TOOLTIP": {
 					"ASSETS": "Open asset details",
 					"START": "Filter for this start date",
@@ -664,7 +665,8 @@
 					"COMMENTS": "View comments",
 					"PAUSED_WORKFLOW": "View paused workflow",
 					"PLAYER": "Open player",
-					"PRESENTER": "Filter for this presenter"
+					"PRESENTER": "Filter for this presenter",
+					"LANGUAGE": "Filter for this language"
 				},
 				"SELECT_ALL": "Select all events",
 				"SELECT_EVENT": "Select event \"{{title}}\""

--- a/src/slices/eventSlice.ts
+++ b/src/slices/eventSlice.ts
@@ -84,6 +84,8 @@ export type Event = {
 	technical_start: string,
 	title: string,
 	workflow_state: string,
+	language: string,
+	language_translation_key: string,
 }
 
 export type MetadataField = {


### PR DESCRIPTION
Helps with #1468.

Adds a new column to the events table that displays each events language (if set). The cells are FilterCells, so they can be clicked to set a language filter with the respective value.

The language column is deactivated per default, so this does not impact the default appearance of the events table.

**Requires https://github.com/opencast/opencast/pull/7329. Will not work otherwise.**

<img width="1537" height="740" alt="Bildschirmfoto vom 2026-01-21 16-51-20" src="https://github.com/user-attachments/assets/51a65436-49a0-4485-8991-8dd528159514" />
