### PR TITLE
Move to node 24 in gh workflows

### DIFF
--- a/.github/workflows/deploy-main-branches.yml
+++ b/.github/workflows/deploy-main-branches.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Get Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Run npm ci
         run: npm ci

--- a/.github/workflows/pr-deploy-test-branch.yml
+++ b/.github/workflows/pr-deploy-test-branch.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Get Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Run npm ci
         run: npm ci

--- a/.github/workflows/pr-test-build.yml
+++ b/.github/workflows/pr-test-build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Get Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Run npm ci
         run: npm ci


### PR DESCRIPTION
The maintenance window for node 20 is running out, we should probably update.