### PR TITLE
LifeCycle Policies - Squashed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "react-hotkeys-hook": "^5.3.3",
         "react-i18next": "17.0.8",
         "react-icons": "^5.7.0",
+        "react-js-cron": "^5.0.1",
         "react-redux": "^9.3.0",
         "react-router": "^7.13.0",
         "react-select": "^5.10.2",
@@ -60,6 +61,127 @@
         "uuid": "^14.0.1",
         "vite": "^8.1.3",
         "vitest": "^4.1.10"
+      }
+    },
+    "node_modules/@ant-design/colors": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-8.0.1.tgz",
+      "integrity": "sha512-foPVl0+SWIslGUtD/xBr1p9U4AKzPhNYEseXYRRo5QSzGACYZrQbe11AYJbYfAWnWSpGBx6JjBmSeugUsD9vqQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ant-design/fast-color": "^3.0.0"
+      }
+    },
+    "node_modules/@ant-design/cssinjs": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs/-/cssinjs-2.1.2.tgz",
+      "integrity": "sha512-2Hy8BnCEH31xPeSLbhhB2ctCPXE2ZnASdi+KbSeS79BNbUhL9hAEe20SkUk+BR8aKTmqb6+FKFruk7w8z0VoRQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.11.1",
+        "@emotion/hash": "^0.8.0",
+        "@emotion/unitless": "^0.7.5",
+        "@rc-component/util": "^1.4.0",
+        "clsx": "^2.1.1",
+        "csstype": "^3.1.3",
+        "stylis": "^4.3.4"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
+      }
+    },
+    "node_modules/@ant-design/cssinjs-utils": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs-utils/-/cssinjs-utils-2.1.2.tgz",
+      "integrity": "sha512-5fTHQ158jJJ5dC/ECeyIdZUzKxE/mpEMRZxthyG1sw/AKRHKgJBg00Yi6ACVXgycdje7KahRNvNET/uBccwCnA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ant-design/cssinjs": "^2.1.2",
+        "@babel/runtime": "^7.23.2",
+        "@rc-component/util": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@ant-design/cssinjs/node_modules/@emotion/hash": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@ant-design/cssinjs/node_modules/@emotion/unitless": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@ant-design/cssinjs/node_modules/stylis": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@ant-design/fast-color": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@ant-design/fast-color/-/fast-color-3.0.1.tgz",
+      "integrity": "sha512-esKJegpW4nckh0o6kV3Tkb7NPIZYbPnnFxmQDUmL08ukXZAvV85TZBr70eGuke/CIArLaP6aw8lt9KILjnWuOw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8.x"
+      }
+    },
+    "node_modules/@ant-design/icons": {
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-6.3.2.tgz",
+      "integrity": "sha512-B6O5a5XJ4wjtNOfZejXYwHW5zvKV5gYkjGf11dHGLEbKn0ABDGndo41+gfIiXyTFhvESj4XTotuud33mUFid0g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ant-design/colors": "^8.0.1",
+        "@ant-design/icons-svg": "^4.5.0",
+        "@rc-component/util": "^1.11.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
+      }
+    },
+    "node_modules/@ant-design/icons-svg": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons-svg/-/icons-svg-4.5.0.tgz",
+      "integrity": "sha512-1BTUFyKPTBZ53MuTP8s0k5SFEXL7o3VHEOwLgzaoWKwnBeqIcqUtVshc4SKzhI6uACfqhJqBwBUE9FsWR3uULA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@ant-design/react-slick": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/react-slick/-/react-slick-2.0.0.tgz",
+      "integrity": "sha512-HMS9sRoEmZey8LsE/Yo6+klhlzU12PisjrVcydW3So7RdklyEd2qehyU6a7Yp+OYN72mgsYs3NFCyP2lCPFVqg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.28.4",
+        "clsx": "^2.1.1",
+        "json2mq": "^0.2.0",
+        "throttle-debounce": "^5.0.0"
+      },
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1069,6 +1191,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1090,6 +1215,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1111,6 +1239,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1132,6 +1263,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1272,6 +1406,752 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@rc-component/async-validator": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/async-validator/-/async-validator-6.0.0.tgz",
+      "integrity": "sha512-D3AGQwdyE58gmvx6waVSXJ80JGO+IY5L2O8HDnSOex7JNlzB3GuN/4hyHNTdhy2qtOhkpbIjmeAN3tL993wKbA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.24.4"
+      },
+      "engines": {
+        "node": ">=14.x"
+      }
+    },
+    "node_modules/@rc-component/cascader": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/cascader/-/cascader-1.17.0.tgz",
+      "integrity": "sha512-3cVNG0zrQF1PoXq262L3wGCU+/YLEC1mGSVHDl577dQmA0ZKkXFbY6nwyXo+beCcM7buo49t24jkr+QZdL7O8w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rc-component/select": "~1.8.0",
+        "@rc-component/tree": "~1.3.2",
+        "@rc-component/util": "^1.11.1",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/checkbox": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/checkbox/-/checkbox-2.0.0.tgz",
+      "integrity": "sha512-3CXGPpAR9gsPKeO2N78HAPOzU30UdemD6HGJoWVJOpa6WleaGB5kzZj3v6bdTZab31YuWgY/RxV3VKPctn0DwQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/collapse": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/collapse/-/collapse-1.2.0.tgz",
+      "integrity": "sha512-ZRYSKSS39qsFx93p26bde7JUZJshsUBEQRlRXPuJYlAiNX0vyYlF5TsAm8JZN3LcF8XvKikdzPbgAtXSbkLUkw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.10.1",
+        "@rc-component/motion": "^1.1.4",
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/color-picker": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/color-picker/-/color-picker-3.1.1.tgz",
+      "integrity": "sha512-OHaCHLHszCegdXmIq2ZRIZBN/EtpT6Wm8SG/gpzLATHbVKc/avvuKi+zlOuk05FTWvgaMmpxAko44uRJ3M+2pg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ant-design/fast-color": "^3.0.1",
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/context": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/context/-/context-2.0.2.tgz",
+      "integrity": "sha512-uiGpAlblCNlziHPwj4S4Iy/oemeuz/hR03mbiEjTCXwsqOIN3BOzsRMyDwpyO5Fm0vIEEJRUf9ZtbRLbhksuTA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rc-component/util": "^1.11.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/dialog": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/dialog/-/dialog-1.10.0.tgz",
+      "integrity": "sha512-eDukNlz9vNszAGv7i3zKXdxEd3wgVmNxuJijYt8zvTh17QwTu8KK/bdURRd/lU4qaMzhO1HKKmMrwOnkaw0BvQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rc-component/motion": "^1.3.3",
+        "@rc-component/portal": "^2.1.0",
+        "@rc-component/util": "^1.9.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/drawer": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/drawer/-/drawer-1.4.2.tgz",
+      "integrity": "sha512-1ib+fZEp6FBu+YvcIktm+nCQ+Q+qIpwpoaJH6opGr4ofh2QMq+qdr5DLC4oCf5qf3pcWX9lUWPYX652k4ini8Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rc-component/motion": "^1.1.4",
+        "@rc-component/portal": "^2.1.3",
+        "@rc-component/util": "^1.9.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/dropdown": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/dropdown/-/dropdown-1.0.2.tgz",
+      "integrity": "sha512-6PY2ecUSYhDPhkNHHb4wfeAya04WhpmUSKzdR60G+kMNVUCX2vjT/AgTS0Lz0I/K6xrPMJ3enQbwVpeN3sHCgg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rc-component/trigger": "^3.0.0",
+        "@rc-component/util": "^1.2.1",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.11.0",
+        "react-dom": ">=16.11.0"
+      }
+    },
+    "node_modules/@rc-component/form": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@rc-component/form/-/form-1.8.5.tgz",
+      "integrity": "sha512-d24EYtvUOBhxEtSd/EqIu9DaMuqrWF2IRIvAFCTM6NQ/GJIYNr8DvEpUSUlv2uPxEJ0ZPwYQ+wwlGIAaiHvdrw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rc-component/async-validator": "^6.0.0",
+        "@rc-component/util": "^1.11.1",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/image": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/image/-/image-1.9.0.tgz",
+      "integrity": "sha512-khF7w7xkBH5B1bsBcI1FSUZdkyd1aqpl2eYyILCqCzzQH3XdfehGUaZTnptyaJJfs09/R5hv9jXWyazOMFIClQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rc-component/motion": "^1.0.0",
+        "@rc-component/portal": "^2.1.2",
+        "@rc-component/util": "^1.10.1",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/input": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/input/-/input-1.3.1.tgz",
+      "integrity": "sha512-iFvTUT9W+JC/MSin2aGAk8NqsVlTzcExNC9DZariON1IWirju9NoNeEk47an4Q8iHazkoVI/y1LnDi88+CPcig==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rc-component/resize-observer": "^1.1.1",
+        "@rc-component/util": "^1.11.1",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
+      }
+    },
+    "node_modules/@rc-component/input-number": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/input-number/-/input-number-1.6.2.tgz",
+      "integrity": "sha512-Gjcq7meZlCOiWN1t1xCC+7/s85humHVokTBI7PJgTfoyw5OWF74y3e6P8PHX104g9+b54jsodFIzyaj6p8LI9w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rc-component/mini-decimal": "^1.0.1",
+        "@rc-component/util": "^1.4.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/mentions": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/mentions/-/mentions-1.10.0.tgz",
+      "integrity": "sha512-CI1njYUVY0NjHtLhNoVmXlJyy568Sfep9Wsak6vmGjtT6uazx98djGYlCXz2xkHhEm73g91Y3MTvzUyE5avI7w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rc-component/input": "~1.3.0",
+        "@rc-component/menu": "~1.4.0",
+        "@rc-component/trigger": "^3.0.0",
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/menu": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/menu/-/menu-1.4.1.tgz",
+      "integrity": "sha512-3GsVRoQ4cnF/AoIQ4P+Z1haBfgfBPQfLT1RJY3Nu4DzOnheTslfCiGSPj7bv/cLj5sW5pHqN25dDXGP3JELAlQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rc-component/motion": "^1.1.4",
+        "@rc-component/overflow": "^1.0.0",
+        "@rc-component/trigger": "^3.0.0",
+        "@rc-component/util": "^1.11.1",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/mini-decimal": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rc-component/mini-decimal/-/mini-decimal-1.1.4.tgz",
+      "integrity": "sha512-xiuXcaCwyOWpD8a8scdExFl+bntNphAW8XeenL1ig2en0AAZY0Pcp4pC0dI22qJ+NvxKn9RoNIoRdqYU3BLH4w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.18.0"
+      },
+      "engines": {
+        "node": ">=8.x"
+      }
+    },
+    "node_modules/@rc-component/motion": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@rc-component/motion/-/motion-1.3.3.tgz",
+      "integrity": "sha512-Xh3IszxvlSv3/PLYFyC2UZi9LNB83yOnkB/LNmRzaypZLvkhqUIPS7MQpGZcCMWrNsXV2p6YTSWbSGvFpEle9A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rc-component/util": "^1.11.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/mutate-observer": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/mutate-observer/-/mutate-observer-2.0.1.tgz",
+      "integrity": "sha512-AyarjoLU5YlxuValRi+w8JRH2Z84TBbFO2RoGWz9d8bSu0FqT8DtugH3xC3BV7mUwlmROFauyWuXFuq4IFbH+w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rc-component/util": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/notification": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@rc-component/notification/-/notification-2.0.7.tgz",
+      "integrity": "sha512-nqZzpf6BPdaj+3ILx7si79LLmqPKyUmQoXa+/9gg0SkH0v1DbD66oJgRMSBEVnd/zUT3D4gwxWIHUKebYf2ZXQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rc-component/motion": "^1.1.4",
+        "@rc-component/util": "^1.11.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/overflow": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/overflow/-/overflow-1.0.1.tgz",
+      "integrity": "sha512-syfmgAABaHCnCDzPwHZ/2tuvIcpOO3jefYZMmfkN+pmo8HKTzsfhS57vxo4ksPdN0By+uWVJhJWNFozNBxi2eA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.11.1",
+        "@rc-component/resize-observer": "^1.0.1",
+        "@rc-component/util": "^1.4.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/pagination": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/pagination/-/pagination-1.4.0.tgz",
+      "integrity": "sha512-CW1g7P9V8u+e8JQdUsl2RWg+GCsoee0mtJjZUCCxn/vb3jzOwDKm6hAdwddHCVBfWJ58eGUBZz3IvnU8rRktjw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rc-component/util": "^1.11.1",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/picker": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/picker/-/picker-1.11.0.tgz",
+      "integrity": "sha512-6qXGKtoJvO8sUd17m5cyNEbEJub0zflCHnaZTBBmj63DPRZYc0WEHN8rp6hFSl+yMCJS/dJY5G+1fQ8bLCuD7A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rc-component/overflow": "^1.0.0",
+        "@rc-component/resize-observer": "^1.0.0",
+        "@rc-component/trigger": "^3.6.15",
+        "@rc-component/util": "^1.11.1",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12.x"
+      },
+      "peerDependencies": {
+        "date-fns": ">= 2.x",
+        "dayjs": ">= 1.x",
+        "luxon": ">= 3.x",
+        "moment": ">= 2.x",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      },
+      "peerDependenciesMeta": {
+        "date-fns": {
+          "optional": true
+        },
+        "dayjs": {
+          "optional": true
+        },
+        "luxon": {
+          "optional": true
+        },
+        "moment": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rc-component/portal": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/portal/-/portal-2.2.1.tgz",
+      "integrity": "sha512-ck+r1kW/JSv0wxPji3KN2ss9K6Z0qqwusw/mf/0JobXhZ8hC2ejZwCJObW/SvDi0uhA0VzmCnx0CaCci95tcmA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rc-component/util": "^1.11.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12.x"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/progress": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/progress/-/progress-1.0.2.tgz",
+      "integrity": "sha512-WZUnH9eGxH1+xodZKqdrHke59uyGZSWgj5HBM5Kwk5BrTMuAORO7VJ2IP5Qbm9aH3n9x3IcesqHHR0NWPBC7fQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rc-component/util": "^1.2.1",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/qrcode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/qrcode/-/qrcode-2.0.0.tgz",
+      "integrity": "sha512-aAv3QhPP1xyafuTZOxub6a54pCeBnN3IwQkpETrBtthq4BL5IgxnCbuoBWPDpdLw1y1j6BgBUCAKV92+yX06Dw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/rate": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/rate/-/rate-1.0.1.tgz",
+      "integrity": "sha512-bkXxeBqDpl5IOC7yL7GcSYjQx9G8H+6kLYQnNZWeBYq2OYIv1MONd6mqKTjnnJYpV0cQIU2z3atdW0j1kttpTw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/resize-observer": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/resize-observer/-/resize-observer-1.1.2.tgz",
+      "integrity": "sha512-t/Bb0W8uvL4PYKAB3YcChC+DlHh0Wt5kM7q/J+0qpVEUMLe7Hk5zuvc9km0hMnTFPSx5Z7Wu/fzCLN6erVLE8Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rc-component/util": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/segmented": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/segmented/-/segmented-1.3.0.tgz",
+      "integrity": "sha512-5J/bJ01mbDnoA6P/FW8SxUvKn+OgUSTZJPzCNnTBntG50tzoP7DydGhqxp7ggZXZls7me3mc2EQDXakU3iTVFg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.11.1",
+        "@rc-component/motion": "^1.1.4",
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
+      }
+    },
+    "node_modules/@rc-component/select": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/select/-/select-1.8.2.tgz",
+      "integrity": "sha512-HQ9zuYqjfZTlcEMWlU1GAPBajd2OHIMVHyjZSGVTCVARwkfCgvXZMTEn0cduy3L+ejAKkaZluOQvxovZoaJaQw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rc-component/overflow": "^1.0.0",
+        "@rc-component/trigger": "^3.0.0",
+        "@rc-component/util": "^1.11.1",
+        "@rc-component/virtual-list": "^1.2.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@rc-component/slider": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/slider/-/slider-1.1.1.tgz",
+      "integrity": "sha512-LSzgWGYDgeCDgR4r1XlU29gbYws6HpLnvJd/uMhLeW/vQgxldeR+Wb4uzHDCHiYEbr1bnEHWdjkPxjJRHxuiig==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/steps": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/steps/-/steps-1.2.2.tgz",
+      "integrity": "sha512-/yVIZ00gDYYPHSY0JP+M+s3ZvuXLu2f9rEjQqiUDs7EcYsUYrpJ/1bLj9aI9R7MBR3fu/NGh6RM9u2qGfqp+Nw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rc-component/util": "^1.2.1",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/switch": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rc-component/switch/-/switch-1.0.3.tgz",
+      "integrity": "sha512-Jgi+EbOBquje/XNdofr7xbJQZPYJP+BlPfR0h+WN4zFkdtB2EWqEfvkXJWeipflwjWip0/17rNbxEAqs8hVHfw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/table": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/@rc-component/table/-/table-1.10.3.tgz",
+      "integrity": "sha512-AiONZrgXVIewFC2Pk3GTqbov+sJhWDZZ96QbJZQGNSrX/vcMzkqoFJVcipGH4OY6EmFSKApwbOhQth6DVyB6gQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rc-component/context": "^2.0.1",
+        "@rc-component/resize-observer": "^1.0.0",
+        "@rc-component/util": "^1.11.1",
+        "@rc-component/virtual-list": "^1.0.1",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/tabs": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/tabs/-/tabs-1.11.0.tgz",
+      "integrity": "sha512-hA/drZYOVa/MMIb4M2fWf3yaTyTG4qVuIABmghvEhyfw2nBob5VTH69lMCDjSVKmgODjO6nWlCV+gVn3xBrj5Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rc-component/dropdown": "~1.0.0",
+        "@rc-component/menu": "~1.4.0",
+        "@rc-component/motion": "^1.1.3",
+        "@rc-component/resize-observer": "^1.0.0",
+        "@rc-component/util": "^1.11.1",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/tooltip": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/tooltip/-/tooltip-1.4.0.tgz",
+      "integrity": "sha512-8Rx5DCctIlLI4raR0I0xHjVTf1aF48+gKCNeAAo5bmF5VoR5YED+A/XEqzXv9KKqrJDRcd3Wndpxh2hyzrTtSg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rc-component/trigger": "^3.7.1",
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/tour": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/tour/-/tour-2.4.0.tgz",
+      "integrity": "sha512-aui4r4TqmTzwaBgcQxHYep8kM8PTjZFufjokObpy35KfFeZ0k9ArquWFZqegQlH24P14t+F0qO0mGTgzlav1yg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rc-component/portal": "^2.2.0",
+        "@rc-component/trigger": "^3.0.0",
+        "@rc-component/util": "^1.7.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/tree": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/tree/-/tree-1.3.2.tgz",
+      "integrity": "sha512-bJFj46wEkpBPnWyTm18XmgAgNQ/4YvprxMOPPY2a6rmhGJYxLuNKEFiL5Qej4Qctu9wHJm8WW+v2SYskafE0kA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rc-component/motion": "^1.0.0",
+        "@rc-component/util": "^1.11.1",
+        "@rc-component/virtual-list": "^1.2.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=10.x"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@rc-component/tree-select": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/tree-select/-/tree-select-1.11.0.tgz",
+      "integrity": "sha512-EhS0X0wtUhBfK4S5TlpSY3MR9ndPMGgujtt1PJW3Ej+ToAlnS/6ohYURtCoXBYGqazUwHmgQGVUDsfpVwhWPkg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rc-component/select": "~1.8.0",
+        "@rc-component/tree": "~1.3.2",
+        "@rc-component/util": "^1.11.1",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@rc-component/trigger": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/trigger/-/trigger-3.9.1.tgz",
+      "integrity": "sha512-LNsYvz60mrLJ/kRvKcHE7boUvcQfVMCfRqZ71x3Fo9AOiZ1KKIEqkzMA8DNvz2V3Bcvir/vwQNn7JF1NPODQ7Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rc-component/motion": "^1.1.4",
+        "@rc-component/portal": "^2.2.0",
+        "@rc-component/resize-observer": "^1.1.1",
+        "@rc-component/util": "^1.2.1",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/upload": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/upload/-/upload-1.1.1.tgz",
+      "integrity": "sha512-GvYWSKeaJTOxxC5p6+nOSadzfvXA1h8C/iHFPFZX+szH3JUXrvs+DLiW8YUTBgvMh8m63mJeHrlYlJzAlg+pDA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rc-component/util": "^1.11.1",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/util": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/util/-/util-1.11.1.tgz",
+      "integrity": "sha512-awVlI3ub2vqfqkYxOBc/uQ0efm3jw0wcrhtO/YWLyZfxiKXczKwNbVuhlnyxytDt7H9pbbVQiqr+O6MLATtRYg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "is-mobile": "^5.0.0",
+        "react-is": "^18.2.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/util/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@rc-component/virtual-list": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/virtual-list/-/virtual-list-1.2.0.tgz",
+      "integrity": "sha512-iavRm1Jo4GDbASQwdGa7jFyk93RvSOo9xHyBT4QL1pgFJj/Fdf1G+3RErH7/7BmAMvx2AkF62mjGYxDbXsK9TQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.20.0",
+        "@rc-component/resize-observer": "^1.0.1",
+        "@rc-component/util": "^1.4.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
       }
     },
     "node_modules/@redux-devtools/extension": {
@@ -2246,6 +3126,70 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/antd": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/antd/-/antd-6.5.0.tgz",
+      "integrity": "sha512-9zbVc9UukfGuqCvIAov01nlpDQWfARNmZQyt21ZhqLX7ilXmi4cdkp12xA48WEmXRXwZvno8A03qQuGE9JG8fg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ant-design/colors": "^8.0.1",
+        "@ant-design/cssinjs": "^2.1.2",
+        "@ant-design/cssinjs-utils": "^2.1.2",
+        "@ant-design/fast-color": "^3.0.1",
+        "@ant-design/icons": "^6.3.1",
+        "@ant-design/react-slick": "~2.0.0",
+        "@babel/runtime": "^7.29.2",
+        "@rc-component/cascader": "~1.17.0",
+        "@rc-component/checkbox": "~2.0.0",
+        "@rc-component/collapse": "~1.2.0",
+        "@rc-component/color-picker": "~3.1.1",
+        "@rc-component/dialog": "~1.10.0",
+        "@rc-component/drawer": "~1.4.2",
+        "@rc-component/dropdown": "~1.0.2",
+        "@rc-component/form": "~1.8.5",
+        "@rc-component/image": "~1.9.0",
+        "@rc-component/input": "~1.3.1",
+        "@rc-component/input-number": "~1.6.2",
+        "@rc-component/mentions": "~1.10.0",
+        "@rc-component/menu": "~1.4.1",
+        "@rc-component/motion": "^1.3.3",
+        "@rc-component/mutate-observer": "^2.0.1",
+        "@rc-component/notification": "~2.0.7",
+        "@rc-component/pagination": "~1.4.0",
+        "@rc-component/picker": "~1.11.0",
+        "@rc-component/progress": "~1.0.2",
+        "@rc-component/qrcode": "~2.0.0",
+        "@rc-component/rate": "~1.0.1",
+        "@rc-component/resize-observer": "^1.1.2",
+        "@rc-component/segmented": "~1.3.0",
+        "@rc-component/select": "~1.8.2",
+        "@rc-component/slider": "~1.1.1",
+        "@rc-component/steps": "~1.2.2",
+        "@rc-component/switch": "~1.0.3",
+        "@rc-component/table": "~1.10.2",
+        "@rc-component/tabs": "~1.11.0",
+        "@rc-component/tooltip": "~1.4.0",
+        "@rc-component/tour": "~2.4.0",
+        "@rc-component/tree": "~1.3.2",
+        "@rc-component/tree-select": "~1.11.0",
+        "@rc-component/trigger": "^3.9.1",
+        "@rc-component/upload": "~1.1.1",
+        "@rc-component/util": "^1.11.1",
+        "clsx": "^2.1.1",
+        "dayjs": "^1.11.11",
+        "scroll-into-view-if-needed": "^3.1.0",
+        "throttle-debounce": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ant-design"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -2693,6 +3637,13 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/compute-scroll-into-view": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
+      "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2837,6 +3788,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -4276,6 +5234,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-mobile": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-mobile/-/is-mobile-5.0.0.tgz",
+      "integrity": "sha512-Tz/yndySvLAEXh+Uk8liFCxOwVH6YutuR74utvOcu7I9Di+DwM0mtdPVZNaVvvBUM2OXxne/NhOs1zAO7riusQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/is-negative-zero": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
@@ -4569,6 +5534,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json2mq": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
+      "integrity": "sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "string-convert": "^0.2.0"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -4752,6 +5727,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4773,6 +5751,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5558,6 +6539,17 @@
       "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
       "license": "MIT"
     },
