### PR TITLE
Fix typo for cancelled wf processes

### DIFF
--- a/src/utils/bulkActionUtils.ts
+++ b/src/utils/bulkActionUtils.ts
@@ -117,7 +117,7 @@ export const isStartable = (event: Event) => {
 	return (
 		event.event_status.toUpperCase().indexOf("PROCESSED") > -1 ||
 		event.event_status.toUpperCase().indexOf("PROCESSING_FAILURE") > -1 ||
-		event.event_status.toUpperCase().indexOf("PROCESSING_CANCELED") > -1 ||
+		event.event_status.toUpperCase().indexOf("PROCESSING_CANCELLED") > -1 ||
 		!event.selected
 	);
 };


### PR DESCRIPTION
Currently after cancelling a WF you can't restart it through the admin-ui, because its state is in `PROCESSING_CANCELLED` while the code checks for `PROCESSING_CANCELED` .  (one vs two 'L' )

This PR fixes the mismatched check. 