### PR TITLE
Remove @types/uuid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,6 @@
         "@types/lodash": "^4.17.23",
         "@types/node": "^25.3.0",
         "@types/react-dom": "^19.2.3",
-        "@types/uuid": "^11.0.0",
         "@vitejs/plugin-react": "^6.0.1",
         "eslint": "^9.39.2",
         "prop-types": "^15.8.1",
@@ -1742,17 +1741,6 @@
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
-    },
-    "node_modules/@types/uuid": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-11.0.0.tgz",
-      "integrity": "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA==",
-      "deprecated": "This is a stub types definition. uuid provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "uuid": "*"
-      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.58.2",
@@ -3968,6 +3956,9 @@
         }
       ],
       "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4"
+      },
       "peerDependencies": {
         "typescript": "^5 || ^6"
       },

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "@types/lodash": "^4.17.23",
     "@types/node": "^25.3.0",
     "@types/react-dom": "^19.2.3",
-    "@types/uuid": "^11.0.0",
     "@vitejs/plugin-react": "^6.0.1",
     "eslint": "^9.39.2",
     "prop-types": "^15.8.1",


### PR DESCRIPTION
Type definitions are now included within uuid, so there is no need anymore for an extra type
package