### PR TITLE
Make "Create User" dialog similar to other create dialogs

### DIFF
--- a/src/components/users/partials/wizard/EditUserGeneralTab.tsx
+++ b/src/components/users/partials/wizard/EditUserGeneralTab.tsx
@@ -4,6 +4,7 @@ import { Field } from "../../../shared/Field";
 import { FormikProps } from "formik";
 import { NotificationComponent } from "../../../shared/Notifications";
 import ModalContent from "../../../shared/modals/ModalContent";
+import { PasswordStrengthIndicator } from "./NewUserGeneralTab";
 
 /**
  * This component renders the general user information tab in the users details modal.
@@ -105,6 +106,9 @@ const EditUserGeneralTab = <T extends RequiredFormProps>({
 						}
 					/>
 				</div>
+					<PasswordStrengthIndicator
+						password={formik.values.password}
+					/>
 			</div>
 		</ModalContent>
 	);

--- a/src/components/users/partials/wizard/NewUserGeneralTab.tsx
+++ b/src/components/users/partials/wizard/NewUserGeneralTab.tsx
@@ -125,7 +125,7 @@ const NewUserGeneralTab = <T extends RequiredFormProps>({
 	);
 };
 
-const PasswordStrengthIndicator = ({
+export const PasswordStrengthIndicator = ({
 	password,
 }: {
 	password: string

--- a/src/components/users/partials/wizard/NewUserGeneralTab.tsx
+++ b/src/components/users/partials/wizard/NewUserGeneralTab.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import cn from "classnames";
 import ModalContent from "../../../shared/modals/ModalContent";
 import { ParseKeys } from "i18next";
+import WizardNavigationButtons from "../../../shared/wizard/WizardNavigationButtons";
 
 /**
  * This component renders the general user information tab for new users in the new users wizard.
@@ -19,96 +20,108 @@ interface RequiredFormProps {
 
 const NewUserGeneralTab = <T extends RequiredFormProps>({
 	formik,
+	nextPage,
 }: {
 	formik: FormikProps<T>
+	nextPage: (values: T) => void,
 }) => {
 	const { t } = useTranslation();
 
 	return (
-		<ModalContent>
-			<div className="form-container">
-				<Notifications context={"other"}/>
-				{/* Fields for user information needed */}
-				<div className="row">
-					<label>
-						{t("USERS.USERS.DETAILS.FORM.USERNAME")}
-						<i className="required">*</i>
-					</label>
-					<Field
-						type="text"
-						name="username"
-						autoFocus
-						className={cn({
-							error: formik.touched.username && formik.errors.username,
-						})}
-						placeholder={t("USERS.USERS.DETAILS.FORM.USERNAME") + "..."}
+		<>
+			<ModalContent>
+				<div className="form-container">
+					<Notifications context={"other"}/>
+					{/* Fields for user information needed */}
+					<div className="row">
+						<label>
+							{t("USERS.USERS.DETAILS.FORM.USERNAME")}
+							<i className="required">*</i>
+						</label>
+						<Field
+							type="text"
+							name="username"
+							autoFocus
+							className={cn({
+								error: formik.touched.username && formik.errors.username,
+							})}
+							placeholder={t("USERS.USERS.DETAILS.FORM.USERNAME") + "..."}
+						/>
+					</div>
+					<div className="row">
+						<label>
+							{t("USERS.USERS.DETAILS.FORM.NAME")}
+							<i className="required">*</i>
+						</label>
+						<Field
+							type="text"
+							name="name"
+							className={cn({
+								error: formik.touched.name && formik.errors.name,
+							})}
+							placeholder={t("USERS.USERS.DETAILS.FORM.NAME") + "..."}
+						/>
+					</div>
+					<div className="row">
+						<label>
+							{t("USERS.USERS.DETAILS.FORM.EMAIL")}
+							<i className="required">*</i>
+						</label>
+						<Field
+							type="text"
+							name="email"
+							className={cn({
+								error: formik.touched.email && formik.errors.email,
+							})}
+							placeholder={t("USERS.USERS.DETAILS.FORM.EMAIL") + "..."}
+						/>
+					</div>
+					<div className="row">
+						<label>
+							{t("USERS.USERS.DETAILS.FORM.PASSWORD")}
+							<i className="required">*</i>
+						</label>
+						<Field
+							type="password"
+							name="password"
+							className={cn({
+								error: formik.touched.password && formik.errors.password,
+							})}
+							placeholder={t("USERS.USERS.DETAILS.FORM.PASSWORD") + "..."}
+						/>
+					</div>
+					<div className="row">
+						<label>
+							{t("USERS.USERS.DETAILS.FORM.REPEAT_PASSWORD")}
+							<i className="required">*</i>
+						</label>
+						<Field
+							type="password"
+							name="passwordConfirmation"
+							className={cn({
+								error:
+									formik.touched.passwordConfirmation &&
+									formik.errors.passwordConfirmation,
+							})}
+							placeholder={
+								t("USERS.USERS.DETAILS.FORM.REPEAT_PASSWORD") + "..."
+							}
+						/>
+					</div>
+					<PasswordStrengthIndicator
+						password={formik.values.password}
 					/>
 				</div>
