### PR TITLE
Fix Imprint/Privacy page breaking the app

### DIFF
--- a/src/components/shared/MainNav.tsx
+++ b/src/components/shared/MainNav.tsx
@@ -174,14 +174,18 @@ const MainNav = ({
 	// current view is always the first element. Otherwise, NavLink will not
 	// recognize the current view as active.
 	if (firstPathFragment.length > 0) {
-		const arrToSort = linkMap[firstPathFragment as keyof typeof linkMap].links;
-		if (arrToSort != undefined && arrToSort.length > 1) {
-			arrToSort.forEach(item => {
+		const linkMapItem = linkMap[firstPathFragment as keyof typeof linkMap];
+
+		if (linkMapItem?.links && linkMapItem.links.length > 1) {
+			const arrToSort = linkMapItem.links;
+			if (arrToSort != undefined && arrToSort.length > 1) {
+				arrToSort.forEach(item => {
+					// @ts-expect-error: TODO: Someone else can fix this
+					if (item.path === pathname) { item.tmpIndex = 0; } else { item.tmpIndex = 1; }
+				});
 				// @ts-expect-error: TODO: Someone else can fix this
-				if (item.path === pathname) { item.tmpIndex = 0; } else { item.tmpIndex = 1; }
-			});
-			// @ts-expect-error: TODO: Someone else can fix this
-			arrToSort.sort((a, b) => a.tmpIndex - b.tmpIndex);
+				arrToSort.sort((a, b) => a.tmpIndex - b.tmpIndex);
+			}
 		}
 	}
 


### PR DESCRIPTION
Opening one of the two about pages would crash the admin ui. This should fix that.

### How to test this

The about pages need to be enabled in Opencast https://github.com/opencast/opencast/blob/b5e66efac8dd8d182eecab302879d41d24e55d1c/etc/org.opencastproject.organization-mh_default_org.cfg#L139. After enabling them, you should find links to them in the footer.