### PR TITLE
Change text for "time in queue"

### DIFF
--- a/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
@@ -1057,7 +1057,7 @@
 						"DESCRIPTION": "Description",
 						"EXECUTION_HOST": "Execution Host",
 						"JOB": "Job",
-						"TIME_IN_QUEUE": "Time in Queue",
+						"TIME_IN_QUEUE": "Total subjobs time in queue",
 						"STARTED": "Started",
 						"FINISHED": "Finished",
 						"RETRY_STRATEGY": "Retry Strategy",


### PR DESCRIPTION
*Originally #1396*

"Time in queue" is one of the variables shown for worklow operation details. However, the name is misleading, as this does not refer to the time the operation (or the job representing it) was waiting before starting. Instead, it represents the time all the jobs the operation has spawned were waiting.
Which is why "time in queue" so often has the value "0ms", as many workflow operations simply don't spawn an jobs.

This patch attempts to make this more clear by changing "time in queue" to "total subjobs time in queue". Suggestions are welcome.