### PR TITLE
Correct module version information

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   </properties>
   <profiles>
     <profile>
-      <id>frontend-no-prebuild</id>
+      <id>frontend-no-prebuilt</id>
       <properties>
         <ui.include.resource>/admin-ui=-build/</ui.include.resource>
       </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,26 @@
               </execution>
             </executions>
           </plugin>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>buildnumber-maven-plugin</artifactId>
+            <version>3.3.0</version>
+            <executions>
+              <execution>
+                <phase>validate</phase>
+                <goals>
+                  <goal>create</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <doCheck>true</doCheck>
+              <doUpdate>false</doUpdate>
+              <failTheBuild>false</failTheBuild>
+              <shortRevisionLength>7</shortRevisionLength>
+              <buildNumberPropertyName>submoduleHash</buildNumberPropertyName>
+            </configuration>
+          </plugin>
         </plugins>
       </build>
     </profile>
@@ -131,6 +151,26 @@
               </filesets>
             </configuration>
           </plugin>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>buildnumber-maven-plugin</artifactId>
+            <version>3.3.0</version>
+            <executions>
+              <execution>
+                <phase>validate</phase>
+                <goals>
+                  <goal>create</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <doCheck>true</doCheck>
+              <doUpdate>false</doUpdate>
+              <failTheBuild>false</failTheBuild>
+              <shortRevisionLength>7</shortRevisionLength>
+              <buildNumberPropertyName>submoduleHash</buildNumberPropertyName>
+            </configuration>
+          </plugin>
         </plugins>
       </build>
     </profile>
@@ -148,7 +188,18 @@
         <configuration>
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+            <!-- NOTE: This property is defined in the parent/main pom, at runtime.
+                 Building this module directly will leave this blank and thus it will be omitted from the built jar.
+                 Look up building specific maven project (-pl) if you need to build this module and care about this.
+             -->
             <Build-Number>${buildNumber}</Build-Number>
+            <Submodule-Hash>${submoduleHash}</Submodule-Hash>
+            <!-- NOTE: This flag is showing if there are any un-committed modifications in the submodule.
+                 It does *not* check to see if you have modified the submodule relative to the branch.
+                 Adopters modifying their local forks should expect that this reads false.
+                 Developers modifying their local copies for testing should expect this could read true.
+            -->
+            <Submodule-Tainted>${buildIsTainted}</Submodule-Tainted>
             <Include-Resource>${ui.include.resource}</Include-Resource>
             <Private-Package>admin-ui.*</Private-Package>
             <Http-Alias>/admin-ui</Http-Alias>


### PR DESCRIPTION
This PR adds a new, submodule specific buildnumer and taint status to the built artifact's pom. This is important because otherwise the buildnumber for the submodule(s) does not match the parent pom's, yielding a Opencast – built on unknown at the bottom of the admin UI. This change uses the parent's buildnumber value in place of the module's normal one, moving the module's into a different field. Note that building the module directly from inside modules/admin does not yield the correct buildnumber, instead omitting the value entirely. This is because the child module cannot know the parent's hash. If you as a developer want to have the correct data when building locally, look into maven's -pl flag.

This comit also fixes a typo related to build profiles.