+    "node_modules/react-js-cron": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-js-cron/-/react-js-cron-5.2.0.tgz",
+      "integrity": "sha512-+Mxm3cS7qmIoAIz7NVY27jvsJKNZ4tx+H/nNtMUJW4DcKR7jUIL1GP0jOD79K5j86Dq8jvShKJMh30+c8bmVtA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "antd": ">=5.8.0",
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
     "node_modules/react-redux": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
@@ -5921,6 +6913,16 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
+    "node_modules/scroll-into-view-if-needed": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.1.0.tgz",
+      "integrity": "sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "compute-scroll-into-view": "^3.0.2"
+      }
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -6139,6 +7141,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/string-convert": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
+      "integrity": "sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.12",
       "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
@@ -6297,6 +7306,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/throttle-debounce": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-5.0.2.tgz",
+      "integrity": "sha512-B71/4oyj61iNH0KeCamLuE2rmKuTO5byTOSVwECM5FA7TiAiAW+UqTKZ9ERueC4qvgSttUhdmq1mXC3kJqGX7A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.22"
       }
     },
     "node_modules/tiny-case": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react-hotkeys-hook": "^5.3.3",
     "react-i18next": "17.0.8",
     "react-icons": "^5.7.0",
+    "react-js-cron": "^5.0.1",
     "react-redux": "^9.3.0",
     "react-router": "^7.13.0",
     "react-select": "^5.10.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import About from "./components/About";
 import Playlists from "./components/events/Playlists";
 import { useAppDispatch } from "./store";
 import { fetchOcVersion, fetchUserInfo } from "./slices/userInfoSlice";
+import LifeCyclePolicies from "./components/events/LifeCyclePolicies";
 import { subscribeToAuthEvents } from "./utils/broadcastSync";
 import { useTableFilterStateValidation } from "./hooks/useTableFilterStateValidation";
 
