### PR TITLE
Fix warning wrongly appearing on template change

### DIFF
--- a/src/utils/aclUtils.ts
+++ b/src/utils/aclUtils.ts
@@ -102,6 +102,5 @@ export const handleTemplateChange = async <T extends { policies: TransformedAcl[
 
 	formik.setFieldValue("policies", template.acl);
 	formik.setFieldValue("aclTemplate", templateId);
-	// Is this necessary?
-	dispatch(checkAcls(formik.values.policies));
+	dispatch(checkAcls(template.acl));
 };


### PR DESCRIPTION
When changing the template in the acl tab, if the current acl settings were invalid, a warning would appear *after* the template change about how the acl was invalid, when due to the template change it actually no longer wasn't.
This fixes that.

### How to test this

Get your ACL to be invalid (by removing all roles, or by adding a new role and not selecting a role in the dropdown). Then change template.