### PR TITLE
Always sort asc first for new column

### DIFF
--- a/src/components/shared/Table.tsx
+++ b/src/components/shared/Table.tsx
@@ -222,10 +222,14 @@ const TableHeadRows = ({ forceDeselectAll }: { forceDeselectAll: () => unknown }
 		forceDeselectAll();
 		dispatch(setSortBy(colName));
 		let direction: ReverseOptions = "ASC";
-		if (reverse && reverse === "ASC") {
-			direction = "DESC";
-		} else if (reverse && reverse === "DESC") {
-			direction = "NONE";
+		if (sortBy !== colName) {
+			direction = "ASC";
+		} else {
+			if (reverse && reverse === "ASC") {
+				direction = "DESC";
+			} else if (reverse && reverse === "DESC") {
+				direction = "NONE";
+			}
 		}
 		dispatch(reverseTable(direction));
 		dispatch(updatePages());


### PR DESCRIPTION
When sorting by a different column than before (e.g. by title instead of date), the sorting will now always be ascending first. Then on subsequent clicks on the same column you get descending and none. The goal for this patchis to improve the user experience through more intuitive behaviour.

### How to test this

Can be tested as is. You can sort a table by a specific column by clicking on the column head.