### PR TITLE
fix formik metadata reference according to new scheme

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/NewAccessPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewAccessPage.tsx
@@ -26,7 +26,6 @@ import ModalContentTable from "../../../shared/modals/ModalContentTable";
 interface RequiredFormProps {
   metadata: {
     "dublincore/episode_isPartOf": string,
-    // other metadata fields as needed
   },
   policies: TransformedAcl[],
   aclTemplate: string,

--- a/src/components/events/partials/ModalTabsAndPages/NewAccessPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewAccessPage.tsx
@@ -24,10 +24,13 @@ import ModalContentTable from "../../../shared/modals/ModalContentTable";
  * This component renders the access page for new events and series in the wizards.
  */
 interface RequiredFormProps {
-	"dublincore/episode_isPartOf": string,
-	policies: TransformedAcl[],
-	aclTemplate: string,
-	// theme: string,
+  metadata: {
+    "dublincore/episode_isPartOf": string,
+    // other metadata fields as needed
+  },
+  policies: TransformedAcl[],
+  aclTemplate: string,
+  // theme: string,
 }
 
 const NewAccessPage = <T extends RequiredFormProps>({
@@ -121,7 +124,7 @@ const NewAccessPage = <T extends RequiredFormProps>({
 										{hasAccess(viewUsersAccessRole, user) &&
 											<AccessPolicyTable
 												isUserTable={true}
-												policiesFiltered={policiesFiltered(formik.values.metadata.policies, true)}
+												policiesFiltered={policiesFiltered(formik.values.policies, true)}
 												rolesFilteredbyPolicies={rolesFiltered(roles, true)}
 												header={"EVENTS.EVENTS.DETAILS.ACCESS.ACCESS_POLICY.USERS"}
 												firstColumnHeader={"EVENTS.EVENTS.DETAILS.ACCESS.ACCESS_POLICY.USER"}
@@ -138,7 +141,7 @@ const NewAccessPage = <T extends RequiredFormProps>({
 										{hasAccess(viewNonUsersAccessRole, user) &&
 											<AccessPolicyTable
 												isUserTable={false}
-												policiesFiltered={policiesFiltered(formik.values.metadata.policies, false)}
+												policiesFiltered={policiesFiltered(formik.values.policies, false)}
 												rolesFilteredbyPolicies={rolesFiltered(roles, false)}
 												header={"USERS.ACLS.NEW.ACCESS.ACCESS_POLICY.NON_USER_ROLES"}
 												firstColumnHeader={"EVENTS.EVENTS.DETAILS.ACCESS.ACCESS_POLICY.ROLE"}
@@ -158,7 +161,7 @@ const NewAccessPage = <T extends RequiredFormProps>({
 									<>
 										<AccessPolicyTable
 											isUserTable={false}
-											policiesFiltered={formik.values.metadata.policies}
+											policiesFiltered={formik.values.policies}
 											rolesFilteredbyPolicies={roles}
 											firstColumnHeader={"EVENTS.EVENTS.DETAILS.ACCESS.ACCESS_POLICY.ROLE"}
 											createLabel={"EVENTS.EVENTS.DETAILS.ACCESS.ACCESS_POLICY.NEW"}
@@ -186,8 +189,8 @@ const NewAccessPage = <T extends RequiredFormProps>({
 			<WizardNavigationButtons
 				formik={formik}
 				nextPage={() => {
-					if (dispatch(checkAcls(formik.values.metadata.policies))) {
-						nextPage(formik.values.metadata);
+					if (dispatch(checkAcls(formik.values.policies))) {
+						nextPage(formik.values);
 					}
 				}}
 				previousPage={previousPage}

--- a/src/components/events/partials/ModalTabsAndPages/NewAccessPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewAccessPage.tsx
@@ -76,15 +76,15 @@ const NewAccessPage = <T extends RequiredFormProps>({
 
 	// If we have to use series ACL, fetch it
 	useEffect(() => {
-		if (initEventAclWithSeriesAcl && formik.values["dublincore/episode_isPartOf"]) {
-			dispatch(fetchSeriesDetailsAcls(formik.values["dublincore/episode_isPartOf"]));
+		if (initEventAclWithSeriesAcl && formik.values.metadata["dublincore/episode_isPartOf"]) {
+			dispatch(fetchSeriesDetailsAcls(formik.values.metadata["dublincore/episode_isPartOf"]));
 		}
 	// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [formik.values["dublincore/episode_isPartOf"], initEventAclWithSeriesAcl, dispatch]);
+	}, [formik.values.metadata["dublincore/episode_isPartOf"], initEventAclWithSeriesAcl, dispatch]);
 
 	// If we have to use series ACL, overwrite existing rules
 	useEffect(() => {
-		if (initEventAclWithSeriesAcl && formik.values["dublincore/episode_isPartOf"] && seriesAcl) {
+		if (initEventAclWithSeriesAcl && formik.values.metadata["dublincore/episode_isPartOf"] && seriesAcl) {
 			formik.setFieldValue("policies", seriesAcl);
 		}
 	// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -121,7 +121,7 @@ const NewAccessPage = <T extends RequiredFormProps>({
 										{hasAccess(viewUsersAccessRole, user) &&
 											<AccessPolicyTable
 												isUserTable={true}
-												policiesFiltered={policiesFiltered(formik.values.policies, true)}
+												policiesFiltered={policiesFiltered(formik.values.metadata.policies, true)}
 												rolesFilteredbyPolicies={rolesFiltered(roles, true)}
 												header={"EVENTS.EVENTS.DETAILS.ACCESS.ACCESS_POLICY.USERS"}
 												firstColumnHeader={"EVENTS.EVENTS.DETAILS.ACCESS.ACCESS_POLICY.USER"}
@@ -138,7 +138,7 @@ const NewAccessPage = <T extends RequiredFormProps>({
 										{hasAccess(viewNonUsersAccessRole, user) &&
 											<AccessPolicyTable
 												isUserTable={false}
-												policiesFiltered={policiesFiltered(formik.values.policies, false)}
+												policiesFiltered={policiesFiltered(formik.values.metadata.policies, false)}
 												rolesFilteredbyPolicies={rolesFiltered(roles, false)}
 												header={"USERS.ACLS.NEW.ACCESS.ACCESS_POLICY.NON_USER_ROLES"}
 												firstColumnHeader={"EVENTS.EVENTS.DETAILS.ACCESS.ACCESS_POLICY.ROLE"}
@@ -158,7 +158,7 @@ const NewAccessPage = <T extends RequiredFormProps>({
 									<>
 										<AccessPolicyTable
 											isUserTable={false}
-											policiesFiltered={formik.values.policies}
+											policiesFiltered={formik.values.metadata.policies}
 											rolesFilteredbyPolicies={roles}
 											firstColumnHeader={"EVENTS.EVENTS.DETAILS.ACCESS.ACCESS_POLICY.ROLE"}
 											createLabel={"EVENTS.EVENTS.DETAILS.ACCESS.ACCESS_POLICY.NEW"}
@@ -186,8 +186,8 @@ const NewAccessPage = <T extends RequiredFormProps>({
 			<WizardNavigationButtons
 				formik={formik}
 				nextPage={() => {
-					if (dispatch(checkAcls(formik.values.policies))) {
-						nextPage(formik.values);
+					if (dispatch(checkAcls(formik.values.metadata.policies))) {
+						nextPage(formik.values.metadata);
 					}
 				}}
 				previousPage={previousPage}


### PR DESCRIPTION
Fixes #1518 

"In the add event wizard, if a series is selected in the metadata tab, the respective ACL is copied to the new event and it's automatically set and visible in the ACL tab. The bug consists in that the above expected behaviour is broken (the series ACL does not get copied to the event ACL).

"It is assumed that this unintended behaviour was introduced with https://github.com/opencast/opencast-admin-interface/commit/25b77adaa0cefdbb9b8869f88b86dfa6b80b9946"

grok.com (v4.1, Expert Mode) has helped with analysis and coding.