-				<div className="row">
-					<label>
-						{t("USERS.USERS.DETAILS.FORM.NAME")}
-						<i className="required">*</i>
-					</label>
-					<Field
-						type="text"
-						name="name"
-						className={cn({
-							error: formik.touched.name && formik.errors.name,
-						})}
-						placeholder={t("USERS.USERS.DETAILS.FORM.NAME") + "..."}
-					/>
-				</div>
-				<div className="row">
-					<label>
-						{t("USERS.USERS.DETAILS.FORM.EMAIL")}
-						<i className="required">*</i>
-					</label>
-					<Field
-						type="text"
-						name="email"
-						className={cn({
-							error: formik.touched.email && formik.errors.email,
-						})}
-						placeholder={t("USERS.USERS.DETAILS.FORM.EMAIL") + "..."}
-					/>
-				</div>
-				<div className="row">
-					<label>
-						{t("USERS.USERS.DETAILS.FORM.PASSWORD")}
-						<i className="required">*</i>
-					</label>
-					<Field
-						type="password"
-						name="password"
-						className={cn({
-							error: formik.touched.password && formik.errors.password,
-						})}
-						placeholder={t("USERS.USERS.DETAILS.FORM.PASSWORD") + "..."}
-					/>
-				</div>
-				<div className="row">
-					<label>
-						{t("USERS.USERS.DETAILS.FORM.REPEAT_PASSWORD")}
-						<i className="required">*</i>
-					</label>
-					<Field
-						type="password"
-						name="passwordConfirmation"
-						className={cn({
-							error:
-								formik.touched.passwordConfirmation &&
-								formik.errors.passwordConfirmation,
-						})}
-						placeholder={
-							t("USERS.USERS.DETAILS.FORM.REPEAT_PASSWORD") + "..."
-						}
-					/>
-				</div>
-				<PasswordStrengthIndicator
-					password={formik.values.password}
-				/>
-			</div>
-		</ModalContent>
+
+			</ModalContent>
+			{/* Navigation buttons */}
+			<WizardNavigationButtons
+				isFirst
+				formik={formik}
+				nextPage={nextPage}
+				cancelTranslationString={"CANCEL"}
+			/>
+		</>
 	);
 };
 

--- a/src/components/users/partials/wizard/NewUserSummaryPage.tsx
+++ b/src/components/users/partials/wizard/NewUserSummaryPage.tsx
@@ -1,0 +1,62 @@
+import WizardNavigationButtons from "../../../shared/wizard/WizardNavigationButtons";
+import { useTranslation } from "react-i18next";
+import Notifications from "../../../shared/Notifications";
+import { FormikProps } from "formik";
+import { initialFormValuesNewUser } from "../../../../configs/modalConfig";
+import ModalContentTable from "../../../shared/modals/ModalContentTable";
+
+/**
+ * This component renders the summary page for new groups in the new group wizard.
+ */
+const NewUserSummaryPage = <T extends typeof initialFormValuesNewUser>({
+  formik,
+  previousPage,
+}: {
+  formik: FormikProps<T>,
+  previousPage?: (values: T) => void,
+}) => {
+  const { t } = useTranslation();
+
+  // get values of objects in field that should be shown
+  const getValues = (fields: { name: string }[]) => {
+    const names = [];
+    for (const field of fields) {
+      names.push(field.name);
+    }
+    return names;
+  };
+
+  return (
+    <>
+      <ModalContentTable>
+        <Notifications context={"other"}/>
+
+        <div className="obj">
+          <header>{t("USERS.USERS.DETAILS.TABS.SUMMARY")}</header>
+          <div className="obj-container">
+            <table className="main-tbl">
+              <tbody>
+                <tr>
+                  <td>{t("USERS.USERS.DETAILS.TABS.USER")}</td>
+                  <td>{formik.values.name}</td>
+                </tr>
+                <tr>
+                  <td>{t("USERS.USERS.DETAILS.TABS.ROLES")}</td>
+                  <td>{getValues(formik.values.roles).join(", ")}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </ModalContentTable>
+      {/* Button for navigation to next page */}
+      <WizardNavigationButtons
+        isLast
+        previousPage={previousPage}
+        formik={formik}
+      />
+    </>
+  );
+};
+
+export default NewUserSummaryPage;

