### PR TITLE
Show again that there are open comments

### DIFF
--- a/src/components/events/partials/EventActionCell.tsx
+++ b/src/components/events/partials/EventActionCell.tsx
@@ -17,7 +17,7 @@ import { openModal } from "../../../slices/eventDetailsSlice";
 import { ActionCellDelete } from "../../shared/ActionCellDelete";
 import { Modal, ModalHandle } from "../../shared/modals/Modal";
 import ButtonLikeAnchor from "../../shared/ButtonLikeAnchor";
-import { LuFileSymlink, LuFileText, LuFolderOpen, LuLink, LuMessageCircle, LuScissors, LuTriangleAlert } from "react-icons/lu";
+import { LuFileSymlink, LuFileText, LuFolderOpen, LuLink, LuMessageCircle, LuMessageCircleWarning, LuScissors, LuTriangleAlert } from "react-icons/lu";
 import { SeriesDetailsPage } from "./modals/SeriesDetails";
 
 /**
@@ -148,7 +148,7 @@ const EventActionCell = ({
 					// tooltipText={"EVENTS.EVENTS.TABLE.TOOLTIP.COMMENTS"} // Disabled due to performance concerns
 					className={"action-cell-button comments-open"}
 				>
-					<LuMessageCircle className="blue"/>
+					<LuMessageCircleWarning className="blue"/>
 				</ButtonLikeAnchor>
 			)}
 


### PR DESCRIPTION
Fixes #1544.

In the events table, a "comment" icon is displayed for events with comments. Before we switched to lucide icons, there were two different comment icons, depending on if the event still had unresolved comments or not. This behaviour was lost.

This patch brings the behaviour back. If there are still unresolved comments, the speech bubble icon now has an exclamation point in it.

Why not a filled icon like before? Because lucide does not have that.

### How to test this

Can be tested as is. Add comments to an event in the event details, then watch the icons on the right in the events table.