### PR TITLE
Improve npm checks

### DIFF
--- a/.github/workflows/pr-test-build.yml
+++ b/.github/workflows/pr-test-build.yml
@@ -26,7 +26,7 @@ jobs:
           || (echo "Node version does not match.  Expected $NODE_VERSION, found $FOUND_VERSION"; exit 1)
 
       - name: Ensure our node version matches the main repo's version for push events
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && (startsWith("r/", github.ref_name) || "develop" == github.ref_name)
         run: |
           curl -s https://raw.githubusercontent.com/opencast/opencast/refs/heads/${{ github.ref_name }}/pom.xml -o pom.xml
           export FOUND_VERSION="$(grep node.version pom.xml | grep -Eo 'v[0-9.]+' | cut -f 1 -d '.' | cut -c 2-)"

--- a/.github/workflows/pr-test-build.yml
+++ b/.github/workflows/pr-test-build.yml
@@ -16,20 +16,23 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v5
 
-      - name: Ensure our node version matches the main repo's version
+      - name: Ensure our node version matches the main repo's version for pull requests
         if: github.event_name == 'pull_request'
         run: |
-          [[ "$(curl -s https://raw.githubusercontent.com/opencast/opencast/refs/heads/${{ github.base_ref }}/pom.xml | \
-              grep node.version | grep -Eo 'v[0-9.]+' | cut -f 1 -d '.' | cut -c 2-)" == "$NODE_VERSION" ]] \
+          curl -s https://raw.githubusercontent.com/opencast/opencast/refs/heads/${{ github.base_ref }}/pom.xml -o pom.xml
+          export FOUND_VERSION="$(grep node.version pom.xml | grep -Eo 'v[0-9.]+' | cut -f 1 -d '.' | cut -c 2-)"
+          [[ "$FOUND_VERSION" == "$NODE_VERSION" ]] \
           && exit 0 \
-          || (echo "Node version does not match"; exit 1)
-      - name: Ensure our node version matches the main repo's version
+          || (echo "Node version does not match.  Expected $NODE_VERSION, found $FOUND_VERSION"; exit 1)
+
+      - name: Ensure our node version matches the main repo's version for push events
         if: github.event_name == 'push'
         run: |
-          [[ "$(curl -s https://raw.githubusercontent.com/opencast/opencast/refs/heads/${{ github.ref_name }}/pom.xml | \
-              grep node.version | grep -Eo 'v[0-9.]+' | cut -f 1 -d '.' | cut -c 2-)" == "$NODE_VERSION" ]] \
+          curl -s https://raw.githubusercontent.com/opencast/opencast/refs/heads/${{ github.ref_name }}/pom.xml -o pom.xml
+          export FOUND_VERSION="$(grep node.version pom.xml | grep -Eo 'v[0-9.]+' | cut -f 1 -d '.' | cut -c 2-)"
+          [[ "$FOUND_VERSION" == "$NODE_VERSION" ]] \
           && exit 0 \
-          || (echo "Node version does not match"; exit 1)
+          || (echo "Node version does not match.  Expected $NODE_VERSION, found $FOUND_VERSION"; exit 1)
 
       - name: Get Node.js
         uses: actions/setup-node@v5


### PR DESCRIPTION
This PR:

- Improves the logging in cases where the PR/branch's node version does not match the upstream version expected
- Only run the checks on PRs, or pushes to branches matching `r/`, or `develop`.  Otherwise if you push to `dependabot/my_dep`, we see a failure because that branch doesn't exist in `opencast/opencast`
