### PR TITLE
Fix role getting unselected when changing write

### DIFF
--- a/src/components/shared/modals/ResourceDetailsAccessPolicyTab.tsx
+++ b/src/components/shared/modals/ResourceDetailsAccessPolicyTab.tsx
@@ -547,11 +547,11 @@ export const AccessPolicyTable = <T extends AccessPolicyTabFormikProps>({
 																		handleChange={element => {
 																			if (element) {
 																				const matchingRole = roles.find(role => role.name === element.value);
-																				arrayHelpers.replace(formik.values.policies.findIndex(p => p === policy), {
-																					...policy,
-																					role: element.value,
-																					user: matchingRole ? matchingRole.user : undefined,
-																				});
+																				formik.setFieldValue(`policies.${index}.role`, element.value);
+																				formik.setFieldValue(
+																					`policies.${index}.user`,
+																					matchingRole ? matchingRole.user : undefined,
+																				);
 																			}
 																		}}
 																		placeholder={
@@ -591,10 +591,7 @@ export const AccessPolicyTable = <T extends AccessPolicyTabFormikProps>({
 																			: "false"
 																	}`}
 																	onChange={(read: React.ChangeEvent<HTMLInputElement>) =>
-																		arrayHelpers.replace(formik.values.policies.findIndex(p => p === policy), {
-																			...policy,
-																			read: read.target.checked,
-																		})
+																		formik.setFieldValue(`policies.${index}.read`, read.target.checked)
 																	}
 																/>
 															</td>
@@ -618,11 +615,7 @@ export const AccessPolicyTable = <T extends AccessPolicyTabFormikProps>({
 																			: "false"
 																	}`}
 																	onChange={(write: React.ChangeEvent<HTMLInputElement>) =>
-																		arrayHelpers.replace(formik.values.policies.findIndex(p => p === policy), {
-																			...policy,
-																			write:
-																				write.target.checked,
-																		})
+																		formik.setFieldValue(`policies.${index}.write`, write.target.checked)
 																	}
 																/>
 															</td>


### PR DESCRIPTION
Fixes #1507.

There is a bug in the access policy tab of event details that can be reproduced like so:
1. Add a new policy.
2. Set a role for the new policy.
3. Change the write rights for the new policy.

The role is now unset. This patch should fix that.