@@ -50,6 +51,8 @@ function App() {
 				<Route path={"/events/series"} element={<Series />} />
 
 				<Route path={"/events/playlists"} element={<Playlists />} />
+
+				<Route path={"/events/lifeCyclePolicies"} element={<LifeCyclePolicies />} />
 
 				<Route path={"/recordings/recordings"} element={<Recordings />} />
 

--- a/src/components/events/LifeCyclePolicies.tsx
+++ b/src/components/events/LifeCyclePolicies.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import TableFilters from "../shared/TableFilters";
+import Table from "../shared/Table";
+import Notifications from "../shared/Notifications";
+import { loadLifeCyclePoliciesIntoTable } from "../../thunks/tableThunks";
+import { fetchFilters } from "../../slices/tableFilterSlice";
+import Header from "../Header";
+import NavBar from "../NavBar";
+import MainView from "../MainView";
+import Footer from "../Footer";
+import { useAppDispatch, useAppSelector } from "../../store";
+import { getTotalLifeCyclePolicies } from "../../selectors/lifeCycleSelectors";
+import {
+	fetchLifeCyclePolicies,
+	LifeCyclePolicy as LifeCyclePolicyRow,
+} from "../../slices/lifeCycleSlice";
+import { lifeCyclePoliciesTemplateMap } from "../../configs/tableConfigs/lifeCyclePoliciesTableMap";
+import { fetchLifeCyclePolicyActions, fetchLifeCyclePolicyTargetTypes, fetchLifeCyclePolicyTimings } from "../../slices/lifeCycleDetailsSlice";
+import { ModalHandle } from "../shared/modals/Modal";
+import { eventsLinks } from "./partials/EventsNavigation";
+import { resetTableProperties, Row } from "../../slices/tableSlice";
+import LifeCyclePolicyDetailsModal from "./partials/modals/LifeCyclePolicyDetailsModal";
+
+/**
+ * This component renders the table view of policies
+ */
+const LifeCyclePolicies = () => {
+	const { t } = useTranslation();
+	const dispatch = useAppDispatch();
+	const [displayNavigation, setNavigation] = useState(false);
+	const newPolicyModalRef = useRef<ModalHandle>(null);
+
+	const policiesTotal = useAppSelector(state => getTotalLifeCyclePolicies(state));
+
+	useEffect(() => {
+		// State variable for interrupting the load function
+		let allowLoadIntoTable = true;
+
+		// Clear table of previous data
+		dispatch(resetTableProperties());
+
+		dispatch(fetchFilters("lifeCyclePolicies"));
+
+		// Load policies on mount
+		const loadLifeCyclePolicies = async () => {
+			// Fetching policies from server
+			await dispatch(fetchLifeCyclePolicies());
+
+			// Load policies into table
+			if (allowLoadIntoTable) {
+				dispatch(loadLifeCyclePoliciesIntoTable());
+			}
+		};
+		loadLifeCyclePolicies();
+
+		// Fetch policies repeatedly
+		const fetchInterval = setInterval(() => { loadLifeCyclePolicies(); }, 5000);
+
+		return () => {
+			allowLoadIntoTable = false;
+			clearInterval(fetchInterval);
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
+	const showNewPolicyModal = async () => {
+		await dispatch(fetchLifeCyclePolicyActions());
+		await dispatch(fetchLifeCyclePolicyTargetTypes());
+		await dispatch(fetchLifeCyclePolicyTimings());
+
+		newPolicyModalRef.current?.open();
+	};
+
+	return (
+		<>
+			<Header />
+			<NavBar
+				displayNavigation={displayNavigation}
+				setNavigation={setNavigation}
+				navAriaLabel={"EVENTS.EVENTS.NAVIGATION.LABEL"}
+				links={
+					eventsLinks
+				}
+				create={{
+					accessRole: "ROLE_UI_EVENTS_CREATE",
+					onShowModal: showNewPolicyModal,
+					text: "LIFECYCLE.POLICIES.TABLE.ADD_POLICY",
+					resource: "lifecyclepolicy",
+				}}
+			>
+			</NavBar>
+
+			<MainView open={displayNavigation}>
+				{/* Include notifications component */}
+				<Notifications context={"other"}/>
+
+				<div className="controls-container">
+					{/* Include filters component */}
+					{/* LifeCycle policies are not indexed, can't search or filter them */}
+					{/* But if we don't include this component, the policies won't load on page load, because the first
+							fetch request we send to the backend contains invalid params >.> */}
+					<TableFilters
+						loadResource={fetchLifeCyclePolicies}
+						loadResourceIntoTable={loadLifeCyclePoliciesIntoTable}
+						resource={"lifeCyclePolicies"}
+					/>
+
+					<h1>{t("LIFECYCLE.POLICIES.TABLE.CAPTION")}</h1>
+					<h4>{t("TABLE_SUMMARY", { numberOfRows: policiesTotal })}</h4>
+				</div>
+				{/* Include table component */}
+				<Table<Row & LifeCyclePolicyRow>
+					templateMap={lifeCyclePoliciesTemplateMap}
+					fetchResource={fetchLifeCyclePolicies}
+					loadResourceIntoTable={loadLifeCyclePoliciesIntoTable}
+				/>
+			</MainView>
+			<Footer />
+
+			{/* Include table modal */}
+			<LifeCyclePolicyDetailsModal />
+		</>
+	);
+};
+
+export default LifeCyclePolicies;

--- a/src/components/events/partials/EventsNavigation.tsx
+++ b/src/components/events/partials/EventsNavigation.tsx
@@ -23,4 +23,9 @@ export const eventsLinks: {
     accessRole: "ROLE_UI_PLAYLISTS_VIEW",
     text: "EVENTS.PLAYLISTS.TABLE.CAPTION",
   },
+  {
+    path: "/events/lifeCyclePolicies",
+    accessRole: "ROLE_UI_LIFECYCLEPOLICIES_VIEW",
+    text: "LIFECYCLE.NAVIGATION.POLICIES",
+  },
 ];

--- a/src/components/events/partials/LifeCyclePolicyActionCell.tsx
+++ b/src/components/events/partials/LifeCyclePolicyActionCell.tsx
@@ -1,0 +1,54 @@
+import { useAppDispatch } from "../../../store";
+import { deleteLifeCyclePolicy, LifeCyclePolicy } from "../../../slices/lifeCycleSlice";
+import { fetchLifeCyclePolicyDetails, openModal } from "../../../slices/lifeCycleDetailsSlice";
+import ButtonLikeAnchor from "../../shared/ButtonLikeAnchor";
+import { LuFileText } from "react-icons/lu";
+import { ActionCellDelete } from "../../shared/ActionCellDelete";
+
+/**
+ * This component renders the title cells of series in the table view
+ */
+const LifeCyclePolicyActionCell = ({
+	row,
+}: {
+	row: LifeCyclePolicy
+}) => {
+	const dispatch = useAppDispatch();
+
+	const showLifeCyclePolicyDetails = async () => {
+		await dispatch(fetchLifeCyclePolicyDetails(row.id));
+
+		dispatch(openModal(row));
+	};
+
+	const deletingPolicy = (id: string) => {
+		dispatch(deleteLifeCyclePolicy(id));
+	};
+
+	return (
+		<>
+			{/* view details location/recording */}
+			<ButtonLikeAnchor
+				onClick={() => { showLifeCyclePolicyDetails(); }}
+				className={"action-cell-button"}
+				editAccessRole={"ROLE_UI_LIFECYCLEPOLICY_DETAILS_VIEW"}
+				// tooltipText={"LIFECYCLE.POLICIES.TABLE.TOOLTIP.DETAILS"} // Disabled due to performance concerns
+			>
+				<LuFileText />
+			</ButtonLikeAnchor>
+
+
+			{/* delete policy */}
+			<ActionCellDelete
+				editAccessRole={"ROLE_UI_LIFECYCLEPOLICY_DELETE"}
+				// tooltipText={"LIFECYCLE.POLICIES.TABLE.TOOLTIP.DELETE"} // Disabled due to performance concerns
+				resourceId={row.id}
+				resourceName={row.title}
+				resourceType={"LIFECYCLE_POLICY"}
+				deleteMethod={deletingPolicy}
+			/>
+		</>
+	);
+};
+
+export default LifeCyclePolicyActionCell;

--- a/src/components/events/partials/LifeCyclePolicyIsActiveCell.tsx
+++ b/src/components/events/partials/LifeCyclePolicyIsActiveCell.tsx
@@ -1,0 +1,21 @@
+import { LifeCyclePolicy } from "../../../slices/lifeCycleSlice";
+
+/**
+ * This component renders the maintenance cells of servers in the table view
+ */
+const LifeCyclePolicyIsActiveCell = ({
+	row,
+}: {
+	row: LifeCyclePolicy
+}) => {
+
+	return (
+		<input
+			type="checkbox"
+			checked={row.isActive}
+			disabled={true}
+		/>
+	);
+};
+
+export default LifeCyclePolicyIsActiveCell;

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsLifeCyclePolicy.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsLifeCyclePolicy.tsx
@@ -1,0 +1,111 @@
+import { useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { useAppDispatch, useAppSelector } from "../../../../store";
+import { getLifeCyclePoliciesForEvent } from "../../../../selectors/eventDetailsSelectors";
+import { fetchEventLifeCyclePolicies } from "../../../../slices/eventDetailsSlice";
+import ModalContentTable from "../../../shared/modals/ModalContentTable";
+import Notifications from "../../../shared/Notifications";
+import ButtonLikeAnchor from "../../../shared/ButtonLikeAnchor";
+import { LuChevronRight } from "react-icons/lu";
+import { useNavigate } from "react-router";
+import { fetchLifeCyclePolicyDetails, openModal } from "../../../../slices/lifeCycleDetailsSlice";
+import { LifeCyclePolicy } from "../../../../slices/lifeCycleSlice";
+
+
+/**
+ * This component shows lifecycle policies that would affect the event
+ */
+const EventDetailsLifeCyclePolicy = ({
+  eventId,
+}: {
+  eventId: string,
+}) => {
+  const { t } = useTranslation();
+  const dispatch = useAppDispatch();
+  const navigate = useNavigate();
+
+  const policies = useAppSelector(state => getLifeCyclePoliciesForEvent(state));
+
+  useEffect(() => {
+    dispatch(fetchEventLifeCyclePolicies(eventId));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const openPolicyDetails = async (policy: LifeCyclePolicy) => {
+    await dispatch(fetchLifeCyclePolicyDetails(policy.id));
+    dispatch(openModal(policy));
+    navigate("/events/lifeCyclePolicies");
+  };
+
+  return (
+    <ModalContentTable
+      modalBodyChildren={<Notifications context="not_corner" />}
+    >
+      {/* Disclaimer */}
+      <div className="obj list-obj">
+        <header className="no-expand">
+          {t("EVENTS.EVENTS.DETAILS.LIFECYCLEPOLICIES.DISCLAIMER.TITLE")}
+        </header>
+        <div className="obj-container">
+          <span>{t("EVENTS.EVENTS.DETAILS.LIFECYCLEPOLICIES.DISCLAIMER.MESSAGE")}</span>
+        </div>
+      </div>
+
+      <div className="obj tbl-container">
+        {
+          /* No policies message */
+          policies.length === 0 && (
+            <table className="main-tbl">
+              <tr>
+                <td colSpan={4}>
+                  {t("EVENTS.EVENTS.DETAILS.LIFECYCLEPOLICIES.EMPTY")}
+                </td>
+              </tr>
+            </table>
+          )
+        }
+
+        { policies.length !== 0 && (
+          <div className="obj-container">
+            <table className="main-tbl">
+                <>
+                  <thead>
+                    <tr>
+                      <th>
+                        {t("EVENTS.EVENTS.DETAILS.LIFECYCLEPOLICIES.TABLE_TITLE")}
+                      </th>
+                      <th className="medium" />
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {
+                      policies.map((policy, key) => (
+                        <tr key={key}>
+                          <td>
+                            {policy.title}
+                          </td>
+
+                          {/* link to 'Details' sub-Tab */}
+                          <td>
+                            <ButtonLikeAnchor
+                              className="details-link"
+                              onClick={() => { openPolicyDetails(policy); }}
+                            >
+                              {t("EVENTS.EVENTS.DETAILS.MEDIA.DETAILS")}
+                              <LuChevronRight className="details-link-icon"/>
+                            </ButtonLikeAnchor>
+                          </td>
+                        </tr>
+                      ))
+                    }
+                  </tbody>
+                </>
+            </table>
+          </div>
+        )}
+      </div>
+    </ModalContentTable>
+  );
+};
+
+export default EventDetailsLifeCyclePolicy;

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowSchedulingTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowSchedulingTab.tsx
@@ -152,6 +152,7 @@ const EventDetailsWorkflowSchedulingTab = ({
 													<div className="obj-container padded">
 														{hasCurrentAgentAccess() &&
 															isRoleWorkflowEdit &&
+															formik.values.configuration &&
 															!!workflowConfiguration &&
 															!!workflowConfiguration.workflowId && (
 																<div
@@ -162,7 +163,8 @@ const EventDetailsWorkflowSchedulingTab = ({
 																		workflowId={
 																			formik.values.workflowId
 																		}
-																		formik={formik}
+																		configuration={formik.values.configuration}
+																		configurationName={"configuration"}
 																	/>
 																</div>
 															)}

--- a/src/components/events/partials/ModalTabsAndPages/LifeCyclePolicyAccessTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/LifeCyclePolicyAccessTab.tsx
@@ -1,0 +1,56 @@
+import { useEffect } from "react";
+import ResourceDetailsAccessPolicyTab from "../../../shared/modals/ResourceDetailsAccessPolicyTab";
+import { removeNotificationWizardForm } from "../../../../slices/notificationSlice";
+import { useAppDispatch, useAppSelector } from "../../../../store";
+import { getLifeCyclePolicyDetailsAcl } from "../../../../selectors/lifeCycleDetailsSelectors";
+import { fetchLifeCyclePolicyDetailsAcls, updateLifeCyclePolicyAccess } from "../../../../slices/lifeCycleDetailsSlice";
+import { ParseKeys } from "i18next";
+
+/**
+ * This component manages the access policy tab of the series details modal
+ */
+const LifeCyclePolicyDetailsAccessTab = ({
+	seriesId,
+	header,
+	policyChanged,
+	setPolicyChanged,
+}: {
+	seriesId: string,
+	header: ParseKeys,
+	policyChanged: boolean,
+	setPolicyChanged: (value: boolean) => void,
+}) => {
+	const dispatch = useAppDispatch();
+
+	const acl = useAppSelector(state => getLifeCyclePolicyDetailsAcl(state));
+
+	useEffect(() => {
+		dispatch(removeNotificationWizardForm());
+	// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
+	return (
+		<ResourceDetailsAccessPolicyTab
+			resourceId={seriesId}
+			header={header}
+			buttonText={"LIFECYCLE.POLICIES.DETAILS.ACCESS.LABEL"}
+			policies={acl}
+			policyTemplateId={0}	// TODO: Improve?
+			fetchAccessPolicies={fetchLifeCyclePolicyDetailsAcls}
+			// @ts-expect-error: TODO: Figure out why typescript is being funky here
+			saveNewAccessPolicies={updateLifeCyclePolicyAccess}
+			descriptionText={"LIFECYCLE.POLICIES.DETAILS.ACCESS.DESCRIPTION"}
+			policyTableHeaderText={"LIFECYCLE.POLICIES.DETAILS.ACCESS.NON_USER_ROLES"}
+			policyTableRoleText={"LIFECYCLE.POLICIES.DETAILS.ACCESS.ROLE"}
+			policyTableNewText={"LIFECYCLE.POLICIES.DETAILS.ACCESS.NEW"}
+			userPolicyTableHeaderText={"LIFECYCLE.POLICIES.DETAILS.ACCESS.USERS"}
+			userPolicyTableRoleText={"LIFECYCLE.POLICIES.DETAILS.ACCESS.USER"}
+			userPolicyTableNewText={"LIFECYCLE.POLICIES.DETAILS.ACCESS.NEW_USER"}
+			editAccessRole={"ROLE_UI_LIFECYCLEPOLICY_DETAILS_ACL_EDIT"}
+			policyChanged={policyChanged}
+			setPolicyChanged={setPolicyChanged}
+		/>
+	);
+};
+
+export default LifeCyclePolicyDetailsAccessTab;

--- a/src/components/events/partials/ModalTabsAndPages/LifeCyclePolicyGeneralTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/LifeCyclePolicyGeneralTab.tsx
@@ -3,7 +3,6 @@ import { LifeCyclePolicy, TargetFilter } from "../../../../slices/lifeCycleSlice
 import { useAppDispatch, useAppSelector } from "../../../../store";
 import { Formik, FormikProps } from "formik";
 import Notifications from "../../../shared/Notifications";
-import cn from "classnames";
 import { ConfigurationPanelField } from "../../../../slices/workflowSlice";
 import { updateLifeCyclePolicy } from "../../../../slices/lifeCycleDetailsSlice";
 import LifeCyclePolicyGeneralFields from "../wizards/LifeCyclePolicyGeneralFields";
@@ -12,6 +11,9 @@ import { getUserInformation } from "../../../../selectors/userInfoSelectors";
 import { LifeCyclePolicySchema } from "../../../../utils/validate";
 import _ from "lodash";
 import { parseTargetFiltersForEditing, parseTargetFiltersForSubmit } from "../../../../utils/lifeCycleUtils";
+import WizardNavigationButtons from "../../../shared/wizard/WizardNavigationButtons";
+import { addNotification } from "../../../../slices/notificationSlice";
+import { NOTIFICATION_CONTEXT } from "../../../../configs/modalConfig";
 
 /**
  * This component renders details about a recording/capture agent
@@ -54,7 +56,24 @@ const LifeCyclePolicyGeneralTab = ({
 		};
 		// values.actionParameters["workflowParameters"] = JSON.stringify(workflowParameters);
 
-		dispatch(updateLifeCyclePolicy(newValues));
+		dispatch(updateLifeCyclePolicy(newValues))
+			.unwrap()
+			.then(() => {
+				dispatch(addNotification({
+					type: "info",
+					key: "LIFECYCLE_POLICY_SAVED",
+					duration: 3,
+					context: NOTIFICATION_CONTEXT,
+				}));
+			})
+			.catch(() => {
+				dispatch(addNotification({
+					type: "warning",
+					key: "LIFECYCLE_POLICY_NOT_SAVED",
+					duration: 3,
+					context: NOTIFICATION_CONTEXT,
+				}));
+			});
 	};
 
 	// set current values of metadata fields as initial values
@@ -150,30 +169,15 @@ const LifeCyclePolicyGeneralTab = ({
 									</div>
 
 									{formik.dirty && (
-										<>
-											{/* Render buttons for updating metadata */}
-											<footer>
-												<button
-													type="submit"
-													onClick={() => formik.handleSubmit()}
-													disabled={!checkValidity(formik)}
-													className={cn("submit", {
-														active: checkValidity(formik),
-														inactive: !checkValidity(formik),
-													})}
-												>
-													{t("SAVE")}
-												</button>
-												<button
-													className="cancel"
-													onClick={() => formik.resetForm()}
-												>
-													{t("CANCEL")}
-												</button>
-											</footer>
-
-											<div className="btm-spacer" />
-										</>
+										// Render buttons for updating metadata
+										<WizardNavigationButtons
+											formik={formik}
+											customValidation={!checkValidity(formik)}
+											previousPage={() => formik.resetForm()}
+											createTranslationString="SAVE"
+											cancelTranslationString="CANCEL"
+											isLast
+										/>
 									)}
 								{/* </div> */}
 							</div>

--- a/src/components/events/partials/ModalTabsAndPages/LifeCyclePolicyGeneralTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/LifeCyclePolicyGeneralTab.tsx
@@ -1,0 +1,188 @@
+import { useTranslation } from "react-i18next";
+import { LifeCyclePolicy, TargetFilter } from "../../../../slices/lifeCycleSlice";
+import { useAppDispatch, useAppSelector } from "../../../../store";
+import { Formik, FormikProps } from "formik";
+import Notifications from "../../../shared/Notifications";
+import cn from "classnames";
+import { ConfigurationPanelField } from "../../../../slices/workflowSlice";
+import { updateLifeCyclePolicy } from "../../../../slices/lifeCycleDetailsSlice";
+import LifeCyclePolicyGeneralFields from "../wizards/LifeCyclePolicyGeneralFields";
+import { hasAccess } from "../../../../utils/utils";
+import { getUserInformation } from "../../../../selectors/userInfoSelectors";
+import { LifeCyclePolicySchema } from "../../../../utils/validate";
+import _ from "lodash";
+import { parseTargetFiltersForEditing, parseTargetFiltersForSubmit } from "../../../../utils/lifeCycleUtils";
+
+/**
+ * This component renders details about a recording/capture agent
+ */
+const LifeCyclePolicyGeneralTab = ({
+	policy,
+}: {
+	policy: LifeCyclePolicy
+}) => {
+	const { t } = useTranslation();
+	const dispatch = useAppDispatch();
+
+	const user = useAppSelector(state => getUserInformation(state));
+
+	const handleSubmit = (values: LifeCyclePolicy & {
+		workflowParameters: ConfigurationPanelField[],
+		targetFiltersTransformed: { [key: string]: (TargetFilter & { filter: string })[] }
+	}) => {
+
+		// Parse filters
+		const targetFilters: typeof values["targetFilters"] = parseTargetFiltersForSubmit(values.targetFiltersTransformed);
+
+		// TODO: Improve workflowParameters rendering
+		// Parse action parameters
+		// const workflowParameters: { [key: string]: unknown} = {};
+		// for (const field of values.workflowParameters) {
+		//   if (field.fieldset && field.fieldset.length > 0) {
+		//     workflowParameters[field.fieldset[0].name] = field.fieldset[0].value
+		//   }
+		// }
+		// const newActionParameters = {
+		//   ...values.actionParameters,
+		//   workflowParameters
+		// }
+
+		const newValues = {
+			...values,
+			targetFilters: targetFilters,
+			// actionParameters: newActionParameters,
+		};
+		// values.actionParameters["workflowParameters"] = JSON.stringify(workflowParameters);
+
+		dispatch(updateLifeCyclePolicy(newValues));
+	};
+
+	// set current values of metadata fields as initial values
+	const getInitialValues = (policy: LifeCyclePolicy) => {
+		const initialValues: LifeCyclePolicy & {
+			workflowParameters: ConfigurationPanelField[],
+			targetFiltersTransformed: { [key: string]: (TargetFilter & { filter: string })[] }
+		} = {
+			workflowParameters: [],
+			targetFiltersTransformed: {},
+			...policy,
+		};
+
+		// Access policies are handled in a different tab
+		// Remove them here, else they will delete the ACL due to their formatting
+		// @ts-expect-error: TODO: Find a typesafe (or straight up better) way to do this
+		delete initialValues.accessControlEntries;
+
+		// Transform filters into something more editable
+		const targetFiltersTransformed = {
+			"dublincore/episode": [],
+			...parseTargetFiltersForEditing(policy.targetFilters),
+		};
+		// for (const key in policy.targetFilters) {
+		// 	targetFiltersArray.push({
+		// 		filter: key,
+		// 		...policy.targetFilters[key],
+		// 	});
+		// }
+
+		// TODO: Improve workflowParameters rendering
+		// Parse action parameters
+		// const configPanelFields: ConfigurationPanelField[] = []
+		// const workflowParameters = JSON.parse(policy.actionParameters["workflowParameters"] as string)
+		// Object.entries(workflowParameters).forEach(([key, value]) => {
+		//   configPanelFields.push({
+		//     fieldset: [{
+		//       name: key,
+		//       value: value,
+		//       defaultValue: value,
+		//       type: "text",
+		//       checked: false,
+		//       label: key,
+		//     }]
+		//   });
+		// });
+
+		initialValues.targetFiltersTransformed = targetFiltersTransformed;
+		// initialValues.workflowParameters = configPanelFields;
+
+		return initialValues;
+	};
+
+	const checkValidity = (formik: FormikProps<ReturnType<typeof getInitialValues>>) => {
+		if (formik.dirty && formik.isValid && hasAccess("ROLE_UI_LIFECYCLEPOLICY_DETAILS_GENERAL_EDIT", user)) {
+			// check if user provided values differ from initial ones
+			return !_.isEqual(formik.values, formik.initialValues);
+		} else {
+			return false;
+		}
+	};
+
+	return (
+		// initialize form
+		<Formik
+			enableReinitialize
+			initialValues={getInitialValues(policy)}
+			validationSchema={LifeCyclePolicySchema[0]}
+			onSubmit={values => handleSubmit(values)}
+		>
+			{formik => (
+				<>
+					<div className="modal-content">
+						<div className="modal-body">
+							<Notifications context="not_corner" />
+							<div className="full-col">
+								{/* <div className="obj tbl-list">
+									<header className="no-expand">{t("LIFECYCLE.POLICIES.DETAILS.GENERAL.CAPTION")}</header> */}
+
+									{/* Render fields */}
+									<LifeCyclePolicyGeneralFields
+										formik={formik}
+										isNew={false}
+									/>
+
+									<div className="obj list-obj">
+										<header className="no-expand">
+											{t("LIFECYCLE.POLICIES.DETAILS.GENERAL.NOTE.TITLE")}
+										</header>
+										<div className="obj-container">
+											<span>{t("LIFECYCLE.POLICIES.DETAILS.GENERAL.NOTE.MESSAGE")}</span>
+										</div>
+									</div>
+
+									{formik.dirty && (
+										<>
+											{/* Render buttons for updating metadata */}
+											<footer>
+												<button
+													type="submit"
+													onClick={() => formik.handleSubmit()}
+													disabled={!checkValidity(formik)}
+													className={cn("submit", {
+														active: checkValidity(formik),
+														inactive: !checkValidity(formik),
+													})}
+												>
+													{t("SAVE")}
+												</button>
+												<button
+													className="cancel"
+													onClick={() => formik.resetForm()}
+												>
+													{t("CANCEL")}
+												</button>
+											</footer>
+
+											<div className="btm-spacer" />
+										</>
+									)}
+								{/* </div> */}
+							</div>
+						</div>
+					</div>
+				</>
+			)}
+		</Formik>
+	);
+};
+
+export default LifeCyclePolicyGeneralTab;

--- a/src/components/events/partials/ModalTabsAndPages/NewAccessPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewAccessPage.tsx
@@ -25,7 +25,7 @@ import ModalContentTable from "../../../shared/modals/ModalContentTable";
  */
 interface RequiredFormProps {
   metadata: {
-    "dublincore/episode_isPartOf": string,
+    "dublincore/episode_isPartOf"?: string,
   },
   policies: TransformedAcl[],
   aclTemplate: string,
@@ -81,16 +81,14 @@ const NewAccessPage = <T extends RequiredFormProps>({
 		if (initEventAclWithSeriesAcl && formik.values.metadata["dublincore/episode_isPartOf"]) {
 			dispatch(fetchSeriesDetailsAcls(formik.values.metadata["dublincore/episode_isPartOf"]));
 		}
-	// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [formik.values.metadata["dublincore/episode_isPartOf"], initEventAclWithSeriesAcl, dispatch]);
+	}, [initEventAclWithSeriesAcl, dispatch, formik.values.metadata]);
 
 	// If we have to use series ACL, overwrite existing rules
 	useEffect(() => {
 		if (initEventAclWithSeriesAcl && formik.values.metadata["dublincore/episode_isPartOf"] && seriesAcl) {
 			formik.setFieldValue("policies", seriesAcl);
 		}
-	// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [initEventAclWithSeriesAcl, seriesAcl]);
+	}, [formik, initEventAclWithSeriesAcl, seriesAcl]);
 
 	return (
 		<>

--- a/src/components/events/partials/ModalTabsAndPages/NewLifeCyclePolicyGeneralPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewLifeCyclePolicyGeneralPage.tsx
@@ -1,0 +1,37 @@
+import { FormikProps } from "formik";
+import WizardNavigationButtons from "../../../shared/wizard/WizardNavigationButtons";
+import LifeCyclePolicyGeneralFields from "../wizards/LifeCyclePolicyGeneralFields";
+import { LifeCyclePolicy, TargetFilter } from "../../../../slices/lifeCycleSlice";
+
+/**
+ * This component renders the metadata page for new events and series in the wizards.
+ */
+const NewLifeCyclePolicyGeneralPage = <T extends LifeCyclePolicy & {targetFiltersTransformed: { [key: string]: (TargetFilter & { filter: string })[] }}>({
+	formik,
+	nextPage,
+}: {
+	formik: FormikProps<T>,
+	nextPage: (values: T) => void,
+}) => {
+
+	return (
+		<>
+			<div className="modal-content">
+				<div className="modal-body">
+					<div className="full-col">
+							{/* Table view containing input fields for metadata */}
+							<LifeCyclePolicyGeneralFields
+								formik={formik}
+								isNew={true}
+							/>
+					</div>
+				</div>
+			</div>
+
+			{/* Button for navigation to next page */}
+			<WizardNavigationButtons isFirst formik={formik} nextPage={nextPage} />
+		</>
+	);
+};
+
+export default NewLifeCyclePolicyGeneralPage;

--- a/src/components/events/partials/ModalTabsAndPages/NewProcessingPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewProcessingPage.tsx
@@ -16,6 +16,7 @@ import RenderWorkflowSelect from "../wizards/RenderWorkflowSelect";
 interface RequiredFormProps {
 	sourceMode: string,
 	workflowId: string,
+	configuration: { [key: string]: unknown },
 }
 
 const NewProcessingPage = <T extends RequiredFormProps>({
@@ -82,8 +83,8 @@ const NewProcessingPage = <T extends RequiredFormProps>({
 									<RenderWorkflowConfig
 										displayDescription
 										workflowId={formik.values.workflowId}
-										// @ts-expect-error TS(7006):
-										formik={formik}
+										configuration={formik.values.configuration}
+										configurationName="configuration"
 									/>
 								) : null}
 							</div>

--- a/src/components/events/partials/modals/EventDetails.tsx
+++ b/src/components/events/partials/modals/EventDetails.tsx
@@ -51,6 +51,7 @@ import { NOTIFICATION_CONTEXT } from "../../../../configs/modalConfig";
 import { unwrapResult } from "@reduxjs/toolkit";
 import { ParseKeys } from "i18next";
 import EventDetailsWorkflowSchedulingTab from "../ModalTabsAndPages/EventDetailsWorkflowSchedulingTab";
+import EventDetailsLifeCyclePolicy from "../ModalTabsAndPages/EventDetailsLifeCyclePolicy";
 import { useHotkeys } from "react-hotkeys-hook";
 import { availableHotkeys } from "../../../../configs/hotkeysConfig";
 
@@ -65,6 +66,7 @@ export enum EventDetailsPage {
 	Comments,
 	Tobira,
 	Statistics,
+	LifeCyclePolicies,
 }
 
 export type WorkflowTabHierarchy = "workflows" | "workflow-details" | "workflow-operations" | "workflow-operation-details" | "errors-and-warnings" | "workflow-error-details"
@@ -220,6 +222,12 @@ const EventDetails = ({
 			page: EventDetailsPage.Statistics,
 			hidden: !hasStatistics,
 		},
+		{
+			tabNameTranslation: "EVENTS.EVENTS.DETAILS.TABS.LIFECYCLEPOLICIES",
+			accessRole: "ROLE_UI_EVENTS_DETAILS_LIFECYCLEPOLICIES_VIEW",
+			name: "lifecyclepolicies",
+			page: EventDetailsPage.LifeCyclePolicies,
+		},
 	];
 
 	const openTab = (tabNr: EventDetailsPage) => {
@@ -371,6 +379,11 @@ const EventDetails = ({
 					<EventDetailsStatisticsTab
 						eventId={eventId}
 						header={tabs[page].bodyHeaderTranslation ?? "EVENTS.EVENTS.DETAILS.STATISTICS.CAPTION"}
+					/>
+				)}
+				{page === EventDetailsPage.LifeCyclePolicies && (
+					<EventDetailsLifeCyclePolicy
+						eventId={eventId}
 					/>
 				)}
 			</div>

--- a/src/components/events/partials/modals/LifeCyclePolicyDetails.tsx
+++ b/src/components/events/partials/modals/LifeCyclePolicyDetails.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useState } from "react";
+import ModalNavigation from "../../../shared/modals/ModalNavigation";
+import { getLifeCyclePolicyDetails } from "../../../../selectors/lifeCycleDetailsSelectors";
+import LifeCyclePolicyGeneralTab from "../ModalTabsAndPages/LifeCyclePolicyGeneralTab";
+import LifeCyclePolicyDetailsAccessTab from "../ModalTabsAndPages/LifeCyclePolicyAccessTab";
+import { useAppDispatch, useAppSelector } from "../../../../store";
+import { removeNotificationWizardForm } from "../../../../slices/notificationSlice";
+import { fetchLifeCyclePolicyActions, fetchLifeCyclePolicyTargetTypes, fetchLifeCyclePolicyTimings } from "../../../../slices/lifeCycleDetailsSlice";
+import { ParseKeys } from "i18next";
+
+/**
+ * This component manages the tabs of the series details modal
+ */
+const LifeCyclePolicyDetails = ({
+	policyId,
+	policyChanged,
+	setPolicyChanged,
+}: {
+	policyId: string
+	policyChanged: boolean
+	setPolicyChanged: (policyChanged: boolean) => void
+}) => {
+	const [page, setPage] = useState(0);
+	const dispatch = useAppDispatch();
+
+	useEffect(() => {
+		dispatch(removeNotificationWizardForm());
+		dispatch(fetchLifeCyclePolicyActions());
+		dispatch(fetchLifeCyclePolicyTargetTypes());
+		dispatch(fetchLifeCyclePolicyTimings());
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
+	const policy = useAppSelector(state => getLifeCyclePolicyDetails(state));
+
+	// information about tabs
+	const tabs: {
+		tabTranslation: ParseKeys,
+		accessRole: string,
+		name: string,
+	}[] = [
+		{
+			tabTranslation: "LIFECYCLE.POLICIES.DETAILS.TAB.GENERAL",
+			accessRole: "ROLE_UI_LIFECYCLEPOLICIES_DETAILS_GENERAL_VIEW",
+			name: "general",
+		},
+		{
+			tabTranslation: "LIFECYCLE.POLICIES.DETAILS.TAB.ACCESSPOLICIES",
+			accessRole: "ROLE_UI_LIFECYCLEPOLICIES_DETAILS_ACCESSPOLICIES_VIEW",
+			name: "Access Policies",
+		},
+	];
+
+	const openTab = (tabNr: number) => {
+		setPage(tabNr);
+	};
+
+	return (
+		<>
+			{/* Navigation */}
+			<ModalNavigation tabInformation={tabs} page={page} openTab={openTab} />
+
+			<div>
+				{page === 0 && <LifeCyclePolicyGeneralTab policy={policy} />}
+				{page === 1 &&
+					<LifeCyclePolicyDetailsAccessTab
+						seriesId={policyId}
+						header={tabs[page].tabTranslation}
+						policyChanged={policyChanged}
+						setPolicyChanged={setPolicyChanged}
+					/>
+				}
+			</div>
+		</>
+	);
+};
+
+export default LifeCyclePolicyDetails;

--- a/src/components/events/partials/modals/LifeCyclePolicyDetails.tsx
+++ b/src/components/events/partials/modals/LifeCyclePolicyDetails.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from "react";
 import ModalNavigation from "../../../shared/modals/ModalNavigation";
 import { getLifeCyclePolicyDetails } from "../../../../selectors/lifeCycleDetailsSelectors";
 import LifeCyclePolicyGeneralTab from "../ModalTabsAndPages/LifeCyclePolicyGeneralTab";
-import LifeCyclePolicyDetailsAccessTab from "../ModalTabsAndPages/LifeCyclePolicyAccessTab";
 import { useAppDispatch, useAppSelector } from "../../../../store";
 import { removeNotificationWizardForm } from "../../../../slices/notificationSlice";
 import { fetchLifeCyclePolicyActions, fetchLifeCyclePolicyTargetTypes, fetchLifeCyclePolicyTimings } from "../../../../slices/lifeCycleDetailsSlice";
@@ -12,13 +11,13 @@ import { ParseKeys } from "i18next";
  * This component manages the tabs of the series details modal
  */
 const LifeCyclePolicyDetails = ({
-	policyId,
-	policyChanged,
-	setPolicyChanged,
+	_policyId,
+	_policyChanged,
+	_setPolicyChanged,
 }: {
-	policyId: string
-	policyChanged: boolean
-	setPolicyChanged: (policyChanged: boolean) => void
+	_policyId: string
+	_policyChanged: boolean
+	_setPolicyChanged: (policyChanged: boolean) => void
 }) => {
 	const [page, setPage] = useState(0);
 	const dispatch = useAppDispatch();
@@ -44,11 +43,13 @@ const LifeCyclePolicyDetails = ({
 			accessRole: "ROLE_UI_LIFECYCLEPOLICIES_DETAILS_GENERAL_VIEW",
 			name: "general",
 		},
-		{
-			tabTranslation: "LIFECYCLE.POLICIES.DETAILS.TAB.ACCESSPOLICIES",
-			accessRole: "ROLE_UI_LIFECYCLEPOLICIES_DETAILS_ACCESSPOLICIES_VIEW",
-			name: "Access Policies",
-		},
+		// Policies are currently only accessible to admins and the ACLs don't do
+		// anything, so we don't show them.
+		// {
+		// 	tabTranslation: "LIFECYCLE.POLICIES.DETAILS.TAB.ACCESSPOLICIES",
+		// 	accessRole: "ROLE_UI_LIFECYCLEPOLICIES_DETAILS_ACCESSPOLICIES_VIEW",
+		// 	name: "Access Policies",
+		// },
 	];
 
 	const openTab = (tabNr: number) => {
@@ -62,14 +63,14 @@ const LifeCyclePolicyDetails = ({
 
 			<div>
 				{page === 0 && <LifeCyclePolicyGeneralTab policy={policy} />}
-				{page === 1 &&
+				{/* {page === 1 &&
 					<LifeCyclePolicyDetailsAccessTab
 						seriesId={policyId}
 						header={tabs[page].tabTranslation}
 						policyChanged={policyChanged}
 						setPolicyChanged={setPolicyChanged}
 					/>
-				}
+				} */}
 			</div>
 		</>
 	);

--- a/src/components/events/partials/modals/LifeCyclePolicyDetailsModal.tsx
+++ b/src/components/events/partials/modals/LifeCyclePolicyDetailsModal.tsx
@@ -1,0 +1,69 @@
+import { useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { removeNotificationWizardForm } from "../../../../slices/notificationSlice";
+import { useAppDispatch, useAppSelector } from "../../../../store";
+import { Modal } from "../../../shared/modals/Modal";
+import { confirmUnsaved } from "../../../../utils/utils";
+import { FormikProps } from "formik";
+import LifeCyclePolicyDetails from "./LifeCyclePolicyDetails";
+import { getModalLifeCyclePolicy, showModal } from "../../../../selectors/lifeCycleDetailsSelectors";
+import { setModalLifeCyclePolicy, setShowModal } from "../../../../slices/lifeCycleDetailsSlice";
+
+/**
+ * This component renders the modal for displaying lifecycle policy details
+ */
+const LifeCyclePolicyDetailsModal = () => {
+  const { t } = useTranslation();
+  const dispatch = useAppDispatch();
+
+  // tracks, whether the policies are different to the initial value
+  const [policyChanged, setPolicyChanged] = useState(false);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const formikRef = useRef<FormikProps<any>>(null);
+
+  const displayDetailsModal = useAppSelector(state => showModal(state));
+  const policy = useAppSelector(state => getModalLifeCyclePolicy(state))!;
+
+  const hideModal = () => {
+    dispatch(setModalLifeCyclePolicy(null));
+    dispatch(setShowModal(false));
+  };
+
+  const close = () => {
+    let isUnsavedChanges = false;
+    isUnsavedChanges = policyChanged;
+    if (formikRef.current && formikRef.current.dirty !== undefined && formikRef.current.dirty) {
+      isUnsavedChanges = true;
+    }
+
+    if (!isUnsavedChanges || confirmUnsaved(t)) {
+      setPolicyChanged(false);
+      dispatch(removeNotificationWizardForm());
+      hideModal();
+      return true;
+    }
+    return false;
+  };
+
+  return (
+    <>
+      {displayDetailsModal &&
+        <Modal
+          open
+          closeCallback={close}
+          header={t("LIFECYCLE.POLICIES.DETAILS.HEADER", { name: policy.title })}
+          classId="details-modal"
+          focusTrapActive={false}
+        >
+          <LifeCyclePolicyDetails
+            policyId={policy.id}
+            policyChanged={policyChanged}
+            setPolicyChanged={value => setPolicyChanged(value)}
+          />
+        </Modal>
+      }
+    </>
+  );
+};
+
+export default LifeCyclePolicyDetailsModal;

--- a/src/components/events/partials/modals/LifeCyclePolicyDetailsModal.tsx
+++ b/src/components/events/partials/modals/LifeCyclePolicyDetailsModal.tsx
@@ -56,9 +56,9 @@ const LifeCyclePolicyDetailsModal = () => {
           focusTrapActive={false}
         >
           <LifeCyclePolicyDetails
-            policyId={policy.id}
-            policyChanged={policyChanged}
-            setPolicyChanged={value => setPolicyChanged(value)}
+            _policyId={policy.id}
+            _policyChanged={policyChanged}
+            _setPolicyChanged={value => setPolicyChanged(value)}
           />
         </Modal>
       }

--- a/src/components/events/partials/wizards/LifeCyclePolicyGeneralFields.tsx
+++ b/src/components/events/partials/wizards/LifeCyclePolicyGeneralFields.tsx
@@ -1,0 +1,584 @@
+import { useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { FieldArray, FieldProps, FormikProps } from "formik";
+import { Field } from "../../../shared/Field";
+import RenderField from "../../../shared/wizard/RenderField";
+import { ALL_TARGET_FILTER_TYPES, LifeCyclePolicy, TargetFilter } from "../../../../slices/lifeCycleSlice";
+import { useAppDispatch, useAppSelector } from "../../../../store";
+import { getLifeCyclePolicyActions, getLifeCyclePolicyTargetTypes, getLifeCyclePolicyTimings } from "../../../../selectors/lifeCycleDetailsSelectors";
+import DropDown from "../../../shared/DropDown";
+import { getEventMetadata } from "../../../../selectors/eventSelectors";
+import { fetchEventMetadata } from "../../../../slices/eventSlice";
+import { formatPolicyActionsForDropdown, formatWorkflowsForDropdown } from "../../../../utils/dropDownUtils";
+import { getWorkflowDef } from "../../../../selectors/workflowSelectors";
+import { fetchWorkflowDef } from "../../../../slices/workflowSlice";
+import RenderWorkflowConfig, { Configuration } from "./RenderWorkflowConfig";
+import { setDefaultConfig } from "../../../../utils/workflowPanelUtils";
+import ButtonLikeAnchor from "../../../shared/ButtonLikeAnchor";
+import { LuCircleX } from "react-icons/lu";
+
+/**
+ * This component renders the metadata page for new events and series in the wizards.
+ */
+// interface RequiredFormProps {
+// sourceMode: string,
+// processingWorkflow: string,
+// }
+type EventFilterOption = {
+	id: string,
+	type: string,
+	collection?: unknown
+}
+
+const LifeCyclePolicyGeneralFields = <T extends LifeCyclePolicy & {targetFiltersTransformed: { [key: string]: (TargetFilter & { filter: string })[] }}>({
+	formik,
+	isNew,
+}: {
+	formik: FormikProps<T>,
+	isNew: boolean
+}) => {
+	const { t } = useTranslation();
+	const dispatch = useAppDispatch();
+
+	const actions = useAppSelector(state => getLifeCyclePolicyActions(state));
+	const targetTypes = useAppSelector(state => getLifeCyclePolicyTargetTypes(state));
+	const timings = useAppSelector(state => getLifeCyclePolicyTimings(state));
+	const metadataFields = useAppSelector(state => getEventMetadata(state));
+
+	useEffect(() => {
+		dispatch(fetchEventMetadata());
+	// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
+	const ADDITIONAL_TARGET_FILTER_KEYS_EVENTS = [
+		{
+			id: "series_name",
+			type: "text",
+			collection: undefined,
+		},
+		{
+			id: "presenter",
+			type: "text",
+			collection: undefined,
+		},
+		{
+			id: "start_date",
+			type: "date",
+			collection: undefined,
+		},
+		{
+			id: "end_date",
+			type: "date",
+			collection: undefined,
+		},
+		{
+			id: "created",
+			type: "date",
+			collection: undefined,
+		},
+		{
+			id: "source",
+			type: "text",
+			collection: undefined,
+		},
+		{
+			id: "rights",
+			type: "text",
+			collection: undefined,
+		},
+		{
+			id: "location",
+			type: "text",
+			collection: undefined,
+		},
+	];
+
+	const eventFilterOptions: EventFilterOption[] = [];
+	for (const field of metadataFields.fields) {
+		eventFilterOptions.push(field);
+	}
+	for (const field of ADDITIONAL_TARGET_FILTER_KEYS_EVENTS) {
+		eventFilterOptions.push(field);
+	}
+
+	const createTargetFilter = (): TargetFilter => {
+		return {
+			value: "",
+			type: "SEARCH",
+			must: true,
+		};
+	};
+
+	const filterOptions = (targetType: string) => {
+		switch (targetType) {
+			case "EVENT":
+				return eventFilterOptions;
+			default:
+				return [];
+		}
+	};
+
+	const filterTargetTypesByFilter = (filter: string) => {
+		const event = eventFilterOptions.find(event => event.id === filter);
+
+		if (!event) {
+			return ALL_TARGET_FILTER_TYPES;
+		}
+		if (event.type.includes("text")) {
+			return ["SEARCH", "WILDCARD"];
+		}
+		if (event.type.includes("date")) {
+			return ["GREATER_THAN", "LESS_THAN"];
+		}
+		return ALL_TARGET_FILTER_TYPES;
+	};
+
+
+	return (
+		<>
+			<div className="obj tbl-list">
+				<header className="no-expand">{t("LIFECYCLE.POLICIES.NEW.GENERAL.CAPTION")}</header>
+				<table className="main-tbl">
+					<tbody>
+
+					<tr>
+						<td>{t("LIFECYCLE.POLICIES.DETAILS.GENERAL.TITLE")}<i className="required">*</i></td>
+						<td className="editable">
+							<Field
+									type="text"
+									name="title"
+									metadataField={{
+										type: "text",
+										required: true,
+										collection: undefined,
+										id: undefined,
+									}}
+									component={RenderField}
+									isFirstField
+								/>
+							</td>
+					</tr>
+					<tr>
+						<td>{t("LIFECYCLE.POLICIES.DETAILS.GENERAL.ISACTIVE")}<i className="required">*</i></td>
+						<td className="editable">
+							<Field
+								type="checkbox"
+								name="isActive"
+								metadataField={{
+									type: "boolean",
+									required: true,
+									collection: undefined,
+									id: undefined,
+								}}
+								component={RenderField}
+							/>
+						</td>
+					</tr>
+					{!isNew &&
+						<tr>
+							<td>{t("LIFECYCLE.POLICIES.DETAILS.GENERAL.ISCREATEDFROMCONFIG")}</td>
+							<td className="editable">
+								<Field
+									type="checkbox"
+									name="isCreatedFromConfig"
+									disabled={true}
+								/>
+							</td>
+						</tr>
+					}
+					<tr>
+						<td>{t("LIFECYCLE.POLICIES.DETAILS.GENERAL.TARGETTYPE")}<i className="required">*</i></td>
+						<td className="editable">
+							<Field
+								key={targetTypes?.join(",") ?? "targetTypes_empty"}
+								name="targetType"
+								metadataField={{
+									type: "text",
+									required: true,
+									collection: targetTypes.map(element => ({ value: element, name: element })),
+									id: "language",
+								}}
+								component={RenderField}
+							/>
+						</td>
+					</tr>
+					<tr>
+						<td>{t("LIFECYCLE.POLICIES.DETAILS.GENERAL.TIMING")}<i className="required">*</i></td>
+						<td className="editable">
+							<Field
+								key={timings?.join(",") ?? "timings_empty"}
+								name={"timing"}
+								metadataField={{
+									type: "text",
+									required: true,
+									collection: timings.map(element => ({ value: element, name: element })),
+									id: "language",
+								}}
+								component={RenderField}
+							/>
+						</td>
+					</tr>
+					<tr>
+						<td>{t("LIFECYCLE.POLICIES.DETAILS.GENERAL.ACTION")}<i className="required">*</i></td>
+						<td className="editable">
+							<Field
+								key={actions?.join(",") ?? "actions_empty"}
+								name={"action"}
+								metadataField={{
+									type: "text",
+									required: true,
+									collection: actions.map(element => ({ value: element, name: element })),
+									id: "language",
+								}}
+								component={RenderField}
+							/>
+						</td>
+					</tr>
+					{formik.values.timing === "SPECIFIC_DATE" &&
+					<tr>
+						<td>
+							{t("LIFECYCLE.POLICIES.DETAILS.GENERAL.ACTIONDATE")}
+							{formik.values.timing === "SPECIFIC_DATE" && <i className="required">*</i>}
+						</td>
+						<td className="editable">
+							<Field
+								name={"actionDate"}
+								// component={DateTimePickerField}
+								metadataField={{
+									type: "date",
+									required: false,
+									collection: undefined,
+									id: undefined,
+								}}
+								component={RenderField}
+							/>
+						</td>
+					</tr>
+					}
+					{formik.values.timing === "REPEATING" &&
+					<tr>
+						<td>
+							{t("LIFECYCLE.POLICIES.DETAILS.GENERAL.CRONTRIGGER")}
+							{formik.values.timing === "REPEATING" && <i className="required">*</i>}
+						</td>
+						<td>
+							<Field
+								type="cron"
+								name="cronTrigger"
+								metadataField={{
+									type: "cron",
+									required: false,
+									collection: undefined,
+									id: undefined,
+								}}
+								component={RenderField}
+							/>
+						</td>
+					</tr>
+					}
+					{!isNew &&
+						<tr>
+							<td>{t("LIFECYCLE.POLICIES.DETAILS.GENERAL.ID")}</td>
+							<td className="editable">
+								{formik.values.id}
+							</td>
+						</tr>
+					}
+
+					</tbody>
+				</table>
+			</div>
+
+			<div></div>
+
+
+			{/* Target Filters like the ACLs
+						Can we make "key" a dropdown?
+						Type of "Value" should depend on key, e.g. for key "start_date" show a date picker
+			*/}
+			<div className="obj tbl-list">
+				<header>
+					{ t("LIFECYCLE.POLICIES.DETAILS.GENERAL.TARGETFILTERS.CAPTION") }
+				</header>
+
+				<table className="main-tbl">
+					{/* column headers */}
+					<thead>
+						<tr>
+							<th>
+								{ t("LIFECYCLE.POLICIES.DETAILS.GENERAL.TARGETFILTERS.FILTER") }
+							</th>
+							<th className="fit">
+								{ t("LIFECYCLE.POLICIES.DETAILS.GENERAL.TARGETFILTERS.VALUE") }
+							</th>
+							<th className="fit">
+								{ t("LIFECYCLE.POLICIES.DETAILS.GENERAL.TARGETFILTERS.TYPE") }
+							</th>
+							<th className="fit">
+								{ t("LIFECYCLE.POLICIES.DETAILS.GENERAL.TARGETFILTERS.MUST") }
+							</th>
+							<th className="fit">
+								{ t("EVENTS.EVENTS.DETAILS.ACCESS.ACCESS_POLICY.ACTION") }
+							</th>
+						</tr>
+					</thead>
+
+					<tbody>
+						{Object.entries(formik.values.targetFiltersTransformed).map(([outerKey, filters]) => {
+							if (outerKey !== "dublincore/episode") { return null; }
+
+							return (
+								<FieldArray
+									key={outerKey}
+									name={`targetFiltersTransformed.${outerKey}`}
+									render={arrayHelpers => (
+										<>
+											{Object.entries(filters).map(([key, filter], index) => {
+												// Get available filter options
+												const availableFilterOptions = filterOptions(formik.values.targetType);
+
+												// Derive available type options based on selected filter
+												const dependentTypeOptions = filterTargetTypesByFilter(filter.filter);
+
+												return (
+													<tr key={index}>
+														<td className="editable">
+															<Field
+																type="time"
+																name={`targetFiltersTransformed.${outerKey}.${key}.filter`}
+																value={filter.filter}
+																values={availableFilterOptions.map(e => e.id)}
+																creatable={true}
+																clearFieldName={`targetFiltersTransformed.${outerKey}.${key}.value`}
+																component={DropdownField}
+																onChangeOverride={(element: { value: string; label: string } | null) => {
+																	formik.setFieldValue(`targetFiltersTransformed.${outerKey}.${key}.value`, undefined);
+																	formik.setFieldValue(`targetFiltersTransformed.${outerKey}.${key}.filter`, element?.value ?? undefined);
+																	// Reset type when filter changes
+																	formik.setFieldValue(`targetFiltersTransformed.${outerKey}.${key}.type`, undefined);
+																}}
+															/>
+														</td>
+														<td className="editable">
+															<Field
+																key={`type-${filter.filter}-${index}`} // ensures rerender when filter changes
+																name={`targetFiltersTransformed.${outerKey}.${key}.value`}
+																metadataField={{
+																	type: getTargetFilterRenderType(filter.filter, availableFilterOptions),
+																	required: true,
+																	collection: getTargetFilterRenderCollection(filter.filter, availableFilterOptions),
+																	id: undefined,
+																}}
+																component={RenderField}
+															/>
+														</td>
+														<td className="editable">
+															<Field
+																key={`type-${filter.filter}-${index}`} // ensures rerender when filter changes
+																name={`targetFiltersTransformed.${outerKey}.${key}.type`}
+																value={filter.type}
+																values={dependentTypeOptions}
+																component={DropdownField}
+															/>
+														</td>
+														<td className="editable">
+															<Field
+																type="checkbox"
+																name={`targetFiltersTransformed.${outerKey}.${key}.must`}
+															/>
+														</td>
+														<td>
+															<ButtonLikeAnchor
+																onClick={() => arrayHelpers.remove(index)}
+																className="action-cell-button remove"
+															>
+																<LuCircleX />
+															</ButtonLikeAnchor>
+														</td>
+													</tr>
+												);
+											})}
+											<tr>
+												<td colSpan={5}>
+													<ButtonLikeAnchor
+														onClick={() =>
+															arrayHelpers.push(createTargetFilter())
+														}
+														className="button-like-anchor"
+													>
+														+{" "}
+														{t(
+															"LIFECYCLE.POLICIES.DETAILS.GENERAL.TARGETFILTERS.NEW",
+														)}
+													</ButtonLikeAnchor>
+												</td>
+											</tr>
+										</>
+									)}
+								/>
+							);
+						})}
+					</tbody>
+				</table>
+			</div>
+
+			{formik.values.action === "START_WORKFLOW" &&
+				<WorkflowSelector
+					formik={formik}
+				/>
+			}
+		</>
+	);
+};
+
+
+export default LifeCyclePolicyGeneralFields;
+
+const DropdownField = ({
+	field,
+	form: { setFieldValue },
+	value,
+	values,
+	clearFieldName,
+	creatable = false,
+	onChangeOverride,
+}: {
+	field: FieldProps["field"]
+	form: FieldProps["form"]
+	value: string,
+	values: string[]
+	clearFieldName: string
+	creatable: boolean
+	onChangeOverride?: (element: { value: string; label: string } | null) => void
+}) => {
+	const { t } = useTranslation();
+
+	const handleChange = (element: { value: string; label: string } | null) => {
+		if (onChangeOverride) {
+			// call the override function if provided
+			onChangeOverride(element);
+		} else {
+			// default behavior
+			setFieldValue(clearFieldName, undefined);
+			if (element) {
+				setFieldValue(field.name, element.value);
+			}
+		}
+	};
+
+	return (
+		<DropDown
+			value={field.value as string}
+			text={value}
+			options={values ? formatPolicyActionsForDropdown(values) : []}
+			required={true}
+			handleChange={handleChange}
+			placeholder={`-- ${t("SELECT_NO_OPTION_SELECTED")} --`}
+			creatable={creatable}
+			customCSS={{
+				width: "100%",
+			}}
+		/>
+	);
+};
+
+const getTargetFilterRenderType = (filterName: string, targetFilterOptions: { id: string, type: string, collection?: unknown }[]) => {
+	const option = targetFilterOptions.find(e => e.id === filterName);
+	if (option === undefined) {
+		return "text";
+	}
+	// Simplify types like "long_text" or "mixed_text"
+	if (option.type.includes("text")) {
+		return "text";
+	}
+	return option.type;
+};
+
+const getTargetFilterRenderCollection = (filterName: string, targetFilterOptions: { id: string, type: string, collection?: unknown }[]) => {
+	const option = targetFilterOptions.find(e => e.id === filterName);
+	return option !== undefined ? option.collection : undefined;
+};
+
+const WorkflowSelector = <T extends LifeCyclePolicy & {targetFiltersTransformed: { [key: string]: (TargetFilter & { filter: string })[] }}>({
+	formik,
+}: {
+	formik: FormikProps<T>,
+}) => {
+	const { t } = useTranslation();
+	const dispatch = useAppDispatch();
+
+	const workflowDef = useAppSelector(state => getWorkflowDef(state));
+	// const lol = JSON.parse(formik.values.actionParameters.workflowParameters)
+
+	useEffect(() => {
+		// Load workflow definitions for selecting
+		dispatch(fetchWorkflowDef("tasks"));
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
+	const setDefaultValues = (value: string) => {
+		const workflowId = value;
+		// fill values with default configuration of chosen workflow
+		const defaultConfiguration = setDefaultConfig(workflowDef, workflowId);
+
+		// set default configuration in formik
+		formik.setFieldValue("actionParameters.workflowParameters", defaultConfiguration);
+		// set chosen workflow in formik
+		formik.setFieldValue("actionParameters.workflowId", workflowId);
+	};
+
+	return (
+		<div className="obj quick-actions">
+			<header>
+				{t("EVENTS.EVENTS.NEW.PROCESSING.SELECT_WORKFLOW")}
+			</header>
+			<div className="obj-container padded">
+				{workflowDef.length > 0 ? (
+					<div className="editable">
+						<DropDown
+							value={formik.values.actionParameters.workflowId}
+							text={
+								workflowDef.find(
+									workflow =>
+										formik.values.actionParameters.workflowId === workflow.id,
+								)?.title ?? ""
+							}
+							options={formatWorkflowsForDropdown(workflowDef)}
+							required={true}
+							handleChange={element => {
+								if (element) {
+									setDefaultValues(element.value as string);
+								}
+							}}
+							placeholder={t(
+								"EVENTS.EVENTS.NEW.PROCESSING.SELECT_WORKFLOW",
+							)}
+							customCSS={{ width: "100%" }}
+						/>
+					</div>
+				) : (
+					<span>
+						{t("EVENTS.EVENTS.NEW.PROCESSING.SELECT_WORKFLOW_EMPTY")}
+					</span>
+				)}
+
+				{/* Configuration panel of selected workflow */}
+				<div className="collapsible-box">
+					<div
+						id="new-event-workflow-configuration"
+						className="checkbox-container obj-container"
+					>
+						{formik.values.actionParameters.workflowId ? (
+							<RenderWorkflowConfig
+								displayDescription
+								workflowId={formik.values.actionParameters.workflowId as string}
+								configuration={formik.values.actionParameters.workflowParameters as Configuration}
+								configurationName={"actionParameters.workflowParameters"}
+							/>
+						) : null}
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+};

--- a/src/components/events/partials/wizards/LifeCyclePolicyGeneralFields.tsx
+++ b/src/components/events/partials/wizards/LifeCyclePolicyGeneralFields.tsx
@@ -351,7 +351,7 @@ const LifeCyclePolicyGeneralFields = <T extends LifeCyclePolicy & {targetFilters
 																	formik.setFieldValue(`targetFiltersTransformed.${outerKey}.${key}.value`, undefined);
 																	formik.setFieldValue(`targetFiltersTransformed.${outerKey}.${key}.filter`, element?.value ?? undefined);
 																	// Reset type when filter changes
-																	formik.setFieldValue(`targetFiltersTransformed.${outerKey}.${key}.type`, undefined);
+																	formik.setFieldValue(`targetFiltersTransformed.${outerKey}.${key}.type`, element?.value ? filterTargetTypesByFilter(element?.value)[0] : undefined);
 																}}
 															/>
 														</td>

--- a/src/components/events/partials/wizards/LifeCyclePolicyGeneralFields.tsx
+++ b/src/components/events/partials/wizards/LifeCyclePolicyGeneralFields.tsx
@@ -363,7 +363,7 @@ const LifeCyclePolicyGeneralFields = <T extends LifeCyclePolicy & {targetFilters
 																	type: getTargetFilterRenderType(filter.filter, availableFilterOptions),
 																	required: true,
 																	collection: getTargetFilterRenderCollection(filter.filter, availableFilterOptions),
-																	id: undefined,
+																	id: filter.filter,
 																}}
 																component={RenderField}
 															/>

--- a/src/components/events/partials/wizards/LifeCyclePolicyGeneralFields.tsx
+++ b/src/components/events/partials/wizards/LifeCyclePolicyGeneralFields.tsx
@@ -158,22 +158,18 @@ const LifeCyclePolicyGeneralFields = <T extends LifeCyclePolicy & {targetFilters
 								/>
 							</td>
 					</tr>
-					<tr>
-						<td>{t("LIFECYCLE.POLICIES.DETAILS.GENERAL.ISACTIVE")}<i className="required">*</i></td>
-						<td className="editable">
-							<Field
-								type="checkbox"
-								name="isActive"
-								metadataField={{
-									type: "boolean",
-									required: true,
-									collection: undefined,
-									id: undefined,
-								}}
-								component={RenderField}
-							/>
-						</td>
-					</tr>
+					{!isNew &&
+						<tr>
+							<td>{t("LIFECYCLE.POLICIES.DETAILS.GENERAL.ISACTIVE")}<i className="required">*</i></td>
+							<td className="editable">
+								<Field
+									type="checkbox"
+									name="isActive"
+									disabled={true}
+								/>
+							</td>
+						</tr>
+					}
 					{!isNew &&
 						<tr>
 							<td>{t("LIFECYCLE.POLICIES.DETAILS.GENERAL.ISCREATEDFROMCONFIG")}</td>

--- a/src/components/events/partials/wizards/NewEventWizard.tsx
+++ b/src/components/events/partials/wizards/NewEventWizard.tsx
@@ -225,11 +225,8 @@ const NewEventWizard = ({
 								)}
 								{steps[page].name === "access" && (
 									<NewAccessPage
-									// @ts-expect-error TS(7006):
 										previousPage={previousPage}
-										// @ts-expect-error TS(7006):
 										nextPage={nextPage}
-										// @ts-expect-error TS(7006):
 										formik={formik}
 										editAccessRole="ROLE_UI_EVENTS_DETAILS_ACL_EDIT"
 										viewUsersAccessRole="ROLE_UI_EVENTS_DETAILS_ACL_USER_ROLES_VIEW"

--- a/src/components/events/partials/wizards/NewLifeCyclePolicySummary.tsx
+++ b/src/components/events/partials/wizards/NewLifeCyclePolicySummary.tsx
@@ -1,0 +1,124 @@
+import { useTranslation } from "react-i18next";
+import AccessSummaryTable from "./summaryTables/AccessSummaryTable";
+import WizardNavigationButtons from "../../../shared/wizard/WizardNavigationButtons";
+import { FormikProps } from "formik";
+import { renderValidDate } from "../../../../utils/dateUtils";
+import { initialFormValuesNewLifeCyclePolicy } from "../../../../configs/modalConfig";
+
+/**
+ * This component renders the summary page for new series in the new series wizard.
+ */
+// interface RequiredFormProps {
+
+// }
+
+const NewLifeCyclePolicySummary = <T extends typeof initialFormValuesNewLifeCyclePolicy>({
+	formik,
+	previousPage,
+}: {
+	formik: FormikProps<T>,
+	previousPage: (values: T, twoPagesBack?: boolean) => void,
+}) => {
+	const { t } = useTranslation();
+
+	return (
+		<>
+			<div className="modal-content">
+				<div className="modal-body">
+					<div className="full-col">
+
+						<div className="obj tbl-list">
+							<header className="no-expand">{t("LIFECYCLE.POLICIES.NEW.CAPTION")}</header>
+							<div className="obj-container">
+								<table className="main-tbl">
+									<tbody>
+										<tr>
+											<td>{t("LIFECYCLE.POLICIES.DETAILS.GENERAL.TITLE")}</td>
+											<td>{formik.values.title}</td>
+										</tr>
+										<tr>
+											<td>{t("LIFECYCLE.POLICIES.DETAILS.GENERAL.ISACTIVE")}</td>
+											<td><input type="checkbox" disabled checked={formik.values.isActive} /></td>
+										</tr>
+										<tr>
+											<td>{t("LIFECYCLE.POLICIES.DETAILS.GENERAL.TARGETTYPE")}</td>
+											<td>{formik.values.targetType}</td>
+										</tr>
+										<tr>
+											<td>{t("LIFECYCLE.POLICIES.DETAILS.GENERAL.TIMING")}</td>
+											<td>{formik.values.timing}</td>
+										</tr>
+										<tr>
+											<td>{t("LIFECYCLE.POLICIES.DETAILS.GENERAL.ACTION")}</td>
+											<td>{formik.values.action}</td>
+										</tr>
+										<tr>
+											<td>{t("LIFECYCLE.POLICIES.DETAILS.GENERAL.ACTIONDATE")}</td>
+											<td>{t("dateFormats.dateTime.medium", { dateTime: renderValidDate(formik.values.actionDate) })}</td>
+										</tr>
+										<tr>
+											<td>{t("LIFECYCLE.POLICIES.DETAILS.GENERAL.CRONTRIGGER")}</td>
+											<td>{formik.values.cronTrigger}</td>
+										</tr>
+										<tr>
+											<td>{t("LIFECYCLE.POLICIES.DETAILS.GENERAL.TARGETFILTERS.CAPTION")}</td>
+											<td>
+												{Object.entries(formik.values.targetFiltersTransformed)
+													.filter(([outerKey]) => outerKey === "dublincore/episode")
+													.map(([_outerKey, filters]) => (
+														filters.map((filter, key) => (
+															<tr key={key}>
+																<td>{filter.filter}</td>
+																<td>{filter.value.toString()}</td>
+																<td>{filter.type}</td>
+																<td>{filter.must.toString()}</td>
+															</tr>
+														))
+												))}
+											</td>
+										</tr>
+										<tr>
+											<td>{t("LIFECYCLE.POLICIES.DETAILS.GENERAL.ACTIONPARAMETERS.CAPTION")}</td>
+											<td>
+												{formik.values.action === "START_WORKFLOW" &&
+													<tr>
+														{/*  @ts-expect-error: Potentially unknown */}
+														<td>{formik.values.actionParameters.workflowId}</td>
+														<td>
+															{/*  @ts-expect-error: Potentially unknown */}
+															{Object.entries(formik.values.actionParameters.workflowParameters).map(([key, value]) => (
+																<tr key={key}>
+																	<td>{key}</td>
+																	<td>{String(value)}</td>
+																</tr>
+															))}
+														</td>
+													</tr>
+													}
+											</td>
+										</tr>
+									</tbody>
+								</table>
+							</div>
+						</div>
+						{/* Summary access configuration */}
+						<AccessSummaryTable
+							policies={formik.values.policies}
+							header={"EVENTS.SERIES.NEW.ACCESS.CAPTION"}
+						/>
+
+					</div>
+				</div>
+			</div>
+
+			{/* Button for navigation to next page and previous page */}
+			<WizardNavigationButtons
+				isLast
+				previousPage={previousPage}
+				formik={formik}
+			/>
+		</>
+	);
+};
+
+export default NewLifeCyclePolicySummary;

--- a/src/components/events/partials/wizards/NewLifeCyclePolicyWizard.tsx
+++ b/src/components/events/partials/wizards/NewLifeCyclePolicyWizard.tsx
@@ -1,0 +1,181 @@
+import { useEffect, useState } from "react";
+import { Formik } from "formik";
+import NewAccessPage from "../ModalTabsAndPages/NewAccessPage";
+import WizardStepper from "../../../shared/wizard/WizardStepper";
+import { useAppDispatch, useAppSelector } from "../../../../store";
+import { getUserInformation } from "../../../../selectors/userInfoSelectors";
+import { UserInfoState } from "../../../../slices/userInfoSlice";
+import { postNewLifeCyclePolicy } from "../../../../slices/lifeCycleSlice";
+import NewLifeCyclePolicyGeneralPage from "../ModalTabsAndPages/NewLifeCyclePolicyGeneralPage";
+import NewLifeCyclePolicySummary from "./NewLifeCyclePolicySummary";
+import { LifeCyclePolicySchema } from "../../../../utils/validate";
+import { initialFormValuesNewLifeCyclePolicy } from "../../../../configs/modalConfig";
+import { parseTargetFiltersForSubmit } from "../../../../utils/lifeCycleUtils";
+import { ParseKeys } from "i18next";
+
+/**
+ * This component manages the pages of the new event wizard and the submission of values
+ */
+const NewLifeCyclePolicyWizard = ({
+	close,
+}: {
+	close: () => void
+}) => {
+	const dispatch = useAppDispatch();
+
+	const user = useAppSelector(state => getUserInformation(state));
+
+	const initialValues = getInitialValues(user);
+
+	const [page, setPage] = useState(0);
+	const [snapshot, setSnapshot] = useState(initialValues);
+	const [pageCompleted, setPageCompleted] = useState<{ [key: number]: boolean }>({});
+
+	// Caption of steps used by Stepper
+	const steps: {
+		translation: ParseKeys,
+		name: string,
+		hidden: boolean,
+	}[] = [
+		{
+			translation: "LIFECYCLE.POLICIES.NEW.GENERAL.CAPTION",
+			name: "general",
+			hidden: false,
+		},
+		{
+			translation: "EVENTS.EVENTS.NEW.ACCESS.CAPTION",
+			name: "access",
+			hidden: false,
+		},
+		{
+			translation: "EVENTS.EVENTS.NEW.SUMMARY.CAPTION",
+			name: "summary",
+			hidden: false,
+		},
+	];
+
+	const nextPage = (values: typeof initialValues) => {
+		setSnapshot(values);
+
+		// set page as completely filled out
+		const updatedPageCompleted = pageCompleted;
+		updatedPageCompleted[page] = true;
+		setPageCompleted(updatedPageCompleted);
+
+		let newPage = page;
+		do {
+			newPage = newPage + 1;
+		} while (steps[newPage] && steps[newPage].hidden);
+		if (steps[newPage]) {
+			setPage(newPage);
+		}
+	};
+
+	const previousPage = (values: typeof initialValues) => {
+		setSnapshot(values);
+
+		let newPage = page;
+		do {
+			newPage = newPage - 1;
+		} while (steps[newPage] && steps[newPage].hidden);
+		if (steps[newPage]) {
+			setPage(newPage);
+		}
+	};
+
+	const handleSubmit = (values: typeof initialValues) => {
+		const fixedValues = {
+			...values,
+			targetFilters: parseTargetFiltersForSubmit(values.targetFiltersTransformed),
+			accessControlEntries: values.policies,
+		};
+
+		const response = dispatch(postNewLifeCyclePolicy(fixedValues));
+		console.info(response);
+		close();
+	};
+
+	return (
+		<>
+			<Formik
+				initialValues={snapshot}
+				validationSchema={LifeCyclePolicySchema[page]}
+				onSubmit={values => handleSubmit(values)}
+			>
+				{/* Render wizard pages depending on current value of page variable */}
+				{formik => {
+					// eslint-disable-next-line react-hooks/rules-of-hooks
+					useEffect(() => {
+						formik.validateForm();
+						// eslint-disable-next-line react-hooks/exhaustive-deps
+					}, [page]);
+
+					return (
+						<>
+							{/* Stepper that shows each step of wizard as header */}
+							<WizardStepper
+								steps={steps}
+								activePageIndex={page}
+								setActivePage={setPage}
+								completed={pageCompleted}
+								setCompleted={setPageCompleted}
+								isValid={formik.isValid}
+								acls={formik.values.policies}
+							/>
+							<div>
+								{page === 0 && (
+									<NewLifeCyclePolicyGeneralPage
+										// @ts-expect-error TS(7006):
+										nextPage={nextPage}
+										// @ts-expect-error TS(7006):
+										formik={formik}
+										header={steps[page].translation}
+									/>
+								)}
+								{page === 1 && (
+									<NewAccessPage
+									// @ts-expect-error TS(7006):
+										previousPage={previousPage}
+										// @ts-expect-error TS(7006):
+										nextPage={nextPage}
+										// @ts-expect-error TS(7006):
+										formik={formik}
+										editAccessRole="ROLE_UI_LIFECYCLEPOLICY_DETAILS_ACL_EDIT"
+										initEventAclWithSeriesAcl={false}
+									/>
+								)}
+								{page === 2 && (
+									<NewLifeCyclePolicySummary
+										previousPage={previousPage}
+										formik={formik}
+									/>
+								)}
+							</div>
+						</>
+					);
+				}}
+			</Formik>
+		</>
+	);
+};
+
+// Transform all initial values needed from information provided by backend
+const getInitialValues = (
+	user: UserInfoState,
+) => {
+	const initialValues = initialFormValuesNewLifeCyclePolicy;
+
+	initialValues["policies"] = [
+		{
+			role: user.userRole,
+			read: true,
+			write: true,
+			actions: [],
+			user: user.user,
+		},
+	];
+
+	return initialValues;
+};
+
+export default NewLifeCyclePolicyWizard;

--- a/src/components/events/partials/wizards/RenderWorkflowConfig.tsx
+++ b/src/components/events/partials/wizards/RenderWorkflowConfig.tsx
@@ -1,28 +1,30 @@
 import React from "react";
 import { v4 as uuidv4 } from "uuid";
-import { FormikProps } from "formik";
 import { Field } from "../../../shared/Field";
 import {
 	getWorkflowDefById,
 } from "../../../../selectors/workflowSelectors";
 import { useAppSelector } from "../../../../store";
-import { FieldSetField } from "../../../../slices/workflowSlice";
+import { ConfigurationPanelField, FieldSetField } from "../../../../slices/workflowSlice";
 
 /**
  * This component renders the configuration panel for the selected workflow in the processing step of the new event
  * wizard chosen via dropdown.
  */
-interface RequiredFormProps {
-	configuration?: { [key: string]: unknown }
-}
+// interface RequiredFormProps {
+// 	configuration?: { [key: string]: unknown }
+// }
+export type Configuration = { [key: string]: unknown }
 
-const RenderWorkflowConfig = <T extends RequiredFormProps>({
+const RenderWorkflowConfig = ({
 	workflowId,
-	formik,
+	configuration,
+	configurationName,
 	displayDescription,
 }: {
 	workflowId: string
-	formik: FormikProps<T>
+	configuration: Configuration
+	configurationName: string
 	displayDescription?: boolean
 }) => {
 
@@ -32,13 +34,35 @@ const RenderWorkflowConfig = <T extends RequiredFormProps>({
 	const configPanel = !!workflowDef && workflowDef.configurationPanelJson
 		? workflowDef.configurationPanelJson
 		: [];
-	const description = !!workflowDef && workflowDef.description
+	const description = !!workflowDef && workflowDef.description && !displayDescription
 		? workflowDef.description
 		: "";
 
 	return (
+		<WorkflowConfig
+			configuration={configuration}
+			configurationName={configurationName}
+			configPanel={configPanel}
+			description={description}
+		/>
+	);
+};
+
+export const WorkflowConfig = ({
+	configuration,
+	configurationName,
+	configPanel,
+	description,
+}: {
+	configuration: Configuration
+	configurationName: string
+	configPanel: string | ConfigurationPanelField[]
+	description: string
+}) => {
+
+	return (
 		<>
-			{displayDescription && description.length > 0 && (
+			{description.length > 0 && (
 				<div id="workflow-configuration-description-box">
 					<div id="workflow-configuration-description-text">{description.trim()}</div>
 				</div>
@@ -57,7 +81,7 @@ const RenderWorkflowConfig = <T extends RequiredFormProps>({
 								)}
 								<ul>
 									{configOption.fieldset?.map((field, keys) =>
-										renderInputByType(field, keys, formik),
+										renderInputByType(field, keys, configuration, configurationName),
 									)}
 								</ul>
 							</fieldset>
@@ -70,50 +94,50 @@ const RenderWorkflowConfig = <T extends RequiredFormProps>({
 };
 
 // render input depending on field type
-const renderInputByType = <T extends RequiredFormProps>(
+const renderInputByType = (
 	field: FieldSetField,
 	key: React.Key | null | undefined,
-	formik: FormikProps<T>,
+	configuration: Configuration,
+	configurationName: string,
 ) => {
 	switch (field.type) {
 		case "checkbox":
-			return <RenderCheckbox field={field} key={key} formik={formik} />;
+			return <RenderCheckbox field={field} key={key} configuration={configuration} configurationName={configurationName} />;
 		case "radio":
-			return <RenderRadio field={field} key={key} formik={formik} />;
+			return <RenderRadio field={field} key={key} configuration={configuration} configurationName={configurationName} />;
 		case "number":
-			return <RenderNumber field={field} key={key} formik={formik} />;
+			return <RenderNumber field={field} key={key} configuration={configuration} configurationName={configurationName} />;
 		case "text":
-			return <RenderText field={field} key={key} formik={formik} />;
+			return <RenderText field={field} key={key} configuration={configuration} configurationName={configurationName} />;
 		case "datetime-local":
-			return <RenderDatetimeLocal field={field} key={key} formik={formik} />;
+			return <RenderDatetimeLocal field={field} key={key} configuration={configuration} configurationName={configurationName} />;
 		default:
 			return "";
 	}
 };
 
-const RenderDatetimeLocal = <T extends RequiredFormProps>(
-	{ field, formik } : { field: FieldSetField, formik: FormikProps<T> }) => {
-		return <RenderField field={field} formik={formik} />;
+const RenderDatetimeLocal = (
+	{ field, configuration, configurationName } : { field: FieldSetField, configuration: Configuration, configurationName: string }) => {
+		return <RenderField field={field} configuration={configuration} configurationName={configurationName} />;
 };
 
-const RenderCheckbox = <T extends RequiredFormProps>(
-	{ field, formik } : { field: FieldSetField, formik: FormikProps<T> }) => {
-		return <RenderField field={field} formik={formik} />;
+const RenderCheckbox = (
+	{ field, configuration, configurationName } : { field: FieldSetField, configuration: Configuration, configurationName: string }) => {
+		return <RenderField field={field} configuration={configuration} configurationName={configurationName} />;
 };
 
-const RenderRadio = <T extends RequiredFormProps>(
-	{ field } : { field: FieldSetField, formik: FormikProps<T> }) => {
+const RenderRadio = (
+	{ field, configuration, configurationName } : { field: FieldSetField, configuration: Configuration, configurationName: string }) => {
 
 		return (
 			<li>
 				<div role="group" className="configField">
 					{field.options?.map(option =>
 						<label key={option.value}>
-							<Field
-								type="radio"
-								className="configField"
-								name={"configuration." + field.name}
-								value={option.value}
+							<RenderField
+								field={field}
+								configuration={configuration}
+								configurationName={configurationName}
 							/>
 							{option.label}
 						</label>,
@@ -123,8 +147,8 @@ const RenderRadio = <T extends RequiredFormProps>(
 		);
 };
 
-const RenderNumber = <T extends RequiredFormProps>(
-	{ field, formik } : { field: FieldSetField, formik: FormikProps<T> }) => {
+const RenderNumber = (
+	{ field, configuration, configurationName } : { field: FieldSetField, configuration: Configuration, configurationName: string }) => {
 	// validate that value of number is between max and min
 	const validate = (value: string) => {
 		let error;
@@ -134,26 +158,30 @@ const RenderNumber = <T extends RequiredFormProps>(
 		return error;
 	};
 
-		return <RenderField field={field} formik={formik} validate={validate}/>;
+		return <RenderField field={field} configuration={configuration} configurationName={configurationName} validate={validate}/>;
 };
 
-const RenderText = <T extends RequiredFormProps>({
+const RenderText = ({
 	field,
-	formik,
+	configuration,
+	configurationName,
 }: {
 	field: FieldSetField,
-	formik: FormikProps<T>,
+	configuration: Configuration,
+	configurationName: string,
 }) => {
-		return <RenderField field={field} formik={formik} />;
+		return <RenderField field={field} configuration={configuration} configurationName={configurationName} />;
 };
 
-const RenderField = <T extends RequiredFormProps>({
+const RenderField = ({
 	field,
-	formik,
+	configuration,
+	configurationName,
 	validate = undefined,
 }: {
 	field: FieldSetField,
-	formik: FormikProps<T>,
+	configuration: Configuration,
+	configurationName: string,
 	validate?: (value: string) => string | undefined,
 }) => {
 	// id used for Field and label
@@ -167,7 +195,7 @@ const RenderField = <T extends RequiredFormProps>({
 					defaultValue={field.defaultValue}
 					validate={validate}
 					className="configField"
-					name={"configuration." + field.name}
+					name={configurationName + "." + field.name}
 					disabled={disabled}
 					type={field.type}
 					min={field.min}
@@ -182,9 +210,9 @@ const RenderField = <T extends RequiredFormProps>({
 			<label htmlFor={uuid}>{field.label as string}</label>
 			{/* if input has an additional fieldset or further configuration inputs
 						then render again by input type*/}
-			{!!field.fieldset && !!formik.values.configuration && !!formik.values.configuration[field.name] && (
+			{!!field.fieldset && !!configuration && !!configuration[field.name] && (
 				<ul className="workflow-configuration-subpanel">
-					{field.fieldset?.map((f, keys) => renderInputByType(f, keys, formik))}
+					{field.fieldset?.map((f, keys) => renderInputByType(f, keys, configuration, configurationName))}
 				</ul>
 			)}
 		</li>

--- a/src/components/shared/ConfirmModal.tsx
+++ b/src/components/shared/ConfirmModal.tsx
@@ -7,7 +7,7 @@ import BaseButton from "./BaseButton";
 
 export type ResourceType =
   "EVENT" | "SERIES" | "PLAYLIST" | "LOCATION" | "USER" |
-  "GROUP" | "ACL" | "THEME" | "TOBIRA_PATH";
+  "GROUP" | "ACL" | "THEME" | "TOBIRA_PATH" | "LIFECYCLE_POLICY";
 
 const ConfirmModal = <T, >({
 	close,

--- a/src/components/shared/MainNav.tsx
+++ b/src/components/shared/MainNav.tsx
@@ -91,6 +91,12 @@ const MainNav = ({
 					tooltipTitle: "NAV.EVENTS.TITLE",
 					Icon: LuCalendarCheck,
 				},
+				{
+					path: "/events/lifeCyclePolicies",
+					accessRole: "ROLE_UI_LIFECYCLEPOLICIES_VIEW",
+					tooltipTitle: "NAV.EVENTS.TITLE",
+					Icon: LuCalendarCheck,
+				},
 			],
 		},
 		"recordings": {

--- a/src/components/shared/NewResourceModal.tsx
+++ b/src/components/shared/NewResourceModal.tsx
@@ -7,6 +7,7 @@ import NewThemeWizard from "../configuration/partials/wizard/NewThemeWizard";
 import NewAclWizard from "../users/partials/wizard/NewAclWizard";
 import NewGroupWizard from "../users/partials/wizard/NewGroupWizard";
 import NewUserWizard from "../users/partials/wizard/NewUserWizard";
+import NewLifeCyclePolicyWizard from "../events/partials/wizards/NewLifeCyclePolicyWizard";
 import { Modal, ModalHandle } from "./modals/Modal";
 
 /**
@@ -19,7 +20,8 @@ export type NewResource =
   | "user"
   | "group"
   | "acl"
-  | "themes";
+  | "themes"
+  | "lifecyclepolicy";
 
 const NewResourceModal = ({
   handleClose,
@@ -52,6 +54,8 @@ const NewResourceModal = ({
         return t("USERS.GROUPS.NEW.CAPTION");
       case "user":
         return t("USERS.USERS.DETAILS.NEWCAPTION");
+      case "lifecyclepolicy":
+        return t("LIFECYCLE.POLICIES.NEW.CAPTION");
     }
   };
 
@@ -60,6 +64,7 @@ const NewResourceModal = ({
       header={headerText()}
       classId="add-event-modal"
       // initialFocus={"#firstField"}
+      focusTrapActive={resource === "lifecyclepolicy" ? false : true}
       ref={modalRef}
     >
       {resource === "events" && (
@@ -89,6 +94,10 @@ const NewResourceModal = ({
       {resource === "user" && (
         // New User Wizard
         <NewUserWizard close={close} />
+      )}
+      {resource === "lifecyclepolicy" && (
+        // New LifeCyclePolicy Wizard
+        <NewLifeCyclePolicyWizard close={close} />
       )}
     </Modal>
   );

--- a/src/components/shared/modals/Modal.tsx
+++ b/src/components/shared/modals/Modal.tsx
@@ -23,6 +23,7 @@ export type ModalProps = {
   header: string;
   classId: string;
   className?: string;
+  focusTrapActive?: boolean;  // Deactive focus trap, because it clashes with react-js-cron (can't click on dropdown elements)
 };
 
 export type ModalHandle = {
@@ -33,7 +34,7 @@ export type ModalHandle = {
 
 export const Modal = forwardRef<ModalHandle, PropsWithChildren<ModalProps>>(
   (
-    { open = false, closeCallback, header, classId, className, children },
+    { open = false, closeCallback, header, classId, className, children, focusTrapActive = true },
     ref,
   ) => {
     const { t } = useTranslation();
@@ -69,7 +70,9 @@ export const Modal = forwardRef<ModalHandle, PropsWithChildren<ModalProps>>(
 
 	return ReactDOM.createPortal(
 		isOpen &&
-			<FocusTrap>
+			<FocusTrap
+				active={focusTrapActive}
+			>
 				<div>
 					<div className="modal-animation modal-overlay" />
 					<section

--- a/src/components/shared/wizard/RenderField.tsx
+++ b/src/components/shared/wizard/RenderField.tsx
@@ -8,6 +8,8 @@ import DropDown, { DropDownOption } from "../DropDown";
 import { parseISO } from "date-fns";
 import { FieldProps } from "formik";
 import { MetadataField } from "../../../slices/eventSlice";
+import { Cron } from "react-js-cron";
+import "react-js-cron/dist/styles.css";
 import { GroupBase, SelectInstance } from "react-select";
 import TextareaAutosize from "react-textarea-autosize";
 import { LuCheck, LuSquarePen } from "react-icons/lu";
@@ -123,6 +125,12 @@ const RenderField = ({
 					field={field}
 					isFirstField={isFirstField}
 					ref={editableRef}
+				/>
+			)}
+			{metadataField.type === "cron" && (
+				<EditableCronValue
+					field={field}
+					form={form}
 				/>
 			)}
 			<div className="single-value-right">
@@ -327,6 +335,38 @@ const EditableSingleValueTime = ({
 			/>
 		</div>
 	);
+};
+
+const EditableCronValue = ({
+	field,
+	form: { setFieldValue },
+} : {
+	field: FieldProps["field"]
+	form: FieldProps["form"]
+}) => {
+
+	return (
+		<div>
+			<Cron
+				className={"my-project-cron"}
+				value={field.value as string}
+				setValue={(value: string) => { setFieldValue(field.name, value); }}
+			/>
+		</div>
+	);
+		// <div onClick={() => setEditMode(true)} className="show-edit">
+		// 	<span className="editable preserve-newlines">{text || ""}</span>
+		// 	<div>
+		// 		<i className="edit fa fa-pencil-square" />
+		// 		{showCheck && (
+		// 			<i
+		// 				className={cn("saved fa fa-check", {
+		// 					active: initialValues[field.name] !== field.value,
+		// 				})}
+		// 			/>
+		// 		)}
+		// 	</div>
+		// </div>
 };
 
 /**

--- a/src/configs/modalConfig.ts
+++ b/src/configs/modalConfig.ts
@@ -5,6 +5,7 @@ import { TobiraPage } from "../slices/seriesSlice";
 import { initArray } from "../utils/utils";
 import { EditedEvents, Event, UploadAssetsTrack } from "../slices/eventSlice";
 import { Role } from "../slices/aclSlice";
+import { TargetFilter } from "../slices/lifeCycleSlice";
 import { ParseKeys } from "i18next";
 import { UserRole } from "../slices/userSlice";
 import { PlaylistEntry } from "../slices/playlistDetailsSlice";
@@ -239,4 +240,38 @@ export const initialFormValuesEditScheduledEvents: {
 	events: [],
 	editedEvents: [],
 	changedEvents: [],
+};
+
+export const initialFormValuesNewLifeCyclePolicy: {
+	title: string,
+	isActive: boolean,
+	isCreatedFromConfig: boolean,
+	targetType: string,
+	timing: string,
+	action: string,
+	actionDate: string,
+	cronTrigger: string,
+	actionParameters: { [key: string]: unknown }
+	policies: TransformedAcl[]
+	targetFiltersTransformed: { [key: string]: (TargetFilter & { filter: string })[] },
+} = {
+	title: "",
+	isActive: true,
+	isCreatedFromConfig: false,
+	targetType: "EVENT",
+	timing: "SPECIFIC_DATE",
+	action: "START_WORKFLOW",
+	actionDate: "",
+	cronTrigger: "",
+	actionParameters: {
+		// workflowId: "noop",
+		// workflowParameters: "{\"straightToPublishing\": true}",
+		workflowId: "",
+		workflowParameters: { },
+	},
+
+	policies: [],
+	targetFiltersTransformed: {
+		"dublincore/episode": [],
+	},
 };

--- a/src/configs/tableConfigs/lifeCyclePoliciesTableConfig.ts
+++ b/src/configs/tableConfigs/lifeCyclePoliciesTableConfig.ts
@@ -1,0 +1,30 @@
+import { TableConfig } from "./aclsTableConfig";
+
+export const lifeCyclePolicyTableConfig: TableConfig = {
+	columns: [
+		{
+			name: "title",
+			label: "LIFECYCLE.POLICIES.TABLE.TITLE",
+			sortable: true,
+		},
+		{
+			template: "LifeCyclePolicyIsActiveCell",
+			name: "isActive",
+			label: "LIFECYCLE.POLICIES.TABLE.ISACTIVE",
+		},
+		{
+			name: "timing",
+			label: "LIFECYCLE.POLICIES.TABLE.TIMING",
+			sortable: true,
+		},
+		{
+			template: "LifeCyclePolicyActionCell",
+			name: "actions",
+			label: "LIFECYCLE.POLICIES.TABLE.ACTION",
+		},
+	],
+	caption: "TABLE.CAPTION",
+	resource: "lifeCyclePolicies",
+	category: "events",
+	multiSelect: false,
+};

--- a/src/configs/tableConfigs/lifeCyclePoliciesTableMap.ts
+++ b/src/configs/tableConfigs/lifeCyclePoliciesTableMap.ts
@@ -1,0 +1,11 @@
+import LifeCyclePolicyActionCell from "../../components/events/partials/LifeCyclePolicyActionCell";
+import LifeCyclePolicyIsActiveCell from "../../components/events/partials/LifeCyclePolicyIsActiveCell";
+
+/**
+ * This map contains the mapping between the template strings above and the corresponding react component.
+ * This helps to render different templates of cells more dynamically
+ */
+export const lifeCyclePoliciesTemplateMap = {
+	LifeCyclePolicyIsActiveCell: LifeCyclePolicyIsActiveCell,
+	LifeCyclePolicyActionCell: LifeCyclePolicyActionCell,
+};

--- a/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
@@ -123,6 +123,7 @@
 				"USER": "The following user will be deleted",
 				"THEME": "The following theme will be deleted",
 				"LOCATION": "The following location will be deleted",
+				"LIFECYCLE_POLICY": "The following lifeCycle policy will be deleted",
 				"TOBIRA_PATH": "The series will be removed from the following path in Tobira:"
 			},
 			"NAME": "Name"
@@ -209,6 +210,10 @@
 		"EVENTS_NOT_DELETED_NOT_AUTHORIZED": "The event(s) could not be deleted, because you don't have the permission to do so.",
 		"SERIES_DELETED": "The series has been deleted",
 		"SERIES_NOT_DELETED": "The series could not be deleted",
+		"LIFECYCLE_POLICY_ADDED": "The lifeCycle policy has been created",
+		"LIFECYCLE_POLICY_NOT_SAVED": "The lifeCycle policy could not be saved",
+		"LIFECYCLE_POLICY_DELETED": "The lifeCycle policy has been deleted",
+		"LIFECYCLE_POLICY_NOT_DELETED": "The lifeCycle policy could not be deleted",
 		"LOCATION_DELETED": "The location has been deleted",
 		"LOCATION_NOT_DELETED": "The location could not be deleted",
 		"LOCATION_NOT_DELETED_NOT_AUTHORIZED": "The location could not be deleted, because you don't have the permission to do so.",
@@ -217,7 +222,6 @@
 		"CONFLICT_ALREADY_ENDED": "Scheduling error: The event has already ended.",
 		"CONFLICT_END_BEFORE_START": "Scheduling error: Schedule end has to be later than the start.",
 		"CONFLICT_IN_THE_PAST": "The schedule could not be updated: You cannot schedule an event to be in the past.",
-		"CONFLICT_END_TIME_TOO_EARLY": "This event cannot be modified because it is currently in progress.",
 		"CONFLICT_RANGE_DAYS":"At least one repeat day must be within the scheduled date range.",
 		"INVALID_ACL_RULES": "Rules have to contain a valid role and read or/and write right(s).",
 		"MISSING_ACL_RULES": "At least one role with Read and Write permissions is required!",
@@ -718,7 +722,8 @@
 					"ACCESS": "Access policy",
 					"COMMENTS": "Comments",
 					"STATISTICS": "Statistics",
-					"TOBIRA": "Tobira"
+					"TOBIRA": "Tobira",
+					"LIFECYCLEPOLICIES": "LifeCycle Policies"
 				},
 				"PUBLICATIONS": {
 					"CAPTION": "Publications",
@@ -1122,6 +1127,15 @@
 						"TECHNICAL_DETAILS": "Technical details",
 						"OPERATION": "Operation the error occured in"
 					}
+				},
+				"LIFECYCLEPOLICIES": {
+					"EMPTY": "No policies found",
+					"TABLE_TITLE": "LifeCycle Policies",
+					"TITLE": "Policy title",
+					"DISCLAIMER": {
+						"TITLE": "Important note",
+						"MESSAGE": "The list contains lifecycle policies that would affect this event, were the policies to be executed right now. Since policies only decide which events they affect on the moment of their execution, this list cannot claim to be accurate. A policy appearing in the list below is no guarantee that the policy will affect this event."
+					}
 				}
 			}
 		},
@@ -1363,6 +1377,77 @@
 					"USER": "User",
 					"NEW_USER": "New user",
 					"EMPTY": "No access policies defined"
+				}
+			}
+		}
+	},
+	"LIFECYCLE": {
+		"NAVIGATION": {
+			"POLICIES": "LifeCycle Policies"
+		},
+		"POLICIES": {
+			"TABLE": {
+				"ACTION": "Actions",
+				"CAPTION": "LifeCycle Policies",
+				"ISACTIVE": "Active",
+				"TIMING": "Timing",
+				"TITLE": "Title",
+				"TOOLTIP": {
+					"DETAILS": "LifeCycle Policy Details",
+					"DELETE": "Delete LifeCycle Policy"
+				},
+				"ADD_POLICY": "Add LifeCycle Policy"
+			},
+			"NEW": {
+				"CAPTION": "Create LifeCycle Policy",
+				"GENERAL": {
+					"CAPTION": "General"
+				}
+			},
+			"DETAILS": {
+				"HEADER": "LifeCycle Policy Details",
+				"GENERAL": {
+					"ACTION": "Action",
+					"ACTIONDATE": "Action Date",
+					"ACTIONPARAMETERS": {
+						"CAPTION": "Action Parameters",
+						"WORKFLOW_ID": "Workflow ID",
+						"WORKFLOW_PARAMETERS": "Workflow Parameters"
+					},
+					"CAPTION": "LifeCycle Policy Details",
+					"CRONTRIGGER": "Cron Trigger",
+					"ID": "Identifier",
+					"ISACTIVE": "Active",
+					"ISCREATEDFROMCONFIG": "Created from Config",
+					"TARGETTYPE": "Target Type",
+					"TARGETFILTERS": {
+						"CAPTION": "Target Filters",
+						"FILTER": "Filter",
+						"VALUE": "Value",
+						"TYPE": "Type",
+						"MUST": "Must",
+						"NEW": "New Filter"
+					},
+					"TIMING": "Timing",
+					"TITLE": "Title",
+					"NOTE": {
+						"TITLE": "A note on editing LifeCycle Policies",
+						"MESSAGE": "The same policy cannot affect the same target multiple times. Depending on your goals, creating a new policy may be required."
+					}
+				},
+				"ACCESS": {
+					"LABEL": "Select a template",
+					"DESCRIPTION": "At least one role with Read and Write permissions is required.",
+					"NON_USER_ROLES": "Roles and Groups authorized for the policy",
+					"ROLE": "Role",
+					"NEW": "New policy",
+					"USER": "User",
+					"USERS": "Users who are authorized for the policy",
+					"NEW_USER": "New user"
+				},
+				"TAB": {
+					"GENERAL": "General",
+					"ACCESSPOLICIES": "Access Policies"
 				}
 			}
 		}

--- a/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
@@ -211,6 +211,7 @@
 		"SERIES_DELETED": "The series has been deleted",
 		"SERIES_NOT_DELETED": "The series could not be deleted",
 		"LIFECYCLE_POLICY_ADDED": "The lifeCycle policy has been created",
+		"LIFECYCLE_POLICY_SAVED": "The lifeCycle policy was saved",
 		"LIFECYCLE_POLICY_NOT_SAVED": "The lifeCycle policy could not be saved",
 		"LIFECYCLE_POLICY_DELETED": "The lifeCycle policy has been deleted",
 		"LIFECYCLE_POLICY_NOT_DELETED": "The lifeCycle policy could not be deleted",

--- a/src/selectors/eventDetailsSelectors.ts
+++ b/src/selectors/eventDetailsSelectors.ts
@@ -193,3 +193,6 @@ export const hasStatisticsError = (state: RootState) =>
 	state.eventDetails.hasStatisticsError;
 export const isFetchingStatistics = (state: RootState) =>
 	state.eventDetails.statusStatistics === "loading";
+
+export const getLifeCyclePoliciesForEvent = (state: RootState) =>
+	state.eventDetails.lifeCyclePolicies;

--- a/src/selectors/lifeCycleDetailsSelectors.ts
+++ b/src/selectors/lifeCycleDetailsSelectors.ts
@@ -1,0 +1,14 @@
+import { RootState } from "../store";
+
+/**
+ * This file contains selectors regarding details of a certain lifeCyclePolicy/capture agent
+ */
+/* selectors for modal */
+export const showModal = (state: RootState) => state.lifeCyclePolicyDetails.modal.show;
+export const getModalLifeCyclePolicy = (state: RootState) => state.lifeCyclePolicyDetails.modal.policy;
+
+export const getLifeCyclePolicyDetails = (state: RootState) => state.lifeCyclePolicyDetails;
+export const getLifeCyclePolicyDetailsAcl = (state: RootState) => state.lifeCyclePolicyDetails.accessControlEntries;
+export const getLifeCyclePolicyActions = (state: RootState) => state.lifeCyclePolicyDetails.actionsEnum;
+export const getLifeCyclePolicyTargetTypes = (state: RootState) => state.lifeCyclePolicyDetails.targetTypesEnum;
+export const getLifeCyclePolicyTimings = (state: RootState) => state.lifeCyclePolicyDetails.timingsEnum;

--- a/src/selectors/lifeCycleSelectors.ts
+++ b/src/selectors/lifeCycleSelectors.ts
@@ -1,0 +1,7 @@
+import { RootState } from "../store";
+
+/**
+ * This file contains selectors regarding acls
+ */
+export const getLifeCyclePolicies = (state: RootState) => state.lifeCycle.results;
+export const getTotalLifeCyclePolicies = (state: RootState) => state.lifeCycle.total;

--- a/src/slices/eventDetailsSlice.ts
+++ b/src/slices/eventDetailsSlice.ts
@@ -38,6 +38,7 @@ import { Ace } from "./aclSlice";
 import { setTobiraTabHierarchy, TobiraData } from "./seriesDetailsSlice";
 import { handleTobiraError } from "./shared/tobiraErrors";
 import camelcaseKeys from "camelcase-keys";
+import { LifeCyclePolicy } from "./lifeCycleSlice";
 
 // Contains the navigation logic for the modal
 type EventDetailsModal = {
@@ -218,6 +219,8 @@ type EventDetailsState = {
 	errorStatisticsValue: SerializedError | null,
 	statusTobiraData: "uninitialized" | "loading" | "succeeded" | "failed",
 	errorTobiraData: SerializedError | null,
+	statusLifeCyclePolicies: "uninitialized" | "loading" | "succeeded" | "failed",
+	errorLifeCyclePolicies: SerializedError | null,
 	eventId: string,
 	modal: EventDetailsModal,
 	metadata: MetadataCatalog,
@@ -377,6 +380,7 @@ type EventDetailsState = {
 	statistics: Statistics[],
 	hasStatisticsError: boolean,
 	tobiraData: TobiraData,
+	lifeCyclePolicies: LifeCyclePolicy[]
 }
 
 // Initial state of event details in redux store
@@ -441,6 +445,8 @@ const initialState: EventDetailsState = {
 	errorStatisticsValue: null,
 	statusTobiraData: "uninitialized",
 	errorTobiraData: null,
+	statusLifeCyclePolicies: "uninitialized",
+	errorLifeCyclePolicies: null,
 	eventId: "",
 	modal: {
 		show: false,
@@ -609,6 +615,7 @@ const initialState: EventDetailsState = {
 		id: "",
 		hostPages: [],
 	},
+	lifeCyclePolicies: [],
 };
 
 
@@ -1571,6 +1578,13 @@ export const fetchEventStatisticsValueUpdate = createAppAsyncThunk("eventDetails
 			statistics,
 		)
 	);
+});
+
+export const fetchEventLifeCyclePolicies = createAppAsyncThunk("eventDetails/fetchLifeCyclePolicies", async (eventId: Event["id"]) => {
+	const data = await axios.get<EventDetailsState["lifeCyclePolicies"]>(
+		`/api/lifecyclemanagement/policiesForEvent/${eventId}`,
+	);
+	return data.data;
 });
 
 export const updateMetadata = createAppAsyncThunk("eventDetails/updateMetadata", async (params: {
@@ -2546,6 +2560,21 @@ const eventDetailsSlice = createSlice({
 			.addCase(fetchEventDetailsTobira.rejected, (state, action) => {
 				state.statusTobiraData = "failed";
 				state.errorTobiraData = action.error;
+			})
+			// fetch lifecycle
+			.addCase(fetchEventLifeCyclePolicies.pending, state => {
+				state.statusLifeCyclePolicies = "loading";
+			})
+			.addCase(fetchEventLifeCyclePolicies.fulfilled, (state, action: PayloadAction<
+				EventDetailsState["lifeCyclePolicies"]
+			>) => {
+				state.statusLifeCyclePolicies = "succeeded";
+				state.lifeCyclePolicies = action.payload;
+				state.errorLifeCyclePolicies = null;
+			})
+			.addCase(fetchEventLifeCyclePolicies.rejected, (state, action) => {
+				state.statusLifeCyclePolicies = "failed";
+				state.errorLifeCyclePolicies = action.error;
 			});
 	},
 });

--- a/src/slices/lifeCycleDetailsSlice.ts
+++ b/src/slices/lifeCycleDetailsSlice.ts
@@ -1,0 +1,278 @@
+import { PayloadAction, SerializedError, createSlice } from "@reduxjs/toolkit";
+import axios from "axios";
+import { createAppAsyncThunk } from "../createAsyncThunkWithTypes";
+import { LifeCyclePolicy } from "./lifeCycleSlice";
+import { TransformedAcl } from "./aclDetailsSlice";
+import { createPolicy } from "../utils/resourceUtils";
+import { Ace } from "./aclSlice";
+import { addNotification } from "./notificationSlice";
+import { AppDispatch } from "../store";
+
+
+/**
+ * This file contains redux reducer for actions affecting the state of a lifeCyclePolicy/capture agent
+ */
+type LifeCyclePolicyDetailsModal = {
+	show: boolean,
+	policy: { id: string, title: string } | null,
+}
+
+interface LifeCyclePolicyDetailsState extends LifeCyclePolicy {
+	statusLifeCyclePolicyDetails: "uninitialized" | "loading" | "succeeded" | "failed",
+	errorLifeCyclePolicyDetails: SerializedError | null,
+
+	modal: LifeCyclePolicyDetailsModal,
+	actionsEnum: string[],
+	targetTypesEnum: string[],
+	timingsEnum: string[],
+}
+
+// Initial state of lifeCyclePolicy details in redux store
+const initialState: LifeCyclePolicyDetailsState = {
+	statusLifeCyclePolicyDetails: "uninitialized",
+	errorLifeCyclePolicyDetails: null,
+	modal: {
+		show: false,
+		policy: null,
+	},
+	actionParameters: {},
+	timing: "SPECIFIC_DATE",
+	action: "START_WORKFLOW",
+	targetType: "EVENT",
+	id: "",
+	title: "",
+	isActive: false,
+	isCreatedFromConfig: false,
+	actionDate: "",
+	cronTrigger: "",
+	targetFilters: {},
+	accessControlEntries: [],
+
+	actionsEnum: [],
+	targetTypesEnum: [],
+	timingsEnum: [],
+};
+
+// fetch details of certain lifeCyclePolicy from server
+export const fetchLifeCyclePolicyDetails = createAppAsyncThunk("lifeCyclePolicyDetails/fetchLifeCyclePolicyDetails", async (id: string) => {
+	type ReturnType = LifeCyclePolicy & { actionParameters: string, targetFilters: string, accessControlEntries: {
+		id: number,
+		allow: boolean,
+		role: string,
+		action: string,
+	}[] }
+	const res = await axios.get<ReturnType>(`/api/lifecyclemanagement/policies/${id}`);
+	const data = res.data;
+
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+	data.actionParameters = JSON.parse(data.actionParameters);
+	if (data.action === "START_WORKFLOW") {
+		data.actionParameters.workflowParameters = JSON.parse(data.actionParameters.workflowParameters as string);
+	}
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+	data.targetFilters = JSON.parse(data.targetFilters);
+
+	const accessPolicies : {
+		id: number,
+		allow: boolean,
+		role: string,
+		action: string,
+	}[] = data.accessControlEntries;
+	let acls: TransformedAcl[] = [];
+
+		const json = accessPolicies;
+		const newPolicies: { [key: string]: TransformedAcl } = {};
+		const policyRoles: string[] = [];
+		for (let i = 0; i < json.length; i++) {
+			const policy: Ace = json[i];
+			if (!newPolicies[policy.role]) {
+				newPolicies[policy.role] = createPolicy(policy.role);
+				policyRoles.push(policy.role);
+			}
+			if (policy.action === "read" || policy.action === "write") {
+				newPolicies[policy.role][policy.action] = policy.allow;
+			} else if (policy.allow === true) { // || policy.allow === "true") {
+				newPolicies[policy.role].actions.push(policy.action);
+			}
+		}
+		acls = policyRoles.map(role => newPolicies[role]);
+
+	const result = {
+		...data,
+		accessControlEntries: acls,
+	};
+
+	return result;
+});
+
+export const fetchLifeCyclePolicyActions = createAppAsyncThunk("lifeCyclePolicyDetails/fetchLifeCyclePolicyActions", async () => {
+	const res = await axios.get<string[]>("/api/lifecyclemanagement/policies/actions");
+	const data = res.data;
+
+	return data;
+});
+
+export const fetchLifeCyclePolicyTargetTypes = createAppAsyncThunk("lifeCyclePolicyDetails/fetchLifeCyclePolicyTargetTypes", async () => {
+	const res = await axios.get<string[]>("/api/lifecyclemanagement/policies/targettypes");
+	const data = res.data;
+
+	return data;
+});
+
+export const fetchLifeCyclePolicyTimings = createAppAsyncThunk("lifeCyclePolicyDetails/fetchLifeCyclePolicyTimings", async () => {
+	const res = await axios.get<string[]>("/api/lifecyclemanagement/policies/timings");
+	const data = res.data;
+
+	return data;
+});
+
+// Dummy function for compatability
+// eslint-disable-next-line @typescript-eslint/require-await, @typescript-eslint/no-unused-vars
+export const fetchLifeCyclePolicyDetailsAcls = createAppAsyncThunk("lifeCyclePolicyDetails/fetchLifeCyclePolicyDetailsAcls", async (id: string, { getState }) => {
+	const state = getState();
+	return state.lifeCyclePolicyDetails.accessControlEntries;
+});
+
+// Dummy function for compatability
+export const updateLifeCyclePolicyAccess = createAppAsyncThunk("lifeCyclePolicyDetails/fetchLifeCyclePolicyDetailsAcls", async (params: {
+	id: string,
+	policies: { acl: { ace: Ace[] } }
+}, { dispatch }) => {
+	const { id, policies } = params;
+
+	const data = new URLSearchParams();
+	data.append("accessControlEntries", JSON.stringify(policies.acl.ace));
+
+	await axios.put(`/api/lifecyclemanagement/policies/${id}`, data)
+		.then(response => {
+			console.info(response);
+			dispatch(addNotification({ type: "success", key: "LIFECYCLE_POLICY_ADDED" }));
+			return true;
+		})
+		.catch(response => {
+			console.error(response);
+			dispatch(addNotification({ type: "error", key: "LIFECYCLEPOLICY_NOT_SAVED" }));
+			return false;
+		});
+});
+
+export const updateLifeCyclePolicy = createAppAsyncThunk("lifeCyclePolicyDetails/updateLifeCyclePolicy", async (policy: LifeCyclePolicy, { dispatch }) => {
+	const data = new URLSearchParams();
+
+	Object.entries(policy).forEach(([key, value]) => {
+		let stringified = value;
+		if (stringified instanceof Date) {
+			stringified = stringified.toJSON();
+		} else if (stringified === Object(stringified)) {
+			stringified = JSON.stringify(stringified);
+		}
+		// @ts-expect-error: ???
+		data.append(key, stringified);
+	});
+
+	await axios.put(`/api/lifecyclemanagement/policies/${policy.id}`, data)
+		.then(response => {
+			console.info(response);
+			dispatch(addNotification({ type: "success", key: "LIFECYCLE_POLICY_ADDED" }));
+		})
+		.catch(response => {
+			console.error(response);
+			dispatch(addNotification({ type: "error", key: "LIFECYCLEPOLICY_NOT_SAVED" }));
+		});
+});
+
+/**
+ * Open details modal externally
+ *
+ * @param page modal page
+ * @param policy policy to show
+ */
+export const openModal = (
+	policy: LifeCyclePolicyDetailsModal["policy"],
+) => (dispatch: AppDispatch) => {
+	dispatch(setModalLifeCyclePolicy(policy));
+	dispatch(setShowModal(true));
+};
+
+const lifeCyclePolicyDetailsSlice = createSlice({
+	name: "lifeCyclePolicyDetails",
+	initialState,
+	reducers: {
+		setShowModal(state, action: PayloadAction<
+			LifeCyclePolicyDetailsState["modal"]["show"]
+		>) {
+			state.modal.show = action.payload;
+		},
+		setModalLifeCyclePolicy(state, action: PayloadAction<
+			LifeCyclePolicyDetailsState["modal"]["policy"]
+		>) {
+			state.modal.policy = action.payload;
+		},
+	},
+	// These are used for thunks
+	extraReducers: builder => {
+		builder
+			.addCase(fetchLifeCyclePolicyDetails.pending, state => {
+				state.statusLifeCyclePolicyDetails = "loading";
+			})
+			.addCase(fetchLifeCyclePolicyDetails.fulfilled, (state, action: PayloadAction<{
+				actionParameters: LifeCyclePolicyDetailsState["actionParameters"],
+				timing: LifeCyclePolicyDetailsState["timing"],
+				action: LifeCyclePolicyDetailsState["action"],
+				targetType: LifeCyclePolicyDetailsState["targetType"],
+				id: LifeCyclePolicyDetailsState["id"],
+				title: LifeCyclePolicyDetailsState["title"],
+				isActive: LifeCyclePolicyDetailsState["isActive"],
+				isCreatedFromConfig: LifeCyclePolicyDetailsState["isCreatedFromConfig"],
+				actionDate: LifeCyclePolicyDetailsState["actionDate"],
+				cronTrigger: LifeCyclePolicyDetailsState["cronTrigger"],
+				targetFilters: LifeCyclePolicyDetailsState["targetFilters"],
+				accessControlEntries: LifeCyclePolicyDetailsState["accessControlEntries"],
+			}>) => {
+				state.statusLifeCyclePolicyDetails = "succeeded";
+				const lifeCyclePolicyDetails = action.payload;
+				state.actionParameters = lifeCyclePolicyDetails.actionParameters;
+				state.timing = lifeCyclePolicyDetails.timing;
+				state.action = lifeCyclePolicyDetails.action;
+				state.targetType = lifeCyclePolicyDetails.targetType;
+				state.id = lifeCyclePolicyDetails.id;
+				state.title = lifeCyclePolicyDetails.title;
+				state.isActive = lifeCyclePolicyDetails.isActive;
+				state.isCreatedFromConfig = lifeCyclePolicyDetails.isCreatedFromConfig;
+				state.actionDate = lifeCyclePolicyDetails.actionDate;
+				state.cronTrigger = lifeCyclePolicyDetails.cronTrigger;
+				state.targetFilters = lifeCyclePolicyDetails.targetFilters;
+				state.accessControlEntries = lifeCyclePolicyDetails.accessControlEntries;
+			})
+			.addCase(fetchLifeCyclePolicyDetails.rejected, (state, action) => {
+				state.statusLifeCyclePolicyDetails = "failed";
+				state.errorLifeCyclePolicyDetails = action.error;
+			})
+			.addCase(fetchLifeCyclePolicyActions.fulfilled, (state, action: PayloadAction<
+				LifeCyclePolicyDetailsState["actionsEnum"]
+			>) => {
+				const actionsEnum = action.payload;
+				state.actionsEnum = actionsEnum;
+			})
+			.addCase(fetchLifeCyclePolicyTargetTypes.fulfilled, (state, action: PayloadAction<
+				LifeCyclePolicyDetailsState["actionsEnum"]
+			>) => {
+				const targetTypesEnum = action.payload;
+				state.targetTypesEnum = targetTypesEnum;
+			})
+			.addCase(fetchLifeCyclePolicyTimings.fulfilled, (state, action: PayloadAction<
+				LifeCyclePolicyDetailsState["actionsEnum"]
+			>) => {
+				const timingsEnum = action.payload;
+				state.timingsEnum = timingsEnum;
+			});
+	},
+});
+
+export const {
+	setShowModal,
+	setModalLifeCyclePolicy,
+} = lifeCyclePolicyDetailsSlice.actions;
+
+// Export the slice reducer as the default export
+export default lifeCyclePolicyDetailsSlice.reducer;

--- a/src/slices/lifeCycleDetailsSlice.ts
+++ b/src/slices/lifeCycleDetailsSlice.ts
@@ -144,8 +144,7 @@ export const updateLifeCyclePolicyAccess = createAppAsyncThunk("lifeCyclePolicyD
 	data.append("accessControlEntries", JSON.stringify(policies.acl.ace));
 
 	await axios.put(`/api/lifecyclemanagement/policies/${id}`, data)
-		.then(response => {
-			console.info(response);
+		.then(_response => {
 			dispatch(addNotification({ type: "success", key: "LIFECYCLE_POLICY_ADDED" }));
 			return true;
 		})
@@ -171,8 +170,7 @@ export const updateLifeCyclePolicy = createAppAsyncThunk("lifeCyclePolicyDetails
 	});
 
 	await axios.put(`/api/lifecyclemanagement/policies/${policy.id}`, data)
-		.then(response => {
-			console.info(response);
+		.then(_response => {
 			dispatch(addNotification({ type: "success", key: "LIFECYCLE_POLICY_ADDED" }));
 		})
 		.catch(response => {

--- a/src/slices/lifeCycleDetailsSlice.ts
+++ b/src/slices/lifeCycleDetailsSlice.ts
@@ -155,7 +155,7 @@ export const updateLifeCyclePolicyAccess = createAppAsyncThunk("lifeCyclePolicyD
 		});
 });
 
-export const updateLifeCyclePolicy = createAppAsyncThunk("lifeCyclePolicyDetails/updateLifeCyclePolicy", async (policy: LifeCyclePolicy) => {
+export const updateLifeCyclePolicy = createAppAsyncThunk("lifeCyclePolicyDetails/updateLifeCyclePolicy", async (policy: LifeCyclePolicy, { dispatch }) => {
 	const data = new URLSearchParams();
 
 	Object.entries(policy).forEach(([key, value]) => {
@@ -170,6 +170,8 @@ export const updateLifeCyclePolicy = createAppAsyncThunk("lifeCyclePolicyDetails
 	});
 
 	await axios.put(`/api/lifecyclemanagement/policies/${policy.id}`, data);
+
+	dispatch(setPolicy(policy));
 });
 
 /**
@@ -198,6 +200,20 @@ const lifeCyclePolicyDetailsSlice = createSlice({
 			LifeCyclePolicyDetailsState["modal"]["policy"]
 		>) {
 			state.modal.policy = action.payload;
+		},
+		setPolicy(state, action: PayloadAction<LifeCyclePolicy>) {
+			state.actionParameters = action.payload.actionParameters;
+			state.timing = action.payload.timing;
+			state.action = action.payload.action;
+			state.targetType = action.payload.targetType;
+			state.id = action.payload.id;
+			state.title = action.payload.title;
+			state.isActive = action.payload.isActive;
+			state.isCreatedFromConfig = action.payload.isCreatedFromConfig;
+			state.actionDate = action.payload.actionDate;
+			state.cronTrigger = action.payload.cronTrigger;
+			state.targetFilters = action.payload.targetFilters;
+			state.accessControlEntries = action.payload.accessControlEntries;
 		},
 	},
 	// These are used for thunks
@@ -263,6 +279,7 @@ const lifeCyclePolicyDetailsSlice = createSlice({
 export const {
 	setShowModal,
 	setModalLifeCyclePolicy,
+	setPolicy,
 } = lifeCyclePolicyDetailsSlice.actions;
 
 // Export the slice reducer as the default export

--- a/src/slices/lifeCycleDetailsSlice.ts
+++ b/src/slices/lifeCycleDetailsSlice.ts
@@ -155,7 +155,7 @@ export const updateLifeCyclePolicyAccess = createAppAsyncThunk("lifeCyclePolicyD
 		});
 });
 
-export const updateLifeCyclePolicy = createAppAsyncThunk("lifeCyclePolicyDetails/updateLifeCyclePolicy", async (policy: LifeCyclePolicy, { dispatch }) => {
+export const updateLifeCyclePolicy = createAppAsyncThunk("lifeCyclePolicyDetails/updateLifeCyclePolicy", async (policy: LifeCyclePolicy) => {
 	const data = new URLSearchParams();
 
 	Object.entries(policy).forEach(([key, value]) => {
@@ -169,14 +169,7 @@ export const updateLifeCyclePolicy = createAppAsyncThunk("lifeCyclePolicyDetails
 		data.append(key, stringified);
 	});
 
-	await axios.put(`/api/lifecyclemanagement/policies/${policy.id}`, data)
-		.then(_response => {
-			dispatch(addNotification({ type: "success", key: "LIFECYCLE_POLICY_ADDED" }));
-		})
-		.catch(response => {
-			console.error(response);
-			dispatch(addNotification({ type: "error", key: "LIFECYCLEPOLICY_NOT_SAVED" }));
-		});
+	await axios.put(`/api/lifecyclemanagement/policies/${policy.id}`, data);
 });
 
 /**

--- a/src/slices/lifeCycleSlice.ts
+++ b/src/slices/lifeCycleSlice.ts
@@ -118,8 +118,7 @@ export const postNewLifeCyclePolicy = createAppAsyncThunk("lifeCycle/postNewLife
 	data.append("accessControlEntries", JSON.stringify(prepareAccessPolicyRulesForPost(policy.accessControlEntries).acl.ace));
 
 	await axios.post("/api/lifecyclemanagement/policies", data)
-		.then(res => {
-			console.info(res);
+		.then(_res => {
 			dispatch(addNotification({ type: "success", key: "LIFECYCLE_POLICY_ADDED" }));
 		})
 		.catch(res => {
@@ -131,8 +130,7 @@ export const postNewLifeCyclePolicy = createAppAsyncThunk("lifeCycle/postNewLife
 export const deleteLifeCyclePolicy = createAppAsyncThunk("lifeCycle/fetchLifeCyclePolicies", async (id: string, { dispatch }) => {
 	await axios
 		.delete(`/api/lifecyclemanagement/policies/${id}`)
-		.then(res => {
-			console.info(res);
+		.then(_res => {
 			dispatch(addNotification({ type: "success", key: "LIFECYCLE_POLICY_DELETED" }));
 		})
 		.catch(res => {

--- a/src/slices/lifeCycleSlice.ts
+++ b/src/slices/lifeCycleSlice.ts
@@ -1,0 +1,186 @@
+import { PayloadAction, SerializedError, createSlice } from "@reduxjs/toolkit";
+import { TableConfig } from "../configs/tableConfigs/aclsTableConfig";
+import { lifeCyclePolicyTableConfig } from "../configs/tableConfigs/lifeCyclePoliciesTableConfig";
+import axios from "axios";
+import { getURLParams, prepareAccessPolicyRulesForPost } from "../utils/resourceUtils";
+import { createAppAsyncThunk } from "../createAsyncThunkWithTypes";
+import { TransformedAcl } from "./aclDetailsSlice";
+import { addNotification } from "./notificationSlice";
+
+// type LifeCyclePolicyTiming = "SPECIFIC_DATE" | "REPEATING" | "ALWAYS";
+// type LifeCyclePolicyAction = "START_WORKFLOW"
+// type LifeCyclePolicyTargetType = "EVENT"
+export type CommonMetadataCatalogFlavor = "dublincore/episode"; // TODO: Get this from the backend
+export type TargetFilter = {
+	value: string | string[],
+	type: TargetFiltersType,
+	must: boolean
+}
+export const ALL_TARGET_FILTER_TYPES = ["SEARCH", "WILDCARD", "GREATER_THAN", "LESS_THAN"] as const;
+type TargetFilterTypesTuple = typeof ALL_TARGET_FILTER_TYPES;
+type TargetFiltersType = TargetFilterTypesTuple[number];
+
+export type LifeCyclePolicy = {
+	actionParameters: { [key: string]: unknown }, // JSON. Variable, depends on action1
+	timing: string,
+	action: string,
+	targetType: string,
+	id: string,
+	title: string,
+	isActive: boolean,
+	isCreatedFromConfig: boolean,
+	actionDate: string, // Date
+	cronTrigger: string,
+	targetFilters: { [key: string]: { [key: string]: TargetFilter } },
+	accessControlEntries: TransformedAcl[]
+}
+
+type LifeCycleState = {
+	status: "uninitialized" | "loading" | "succeeded" | "failed",
+	error: SerializedError | null,
+	results: LifeCyclePolicy[],
+	columns: TableConfig["columns"],
+	total: number,
+	offset: number,
+	limit: number,
+};
+
+// Fill columns initially with columns defined in aclsTableConfig
+const initialColumns = lifeCyclePolicyTableConfig.columns.map(column => ({
+	...column,
+	deactivated: false,
+}));
+
+// Initial state of acls in redux store
+const initialState: LifeCycleState = {
+	status: "uninitialized",
+	error: null,
+	results: [],
+	columns: initialColumns,
+	total: 0,
+	offset: 0,
+	limit: 0,
+};
+
+type FetchLifeCyclePolicies = {
+	total: number,
+	offset: number,
+	limit: number,
+	results: LifeCyclePolicy[]
+}
+
+export const fetchLifeCyclePolicies = createAppAsyncThunk("lifeCycle/fetchLifeCyclePolicies", async (_, { getState }) => {
+	const state = getState();
+	const params = getURLParams(state, "lifeCyclePolicies");
+	const res = await axios.get<FetchLifeCyclePolicies>("/api/lifecyclemanagement/policies", { params: params });
+	return res.data;
+});
+
+export const postNewLifeCyclePolicy = createAppAsyncThunk("lifeCycle/postNewLifeCyclePolicy", async (
+	policy: {
+		actionParameters: { [key: string]: unknown },
+		timing: string,
+		action: string,
+		targetType: string,
+		title: string,
+		isActive: boolean,
+		actionDate: string,
+		cronTrigger: string,
+		targetFilters: { [key: string]: { [key: string]: TargetFilter } },
+		accessControlEntries: TransformedAcl[]
+	},
+	{ dispatch },
+) => {
+	const data = new URLSearchParams();
+
+	// Format filter collections
+	// for (const filterName in policy.targetFilters) {
+	//   // policy.targetFilters[filterName]
+	//   if (hasOwnProperty(TARGET_FILTER_KEYS_EVENTS, filterName)
+	//     && TARGET_FILTER_KEYS_EVENTS[filterName].collection) {
+	//       policy.targetFilters[filterName].value = policy.targetFilters[filterName].value.toString()
+	//   }
+	// }
+
+	// Stringify
+	Object.entries(policy).forEach(([key, value]) => {
+		let stringified = value;
+		if (stringified instanceof Date) {
+			stringified = stringified.toJSON();
+		} else if (stringified === Object(stringified)) {
+			stringified = JSON.stringify(stringified);
+		}
+		// @ts-expect-error: ???
+		data.append(key, stringified);
+	});
+
+	data.delete("accessControlEntries");
+	data.append("accessControlEntries", JSON.stringify(prepareAccessPolicyRulesForPost(policy.accessControlEntries).acl.ace));
+
+	await axios.post("/api/lifecyclemanagement/policies", data)
+		.then(res => {
+			console.info(res);
+			dispatch(addNotification({ type: "success", key: "LIFECYCLE_POLICY_ADDED" }));
+		})
+		.catch(res => {
+			console.error(res);
+			dispatch(addNotification({ type: "error", key: "LIFECYCLE_POLICY_NOT_SAVED" }));
+		});
+});
+
+export const deleteLifeCyclePolicy = createAppAsyncThunk("lifeCycle/fetchLifeCyclePolicies", async (id: string, { dispatch }) => {
+	await axios
+		.delete(`/api/lifecyclemanagement/policies/${id}`)
+		.then(res => {
+			console.info(res);
+			dispatch(addNotification({ type: "success", key: "LIFECYCLE_POLICY_DELETED" }));
+		})
+		.catch(res => {
+			console.error(res);
+			dispatch(addNotification({ type: "error", key: "LIFECYCLE_POLICY_NOT_DELETED" }));
+		});
+});
+
+const lifeCycleSlice = createSlice({
+	name: "lifeCycle",
+	initialState,
+	reducers: {
+		setLifeCycleColumns(state, action: PayloadAction<
+			LifeCycleState["columns"]
+		>) {
+			state.columns = action.payload;
+		},
+	},
+	// These are used for thunks
+	extraReducers: builder => {
+		builder
+			.addCase(fetchLifeCyclePolicies.pending, state => {
+				state.status = "loading";
+			})
+			// Pass the generated action creators to `.addCase()`
+			.addCase(fetchLifeCyclePolicies.fulfilled, (state, action: PayloadAction<{
+				total: LifeCycleState["total"],
+				limit: LifeCycleState["limit"],
+				offset: LifeCycleState["offset"],
+				results: LifeCycleState["results"],
+			}>) => {
+				// Same "mutating" update syntax thanks to Immer
+				state.status = "succeeded";
+				const policies = action.payload;
+				state.total = policies.total;
+				state.limit = policies.limit;
+				state.offset = policies.offset;
+				state.results = policies.results;
+			})
+			.addCase(fetchLifeCyclePolicies.rejected, (state, action) => {
+				state.status = "failed";
+				state.results = [];
+				state.error = action.error;
+			});
+	},
+});
+
+export const { setLifeCycleColumns } = lifeCycleSlice.actions;
+
+// Export the slice reducer as the default export
+export default lifeCycleSlice.reducer;

--- a/src/slices/tableSlice.ts
+++ b/src/slices/tableSlice.ts
@@ -11,6 +11,7 @@ import { ThemeDetailsType } from "./themeSlice";
 import { Series } from "./seriesSlice";
 import { Playlist } from "./playlistSlice";
 import { Event } from "./eventSlice";
+import { LifeCyclePolicy } from "./lifeCycleSlice";
 import { eventsTableConfig } from "../configs/tableConfigs/eventsTableConfig";
 import { seriesTableConfig } from "../configs/tableConfigs/seriesTableConfig";
 import { playlistsTableConfig } from "../configs/tableConfigs/playlistsTableConfig";
@@ -21,6 +22,7 @@ import { servicesTableConfig } from "../configs/tableConfigs/servicesTableConfig
 import { usersTableConfig } from "../configs/tableConfigs/usersTableConfig";
 import { groupsTableConfig } from "../configs/tableConfigs/groupsTableConfig";
 import { themesTableConfig } from "../configs/tableConfigs/themesTableConfig";
+import { lifeCyclePolicyTableConfig } from "../configs/tableConfigs/lifeCyclePoliciesTableConfig";
 import { RootState } from "../store";
 
 /*
@@ -71,11 +73,11 @@ export function isRowSelectable(row: Row) {
 	return false;
 }
 
-export function isEvent(row: Row | Event | Series | Recording | Server | Job | Service | User | Group | AclResult | ThemeDetailsType): row is Event {
+export function isEvent(row: Row | Event | Series | Recording | Server | Job | Service | User | Group | AclResult | ThemeDetailsType | LifeCyclePolicy): row is Event {
 	return (row as Event).event_status !== undefined;
 }
 
-export function isSeries(row: Row | Event | Series | Recording | Server | Job | Service | User | Group | AclResult | ThemeDetailsType): row is Series {
+export function isSeries(row: Row | Event | Series | Recording | Server | Job | Service | User | Group | AclResult | ThemeDetailsType | LifeCyclePolicy): row is Series {
 	return (row as Series).organizers !== undefined;
 }
 
@@ -85,14 +87,14 @@ export type Meh = Event | Series | Recording | Server | Job | Service | User | G
 export type Row = {
 	id: string, // For use with entityAdapter. Directly taken from event/series etc. if available
 	selected: boolean // If the row was marked in the ui by the user
-} & (Event | Series | Playlist | Recording | Server | Job | Service | User | Group | AclResult | ThemeDetailsType)
+} & (Event | Series | Playlist | Recording | Server | Job | Service | User | Group | AclResult | ThemeDetailsType | LifeCyclePolicy)
 
 export type SubmitRow = {
 	selected: boolean
-} & (Event | Series | Playlist | Recording | Server | Job | Service | User | Group | AclResult | ThemeDetailsType)
+} & (Event | Series | Playlist | Recording | Server | Job | Service | User | Group | AclResult | ThemeDetailsType | LifeCyclePolicy)
 
 export type Resource = "events" | "series" | "playlists" | "recordings"
-	| "jobs" | "servers" | "services" | "users" | "groups" | "acls" | "themes";
+	| "jobs" | "servers" | "services" | "users" | "groups" | "acls" | "themes" | "lifeCyclePolicies";
 
 export type ReverseOptions = "ASC" | "DESC" | "NONE"
 
@@ -149,6 +151,7 @@ const initialState: TableState = {
 		groups: groupsTableConfig.multiSelect,
 		acls: aclsTableConfig.multiSelect,
 		themes: themesTableConfig.multiSelect,
+		lifeCyclePolicies: lifeCyclePolicyTableConfig.multiSelect,
 	},
 	resource: "events",
 	pages: [],
@@ -165,6 +168,7 @@ const initialState: TableState = {
 		groups: "name",
 		acls: "name",
 		themes: "name",
+		lifeCyclePolicies: "title",
 	},
 	predicate: "",
 	reverse: {
@@ -179,6 +183,7 @@ const initialState: TableState = {
 		groups: "ASC",
 		acls: "ASC",
 		themes: "ASC",
+		lifeCyclePolicies: "ASC",
 	},
 	rows: rowsAdapter.getInitialState(),
 	maxLabel: "",

--- a/src/slices/workflowSlice.ts
+++ b/src/slices/workflowSlice.ts
@@ -19,7 +19,7 @@ export type FieldSetField = {
 	[key: string]: unknown
 }
 
-type ConfigurationPanelField = {
+export type ConfigurationPanelField = {
 	// We could potentially specify 'fieldset' more, but I cannot find a definition
 	// for which key value pairs are allowed
 	fieldset?: FieldSetField[]  // Values can be anything

--- a/src/store.ts
+++ b/src/store.ts
@@ -7,6 +7,7 @@ import events from "./slices/eventSlice";
 import table from "./slices/tableSlice";
 import series from "./slices/seriesSlice";
 import playlists from "./slices/playlistSlice";
+import lifeCycle from "./slices/lifeCycleSlice";
 import recordings from "./slices/recordingSlice";
 import jobs from "./slices/jobSlice";
 import servers from "./slices/serverSlice";
@@ -20,6 +21,7 @@ import notifications from "./slices/notificationSlice";
 import workflows from "./slices/workflowSlice";
 import eventDetails from "./slices/eventDetailsSlice";
 import seriesDetails from "./slices/seriesDetailsSlice";
+import lifeCyclePolicyDetails from "./slices/lifeCycleDetailsSlice";
 import userDetails from "./slices/userDetailsSlice";
 import recordingDetails from "./slices/recordingDetailsSlice";
 import groupDetails from "./slices/groupDetailsSlice";
@@ -41,6 +43,7 @@ const tableFilterProfilesPersistConfig = { key: "tableFilterProfiles", storage, 
 const eventsPersistConfig = { key: "events", storage, whitelist: ["columns"] };
 const seriesPersistConfig = { key: "series", storage, whitelist: ["columns"] };
 const playlistPersistConfig = { key: "playlists", storage, whitelist: ["columns"] };
+const lifeCyclePersistConfig = { key: "lifeCycle", storage, whitelist: ["columns"] };
 const tablePersistConfig = { key: "table", storage, whitelist: ["pagination", "sortBy", "reverse"] };
 const recordingsPersistConfig = { key: "recordings", storage, whitelist: ["columns"] };
 const jobsPersistConfig = { key: "jobs", storage, whitelist: ["columns"] };
@@ -58,6 +61,7 @@ const reducers = combineReducers({
   events: persistReducer(eventsPersistConfig, events),
   series: persistReducer(seriesPersistConfig, series),
   playlists: persistReducer(playlistPersistConfig, playlists),
+  lifeCycle: persistReducer(lifeCyclePersistConfig, lifeCycle),
   table: persistReducer(tablePersistConfig, table),
   recordings: persistReducer(recordingsPersistConfig, recordings),
   jobs: persistReducer(jobsPersistConfig, jobs),
@@ -72,6 +76,7 @@ const reducers = combineReducers({
   workflows,
   eventDetails,
   playlistDetails,
+  lifeCyclePolicyDetails,
   themeDetails,
   seriesDetails,
   recordingDetails,

--- a/src/thunks/tableThunks.ts
+++ b/src/thunks/tableThunks.ts
@@ -36,6 +36,7 @@ import { setGroupColumns } from "../slices/groupSlice";
 import { fetchAcls, setAclColumns } from "../slices/aclSlice";
 import { AppDispatch, AppThunk, RootState } from "../store";
 import { fetchPlaylists, setPlaylistColumns } from "../slices/playlistSlice";
+import { fetchLifeCyclePolicies, setLifeCycleColumns } from "../slices/lifeCycleSlice";
 
 /**
  * This file contains methods/thunks used to manage the table in the main view and its state changes
@@ -154,6 +155,30 @@ export const loadPlaylistsIntoTable = (): AppThunk => (dispatch, getState) => {
 		pages: pages,
 		sortBy: table.sortBy["playlists"],
 		reverse: table.reverse["playlists"],
+		totalItems: total,
+	};
+
+	dispatch(loadResourceIntoTable(tableData));
+};
+
+export const loadLifeCyclePoliciesIntoTable = (): AppThunk => (dispatch, getState) => {
+	const { lifeCycle, table } = getState();
+	const pagination = table.pagination;
+	const resource = lifeCycle.results;
+	const total = lifeCycle.total;
+
+	const pages = calculatePages(total / pagination.limit, pagination.offset);
+
+	const tableData = {
+		resource: "lifeCyclePolicies" as const,
+		rows: resource.map(obj => {
+			return { ...obj, selected: false };
+		}),
+		columns: lifeCycle.columns,
+		multiSelect: table.multiSelect["lifeCyclePolicies"],
+		pages: pages,
+		sortBy: table.sortBy["lifeCyclePolicies"],
+		reverse: table.reverse["lifeCyclePolicies"],
 		totalItems: total,
 	};
 
@@ -382,6 +407,11 @@ export const goToPage = (pageNumber: number) => async (dispatch: AppDispatch, ge
 			dispatch(loadPlaylistsIntoTable());
 			break;
 		}
+		case "lifeCyclePolicies": {
+			await dispatch(fetchLifeCyclePolicies());
+			dispatch(loadLifeCyclePoliciesIntoTable());
+			break;
+		}
 		case "recordings": {
 			await dispatch(fetchRecordings());
 			dispatch(loadRecordingsIntoTable());
@@ -448,6 +478,11 @@ export const updatePages = () => async (dispatch: AppDispatch, getState: () => R
 		case "series": {
 			await dispatch(fetchSeries());
 			dispatch(loadSeriesIntoTable());
+			break;
+		}
+		case "lifeCyclePolicies": {
+			await dispatch(fetchLifeCyclePolicies());
+			dispatch(loadLifeCyclePoliciesIntoTable());
 			break;
 		}
 		case "recordings": {
@@ -567,6 +602,11 @@ export const changeColumnSelection = (updatedColumns: TableConfig["columns"]) =>
 		case "playlists": {
 			dispatch(setPlaylistColumns(updatedColumns));
 			dispatch(loadPlaylistsIntoTable());
+			break;
+		}
+		case "lifeCyclePolicies": {
+			dispatch(setLifeCycleColumns(updatedColumns));
+			dispatch(loadLifeCyclePoliciesIntoTable());
 			break;
 		}
 		case "recordings": {

--- a/src/utils/dropDownUtils.ts
+++ b/src/utils/dropDownUtils.ts
@@ -19,3 +19,7 @@ export const formatWorkflowsForDropdown = (workflows: Workflow[]) => {
 export const formatAclTemplatesForDropdown = (templates: { id: string, value: string }[]) => {
 	return templates.map(template => ({ label: template.value, value: template.id }));
 };
+
+export const formatPolicyActionsForDropdown = (policieActions: string[]) => {
+	return policieActions.map(action => ({ label: action, value: action }));
+};

--- a/src/utils/lifeCycleUtils.ts
+++ b/src/utils/lifeCycleUtils.ts
@@ -1,0 +1,38 @@
+import { TargetFilter } from "../slices/lifeCycleSlice";
+
+export function parseTargetFiltersForSubmit(
+  transformed: { [key: string]: (TargetFilter & { filter: string })[] },
+): { [key: string]: { [key: string]: TargetFilter } } {
+  const result: { [key: string]: { [key: string]: TargetFilter } } = {};
+
+  for (const outerKey in transformed) {
+    const list = transformed[outerKey];
+    const innerMap: { [key: string]: TargetFilter } = {};
+
+    for (const item of list) {
+      const { filter, ...rest } = item;
+      innerMap[filter] = rest;
+    }
+
+    result[outerKey] = innerMap;
+  }
+
+  return result;
+}
+
+export function parseTargetFiltersForEditing(
+	targetFilters: { [key: string]: { [key: string]: TargetFilter } },
+): { [key: string]: (TargetFilter & { filter: string })[] } {
+	const result: { [key: string]: (TargetFilter & { filter: string })[] } = {};
+
+	for (const outerKey in targetFilters) {
+		const innerMap = targetFilters[outerKey];
+
+		result[outerKey] = Object.entries(innerMap).map(([innerKey, filterObj]) => ({
+			...filterObj,
+			filter: innerKey,
+		}));
+	}
+
+	return result;
+};

--- a/src/utils/validate.ts
+++ b/src/utils/validate.ts
@@ -271,3 +271,96 @@ export const EditGroupSchema = Yup.object().shape({
 export const AdopterRegistrationSchema = Yup.object().shape({
 	email: Yup.string().email(),
 });
+
+/**
+ * Validation Schema used in lifecycle policy modal
+ */
+const filterItemSchema = Yup.object({
+	filter: Yup.string().required("Required"),
+	value: Yup.mixed().required("Required"),
+	type: Yup.string().required("Required"),
+	must: Yup.boolean(),
+});
+
+const targetFiltersSchema = Yup.object()
+	.test(
+		"has-at-least-one-array",
+		"At least one filter group is required",
+		function (obj) {
+			if (!obj || typeof obj !== "object") { return false; }
+			return Object.keys(obj).length > 0;
+		},
+	)
+	.test(
+		"has-at-least-one-item",
+		"At least one filter must be defined",
+		function (obj) {
+			if (!obj || typeof obj !== "object") { return false; }
+
+			let total = 0;
+
+			for (const key of Object.keys(obj)) {
+				const arr = (obj as Record<string, unknown>)[key];
+				if (Array.isArray(arr)) {
+					total += arr.length;
+				}
+			}
+
+			return total > 0;
+		},
+	)
+	.test(
+		"validate-items",
+		"Invalid filter structure",
+		function (obj) {
+			if (!obj || typeof obj !== "object") { return false; }
+
+			for (const key of Object.keys(obj)) {
+				const arr = (obj as Record<string, unknown>)[key];
+
+				if (!Array.isArray(arr)) {
+					return this.createError({
+						message: `Filter "${key}" must be an array`,
+					});
+				}
+
+				for (const item of arr) {
+					try {
+						filterItemSchema.validateSync(item);
+					} catch (err) {
+						return this.createError({ message: (err as Error).message });
+					}
+				}
+			}
+
+			return true;
+		},
+	);
+
+export const LifeCyclePolicySchema = [
+	Yup.object().shape({
+		title: Yup.string().required("Required"),
+		isActive: Yup.bool().required("Required"),
+		targetType: Yup.string().required("Required"),
+		timing: Yup.string().required("Required"),
+		action: Yup.string().required("Required"),
+		actionParameters: Yup.object().shape({
+			// Property only required if it actually exists on the object
+			workflowId: Yup.string().required("Required"),
+			// workflowId: Yup.string().when("workflowId", {
+			//  is: (exists: any) => !!exists,
+			//  then: Yup.string().required("Required"),
+			// }),
+		}),
+		actionDate: Yup.date().when("timing", {
+			is: (timing: string) => timing === "SPECIFIC_DATE",
+			then: () => Yup.date().required("Required"),
+		}),
+		cronTrigger: Yup.string().when("timing", {
+			is: (timing: string) => timing === "REPEATING",
+			then: () => Yup.string().required("Required"),
+		}),
+		targetFiltersTransformed: targetFiltersSchema,
+	}),
+];
+


### PR DESCRIPTION
*Originally #1004.*

*The old PR for lifecycle policies was old, had many commits and many merges. Creating a squashed commit seemed like the simplest option to bring lifecycle policies from the old history to the new history.*

Instead of only being able to view lifecycle policies, this commit lets you edit them, create new ones and even delete them. 

Depends on changes to the backend: https://github.com/opencast/opencast/pull/6139. These changes are currently pointed at develop.

To test this, you'll need an Opencast with backend changes mentioned above.

Demonstration:
[Bildschirmaufzeichnung vom 2024-12-04 10-45-28.webm](https://github.com/user-attachments/assets/ab48f8cb-6d4c-47aa-b3b5-3ee466676c60)
