### PR TITLE
Enable writing to ghcr from pull requests

### DIFF
--- a/.github/workflows/pr-build-container-image.yml
+++ b/.github/workflows/pr-build-container-image.yml
@@ -25,7 +25,6 @@ jobs:
       - name: Build and push images
         uses: docker/build-push-action@v6
         with:
-          context: .
           push: false # This is handled in another workflow!
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/pr-build-container-image.yml
+++ b/.github/workflows/pr-build-container-image.yml
@@ -1,0 +1,35 @@
+name: PRs » Build container image
+
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+  pull_request:
+    types:
+      - opened
+      - synchronize
+
+jobs:
+  container-image-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+
+      - name: Build and push images
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false # This is handled in another workflow!
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=docker,dest=${{ runner.temp }}/build.tar
+
+      - name: Upload docker image to GHA
+        uses: actions/upload-artifact@v4
+        with:
+          name: build
+          path: ${{ runner.temp }}/build.tar

--- a/.github/workflows/pr-build-container-image.yml
+++ b/.github/workflows/pr-build-container-image.yml
@@ -19,6 +19,9 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push images
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/pr-deploy-container-image.yml
+++ b/.github/workflows/pr-deploy-container-image.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.SUBMODULE_PR_DOCKER_WRITE }}
 
       - name: Extract metadata (tags, labels)
         id: meta
@@ -42,6 +42,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          github-token: ${{ secrets.SUBMODULE_PR_DOCKER_WRITE }}
 
       - name: Add comment
         if: github.event_name == 'pull_request'

--- a/.github/workflows/pr-deploy-container-image.yml
+++ b/.github/workflows/pr-deploy-container-image.yml
@@ -26,7 +26,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: opencastproject
           password: ${{ secrets.SUBMODULE_PR_DOCKER_WRITE }}
 
       - name: Extract metadata (tags, labels)

--- a/.github/workflows/pr-deploy-container-image.yml
+++ b/.github/workflows/pr-deploy-container-image.yml
@@ -1,33 +1,25 @@
-name: PRs » Publish container image
+name: PRs » Push container image
 
 on:
-  push:
-    branches-ignore:
-      - 'dependabot/**'
-  pull_request:
+  workflow_run:
+    workflows: ["PRs » Build container image"]
     types:
-      - opened
-      - synchronize
+      - completed
 
 jobs:
-  container-image:
+  container-image-deploy:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v5
-
-      - name: Prepare commit hash
-        run: git rev-parse HEAD > commit
-
       - name: Log in to the container registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: opencastproject
-          password: ${{ secrets.SUBMODULE_PR_DOCKER_WRITE }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels)
         id: meta
@@ -35,14 +27,17 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
 
-      - name: Build and push images
-        uses: docker/build-push-action@v6
+      - name: Download docker image from GHA
+        uses: actions/download-artifact@v4
         with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          github-token: ${{ secrets.SUBMODULE_PR_DOCKER_WRITE }}
+          name: build
+          path: ${{ runner.temp }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Load image
+        run: |
+          docker load --input ${{ runner.temp }}/build.tar
+          docker push ghcr.io/${{ github.repository }}
 
       - name: Add comment
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
This PR hopefully fixes test container image workflow's current failures.  Previously, this workflow used `pull_request_target`, which has additional, but unsafe, permissions in GHA.  We recently swapped to `pull_request`, which does *not* have permission to write to ghcr, despite adding `packages: write` to the workflow.  Those permissions would work correctly, but *only for PRs originating from the same repository*.

Instead we have defined a custom secret which does have said permissions, and this PR now makes use of that secret.
