### PR TITLE
Fix npm variables in pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
             <artifactId>exec-maven-plugin</artifactId>
             <configuration>
               <environmentVariables>
-                <PUBLIC_PATH>/admin-ui</PUBLIC_PATH>
+                <PUBLIC_URL>/admin-ui</PUBLIC_URL>
               </environmentVariables>
             </configuration>
             <executions>
@@ -84,7 +84,7 @@
               <nodeVersion>${nodejs.version}</nodeVersion>
               <installDirectory>target</installDirectory>
               <environmentVariables>
-                <PUBLIC_PATH>/admin-ui</PUBLIC_PATH>
+                <PUBLIC_URL>/admin-ui</PUBLIC_URL>
               </environmentVariables>
             </configuration>
             <executions>


### PR DESCRIPTION
This PR resolves an issue in the pom file where we were using the studio's node variables, which don't match the admin's.
