### PR TITLE
Fixes start date not showing on create event

### DIFF
--- a/src/components/events/partials/ModalTabsAndPages/NewSourcePage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewSourcePage.tsx
@@ -353,7 +353,7 @@ const Upload = <T extends RequiredFormPropsUpload>({
 									</td>
 									<td className="editable">
 										<Field
-											name={field.id}
+											name={"metadata" + "." + field.id}
 											metadataField={field}
 											component={RenderField}
 										/>


### PR DESCRIPTION
When creating an event, the start date would not show on the source upload page. This patch fixes that.

### How to test this

Can be tested as is.