### PR TITLE
Filter available roles in dropdown by config

### DIFF
--- a/src/components/shared/modals/ResourceDetailsAccessPolicyTab.tsx
+++ b/src/components/shared/modals/ResourceDetailsAccessPolicyTab.tsx
@@ -467,8 +467,8 @@ export const AccessPolicyTable = <T extends AccessPolicyTabFormikProps>({
 
 	// Filter available options by custom prefixes from the config
 	if (aclDefaults) {
-		if (aclDefaults["display_role_filter_prefixes"]) {
-			const prefixes = aclDefaults["display_role_filter_prefixes"].split(",");
+		if (aclDefaults["display_role_filter_blacklist_prefixes"]) {
+			const prefixes = aclDefaults["display_role_filter_blacklist_prefixes"].split(",");
 			rolesFilteredbyPolicies = rolesFilteredbyPolicies.filter(role =>
 				!prefixes.some(prefix => role.name.startsWith(prefix)),
 			);

--- a/src/components/shared/modals/ResourceDetailsAccessPolicyTab.tsx
+++ b/src/components/shared/modals/ResourceDetailsAccessPolicyTab.tsx
@@ -465,6 +465,16 @@ export const AccessPolicyTable = <T extends AccessPolicyTabFormikProps>({
 		return newRole;
 	};
 
+	// Filter available options by custom prefixes from the config
+	if (aclDefaults) {
+		if (aclDefaults["display_role_filter_prefixes"]) {
+			const prefixes = aclDefaults["display_role_filter_prefixes"].split(",");
+			rolesFilteredbyPolicies = rolesFilteredbyPolicies.filter(role =>
+				!prefixes.some(prefix => role.name.startsWith(prefix)),
+			);
+		}
+	}
+
 	return (
 		<>
 			{/* list of policy details and interface for changing them */}


### PR DESCRIPTION
Adds a feature that reduces the number of available options in the dropdowns in the access policy tab. It does this bx matching prefixes that are defined in the
config in the backend.
This can for example be used to filter out all roles with "ROLE_GROUP" prefix, to make the dropdowns more usable.

*Will not break anything without the backend PR: https://github.com/opencast/opencast/pull/7541*

### How to test this

Requires you to be able to make config changes in the backend, else you can only test that everything works as usual.