### PR TITLE
Fix use of NODE_VERSION variable

### DIFF
--- a/.github/workflows/deploy-main-branches.yml
+++ b/.github/workflows/deploy-main-branches.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Get Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: $NODE_VERSION
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Run npm ci
         run: npm ci

--- a/.github/workflows/pr-build-test-branch.yml
+++ b/.github/workflows/pr-build-test-branch.yml
@@ -10,6 +10,9 @@ concurrency:
   group: pull-request-page
   cancel-in-progress: false
 
+env:
+  NODE_VERSION: 24
+
 jobs:
   detect-repo-owner:
     if: github.repository_owner == 'opencast'
@@ -47,7 +50,7 @@ jobs:
       - name: Get Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Run npm ci
         run: npm ci

--- a/.github/workflows/pr-test-build.yml
+++ b/.github/workflows/pr-test-build.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Get Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: $NODE_VERSION
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Run npm ci
         run: npm ci


### PR DESCRIPTION
This PR resolves an issue where the GHA scripts were unable to find a value for `$NODE_VERSION` when installing Node because I was using the variable as a bash shell variable, rather than a GHA templating subtitution.  This PR swaps that, so now the builds run.

We haven't been noticing this because this only affects PRS based off the current tip of `develop`.
