### PR TITLE
Fix scheduling due to missing device id

### DIFF
--- a/src/slices/eventSlice.ts
+++ b/src/slices/eventSlice.ts
@@ -451,6 +451,7 @@ export const postNewEvent = (params: {
 		scheduleStartHour: string,
 		scheduleStartMinute: string,
 		sourceMode: string,
+		location: string,
 		uploadAssetsTrack?: UploadAssetsTrack[],
 		metadata: { [key: string]: unknown },
 	},
@@ -544,7 +545,7 @@ export const postNewEvent = (params: {
 			type: values.sourceMode,
 			metadata: {
 				start: startDate,
-				device: values.metadata.location,
+				device: values.location,
 				inputs: values.inputs ? values.inputs.join(",") : "",
 				end: endDate,
 				duration: duration.toString(),


### PR DESCRIPTION
Fixes #1515.

The function that creates the scheduling request for the backend was looking for the device id in the wrong place.

### How to test
Check if scheduling an event works again with this PR. You can create a dummy capture agent if none is available with the /capture-admin/agents/{name} endpoint.