### PR TITLE
Fix datetime-local field for workflow config

### DIFF
--- a/src/utils/workflowPanelUtils.ts
+++ b/src/utils/workflowPanelUtils.ts
@@ -38,8 +38,7 @@ const fillDefaultConfig = (
       defaultConfiguration[field.name] = field.value;
     } else if (field.type === "datetime-local") {
       const date = new Date(new Date().toString().split("GMT")[0] + " UTC").toISOString().split(".")[0];
-      defaultConfiguration[field.name] = date;
-      field.defaultValue = date;
+      defaultConfiguration[field.name] = field.value ? field.value : date;
     // set value in default configuration
     } else {
       defaultConfiguration[field.name] = field.value;


### PR DESCRIPTION
Fixes  #1613

datetime-local fields in workflow config panels would not render, this patch fixes that.
It also fixes a bug where the specified value for the field would be ignored.


### How to test this

A workflow config panel can be found for example in the create event dialog.

You'll need to be able to change workflow definitions in the Opencast backend. For example, you could add the following to the `configuration_panel_json` of the `schedule-and-upload` workflow.

```
      {
        "type": "datetime-local",
        "name": "MyDate",
        "label": "This is a date",
        "value": "2026-07-01T12:12:12"
      }
```