--- a/src/components/users/partials/wizard/NewUserWizard.tsx
+++ b/src/components/users/partials/wizard/NewUserWizard.tsx
@@ -1,7 +1,4 @@
-import { useState } from "react";
 import { Formik } from "formik";
-import { useTranslation } from "react-i18next";
-import cn from "classnames";
 import NewUserGeneralTab from "./NewUserGeneralTab";
 import UserRolesTab from "./UserRolesTab";
 import { initialFormValuesNewUser } from "../../../../configs/modalConfig";
@@ -9,9 +6,10 @@ import { getUsernames } from "../../../../selectors/userSelectors";
 import { NewUserSchema } from "../../../../utils/validate";
 import { NewUser, postNewUser, UserRole } from "../../../../slices/userSlice";
 import { useAppDispatch, useAppSelector } from "../../../../store";
-import ButtonLikeAnchor from "../../../shared/ButtonLikeAnchor";
-import WizardNavigationButtons from "../../../shared/wizard/WizardNavigationButtons";
 import { Role } from "../../../../slices/aclSlice";
+import WizardStepper, { WizardStep } from "../../../shared/wizard/WizardStepper";
+import { usePageFunctions } from "../../../../hooks/wizardHooks";
+import NewUserSummaryPage from "./NewUserSummaryPage";
 
 /**
  * This component renders the new user wizard
@@ -21,16 +19,39 @@ const NewUserWizard = ({
 }: {
 	close: () => void,
 }) => {
-	const { t } = useTranslation();
 	const dispatch = useAppDispatch();
 
 	const usernames = useAppSelector(state => getUsernames(state));
 
-	const [tab, setTab] = useState(0);
+	const {
+		page,
+		nextPage,
+		previousPage,
+		setPage,
+		pageCompleted,
+		setPageCompleted,
+	} = usePageFunctions(0);
 
-	const openTab = (tabNr: number) => {
-		setTab(tabNr);
-	};
+	type StepName = "metadata" | "roles" | "summary";
+	type Step = WizardStep & {
+		name: StepName,
+	}
+
+	// Caption of steps used by Stepper
+	const steps: Step[] = [
+		{
+			translation: "USERS.USERS.DETAILS.TABS.USER",
+			name: "metadata",
+		},
+		{
+			translation: "USERS.USERS.DETAILS.TABS.ROLES",
+			name: "roles",
+		},
+		{
+			translation: "USERS.USERS.DETAILS.TABS.SUMMARY",
+			name: "summary",
+		},
+	];
 
 	const handleSubmit = (values: {
 			username: string,
@@ -54,23 +75,6 @@ const NewUserWizard = ({
 
 	return (
 		<>
-			{/* Head navigation*/}
-			<nav className="modal-nav">
-				<ButtonLikeAnchor
-					className={cn("wider", { active: tab === 0 })}
-					onClick={() => openTab(0)}
-				>
-					{t("USERS.USERS.DETAILS.TABS.USER")}
-				</ButtonLikeAnchor>
-				<ButtonLikeAnchor
-					className={cn("wider", { active: tab === 1 })}
-					onClick={() => openTab(1)}
-					tooltipText="USERS.USERS.DETAILS.DESCRIPTION.ROLES"
-				>
-					{t("USERS.USERS.DETAILS.TABS.ROLES")}
-				</ButtonLikeAnchor>
-			</nav>
-
 			{/* Initialize overall form */}
 			<Formik
 				initialValues={initialFormValuesNewUser}
