### PR TITLE
Show upload OR schedule workflows in Create Event

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/NewProcessingPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewProcessingPage.tsx
@@ -35,9 +35,12 @@ const NewProcessingPage = <T extends RequiredFormProps>({
 
 	useEffect(() => {
 		// Load workflow definitions for selecting
-		dispatch(fetchWorkflowDef("default"));
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
+		if (formik.values.sourceMode !== "UPLOAD") {
+			dispatch(fetchWorkflowDef("new-event-schedule"));
+		} else {
+			dispatch(fetchWorkflowDef("new-event-upload"));
+		}
+	}, [dispatch, formik.values.sourceMode]);
 
 	// Preselect the first item
 	useEffect(() => {

--- a/src/slices/workflowSlice.ts
+++ b/src/slices/workflowSlice.ts
@@ -53,7 +53,9 @@ const initialState: WorkflowState = {
 };
 
 // fetch workflow definitions from server
-export const fetchWorkflowDef = createAppAsyncThunk("workflow/fetchWorkflowDef", async (type: string) => {
+export const fetchWorkflowDef = createAppAsyncThunk("workflow/fetchWorkflowDef", async (
+	type: "tasks" | "delete-event" | "event-details" | "new-event-upload" | "new-event-schedule" | "default",
+) => {
 	type NewProcessing = {
 		default_workflow_id: string,
 		workflows: Workflow[],
@@ -74,6 +76,16 @@ export const fetchWorkflowDef = createAppAsyncThunk("workflow/fetchWorkflowDef",
 			break;
 		}
 		case "event-details":
+			urlParams = {
+				tags: "schedule",
+			};
+			break;
+		case "new-event-upload":
+			urlParams = {
+				tags: "upload",
+			};
+			break;
+		case "new-event-schedule":
 			urlParams = {
 				tags: "schedule",
 			};


### PR DESCRIPTION
*Originally #1533*

Fixes #1531

No matter if you were upload or scheduling a new event, the "Create Event" modal would always offer you all workflows tagged with either "upload" or "schedule" (or both). This patch changes it so that if you are uploading, you only get workflows tagged with "upload". And if you are scheduling, you only get workflows tagged with "schedule".

### How to test this

Cannot be tested with the default community workflows. You will have to use your own workflows or create new ones. I used these kind of dummy workflows:

```
id: dummy-schedule
title: Dummy Schedule
displayOrder: 1
tags:
  - schedule
operations:
  # We need at least one operation for this to be considered a valid workflow definition
  - id: defaults
```