### PR TITLE
Correctly limit theme watermark filetypes

### DIFF
--- a/src/components/configuration/partials/wizard/WatermarkPage.tsx
+++ b/src/components/configuration/partials/wizard/WatermarkPage.tsx
@@ -75,7 +75,7 @@ const WatermarkPage = <T extends RequiredFormProps>({
 							</header>
 							<div className="obj-container padded">
 								<FileUpload
-									acceptableTypes="image/*"
+									acceptableTypes="image/gif,image/png,image/jpg,image/jpeg,image/bmp"
 									fileId="watermarkFile"
 									fileName="watermarkFileName"
 									formik={formik}

--- a/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
@@ -1672,7 +1672,7 @@
 					"BOTTOM_RIGHT": "Bottom right",
 					"UPLOAD": "Upload",
 					"POSITION": "Watermark position and preview",
-					"FILEUPLOAD_DESCRIPTION": "File should have an alpha channel (transparent background). Acceptable file types are: .PNG, .GIF, .SVG, .WEBP",
+					"FILEUPLOAD_DESCRIPTION": "File should have an alpha channel (transparent background). Acceptable file types are: gif, png, jp(e)g, or bmp",
 					"UPLOAD_LABEL": "Upload image",
 					"UPLOAD_BUTTON": "Upload"
 				},


### PR DESCRIPTION
Fixes #1377

This patch corrects the translation string that tells the user what acceptable files types are for watermark images in a theme. It also sets those file types as acceptable for the file upload (so the users have to at least make an effort if they really want to upload a non-supported file type).


### How to test this

In order to test this you will need to enable themes in Opencast. This can be done in `etc/org.opencastproject.organization-mh_default_org.cfg` configuration file, which should enable a new main menu option.