@@ -81,17 +85,33 @@ const NewUserWizard = ({
 				{formik => {
 					return (
 						<>
-							{tab === 0 && <NewUserGeneralTab formik={formik} />}
-							{tab === 1 && <UserRolesTab formik={formik} />}
-
-							{/* Navigation buttons and validation */}
-							<WizardNavigationButtons
-								isLast
-								formik={formik}
-								nextPage={() => formik.handleSubmit()}
-								previousPage={() => close()}
-								cancelTranslationString={"CANCEL"}
+							<WizardStepper
+								steps={steps}
+								activePageIndex={page}
+								setActivePage={setPage}
+								completed={pageCompleted}
+								setCompleted={setPageCompleted}
+								isValid={formik.isValid}
 							/>
+							{steps[page].name === "metadata" &&
+								<NewUserGeneralTab
+									formik={formik}
+									nextPage={nextPage}
+								/>
+							}
+							{steps[page].name === "roles" &&
+								<UserRolesTab
+									formik={formik}
+									nextPage={nextPage}
+									previousPage={previousPage}
+								/>
+							}
+							{steps[page].name === "summary" &&
+								<NewUserSummaryPage
+									formik={formik}
+									previousPage={previousPage}
+								/>
+							}
 						</>
 					);
 				}}

--- a/src/components/users/partials/wizard/UserRolesTab.tsx
+++ b/src/components/users/partials/wizard/UserRolesTab.tsx
@@ -4,6 +4,7 @@ import SelectContainer from "../../../shared/wizard/SelectContainer";
 import { FormikProps } from "formik";
 import { NotificationComponent } from "../../../shared/Notifications";
 import ModalContent from "../../../shared/modals/ModalContent";
+import WizardNavigationButtons from "../../../shared/wizard/WizardNavigationButtons";
 
 /**
  * This component renders the role selection tab of the new user wizard and the user details modal
@@ -14,8 +15,12 @@ interface RequiredFormProps {
 
 const UserRolesTab = <T extends RequiredFormProps>({
 	formik,
+	nextPage,
+	previousPage,
 }: {
 	formik: FormikProps<T>
+	nextPage?: (values: T) => void, // For create modal
+	previousPage?: (values: T) => void, // For create modal
 }) => {
 	// roles that can be chosen by user
 	const [roles, setRoles] = useState<Role[]>([]);
@@ -35,31 +40,41 @@ const UserRolesTab = <T extends RequiredFormProps>({
 	}, []);
 
 	return (
-		<ModalContent>
-			{!formik.values.manageable && (
-				<NotificationComponent
-					notification={{
-						type: "warning",
-						message: "NOTIFICATIONS.USER_NOT_MANAGEABLE",
-						id: 0,
-					}}
-				/>
-			)}
-			<div className="form-container">
-				{/* Select container for roles*/}
-				{!loading && (
-					<SelectContainer
-						resource={{
-							searchable: true,
-							label: "USERS.USERS.DETAILS.ROLES",
-							items: roles,
+		<>
+			<ModalContent>
+				{!formik.values.manageable && (
+					<NotificationComponent
+						notification={{
+							type: "warning",
+							message: "NOTIFICATIONS.USER_NOT_MANAGEABLE",
+							id: 0,
 						}}
-						formikField="assignedRoles"
-						manageable={formik.values.manageable}
 					/>
 				)}
-			</div>
-		</ModalContent>
+				<div className="form-container">
+					{/* Select container for roles*/}
+					{!loading && (
+						<SelectContainer
+							resource={{
+								searchable: true,
+								label: "USERS.USERS.DETAILS.ROLES",
+								items: roles,
+							}}
+							formikField="assignedRoles"
+							manageable={formik.values.manageable}
+						/>
+					)}
+				</div>
+
+			</ModalContent>
+			{previousPage && nextPage &&
+				<WizardNavigationButtons
+					formik={formik}
+					nextPage={nextPage}
+					previousPage={previousPage}
+				/>
+			}
+		</>
 	);
 };
 

--- a/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/src/i18n/org/opencastproject/adminui/languages/lang-en_US.json
@@ -1381,7 +1381,8 @@
 					"USER": "User",
 					"ROLES": "Roles",
 					"EXTERNALROLES": "External Roles",
-					"EFFECTIVEROLES": "Effective Roles"
+					"EFFECTIVEROLES": "Effective Roles",
+					"SUMMARY": "Summary"
 				},
 				"DESCRIPTION": {
 					"ROLES": "Roles and groups that can be or are already assigned to the user.",


### PR DESCRIPTION
Fixes https://github.com/opencast/admin-interface/issues/1195.

Out of all "Create" dialogs, the one for users was working differently from the all the others. As I can see no reason why it should be like that, this patch brings the "Create New User" dialog in line with all the other create dialogs, for consistencies and usabilities sake.

### How to test this

Can be tested as is.