### PR TITLE
Fix a bunch of eslint and type-checker complaints

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,8 +39,8 @@ function App() {
 			dispatch(fetchUserInfo());
 		});
 
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
+		// Only run on mount
+	}, [dispatch]);
 
 	return (
 		<HashRouter>

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -32,6 +32,7 @@ const About = () => {
 						setAboutContent(t("ABOUT.NOCONTENT").toString());
 					});
 			});
+	// Exclude t from the array, as it is not guaranteed to be stable
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [location.pathname]); // Listen to changes in pathname
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -57,10 +57,6 @@ const Header = () => {
 	const orgProperties = useAppSelector(state => getOrgProperties(state));
 	const displayTerms = (orgProperties["org.opencastproject.admin.display_terms"] || "false").toLowerCase() === "true";
 
-	const loadHealthStatus = async () => {
-		await dispatch(fetchHealthStatus());
-	};
-
 	const hideMenuHelp = () => {
 		setMenuHelp(false);
 	};
@@ -120,6 +116,9 @@ const Header = () => {
 			}
 		};
 
+		const loadHealthStatus = async () => {
+			await dispatch(fetchHealthStatus());
+		};
 
 		// Fetching health status information at mount
 		loadHealthStatus().then(r => console.info(r));
@@ -133,8 +132,8 @@ const Header = () => {
 			clearInterval(interval);
 			window.removeEventListener("mousedown", handleClickOutside);
 		};
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
+		// Only run on mount
+	}, [dispatch]);
 
 	useEffect(() => {
   			if (!user) { return; }

--- a/src/components/events/Events.tsx
+++ b/src/components/events/Events.tsx
@@ -56,8 +56,7 @@ const Events = () => {
 	useEffect(() => {
 		// disable actions button
 		dispatch(setShowActions(false));
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [location.hash]);
+	}, [dispatch, location.hash]);
 
 	const onNewEventModal = async () => {
 		await Promise.all([

--- a/src/components/events/Series.tsx
+++ b/src/components/events/Series.tsx
@@ -40,8 +40,7 @@ const Series = () => {
 	useEffect(() => {
 		// disable actions button
 		dispatch(showActionsSeries(false));
-	// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [location.hash]);
+	}, [dispatch, location.hash]);
 
 	const onNewSeriesModal = async () => {
 		await Promise.all([

--- a/src/components/events/partials/ModalTabsAndPages/DetailsTobiraTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/DetailsTobiraTab.tsx
@@ -42,8 +42,7 @@ const DetailsTobiraTab = ({ kind, id }: DetailsTobiraTabProps) => {
 			// is removed when switching to another tab.
 			dispatch(fetchEventDetailsTobira(id));
 		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [id]);
+	}, [dispatch, id, kind]);
 
 	const [initialValues, setInitialValues] = useState<TobiraFormProps>({
 		breadcrumbs: [],

--- a/src/components/events/partials/ModalTabsAndPages/EditScheduledEventsEditPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EditScheduledEventsEditPage.tsx
@@ -71,6 +71,8 @@ const EditScheduledEventsEditPage = <T extends RequiredFormProps>({
 			fetchNewScheduling: fetchEventInfos,
 			setFieldValue: formik.setFieldValue,
 	}));
+		// Dispatching the backend request should only happen when events change,
+		// and WILL change editedEvents
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [formik.values.events]);
 

--- a/src/components/events/partials/ModalTabsAndPages/EditScheduledEventsEditPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EditScheduledEventsEditPage.tsx
@@ -95,20 +95,22 @@ const EditScheduledEventsEditPage = <T extends RequiredFormProps>({
 	 */
 	const reduceGroupedEvent = (groupedEvents: EditedEvents[]) => {
 		const result = groupedEvents.reduce((prev, curr) => {
-			for (const [key, value] of Object.entries(curr)) {
-				// TODO: This relies on the fact that the EditedEvent type only contains 'string' and 'string[]'. Improve on that.
-				if (typeof value === "string") {
-					// @ts-expect-error TS(7006):
-					prev[key as keyof EditedEvents] = prev[key as keyof EditedEvents] === curr[key as keyof EditedEvents] ? curr[key as keyof EditedEvents] : "";
-				} else {
-					// @ts-expect-error TS(7006):
-					prev[key as keyof EditedEvents] = prev[key as keyof EditedEvents] === curr[key as keyof EditedEvents] ? curr[key as keyof EditedEvents] : [];
-				}
+			for (const key of Object.keys(curr) as Array<keyof EditedEvents>) {
+				updateKey(key, prev, curr, defaultValuesEditedEvents);
 			}
 			return prev;
 		}, lodash.cloneDeep(groupedEvents[0]));
 		return result;
 	};
+
+	function updateKey<K extends keyof EditedEvents>(
+		key: K,
+		prev: EditedEvents,
+		curr: EditedEvents,
+		defaults: EditedEvents,
+	) {
+		prev[key] = prev[key] === curr[key] ? curr[key] : defaults[key];
+	}
 
 	const findSeriesName = (seriesOptions: { name: string, value: string }[], editedEvents: EditedEvents[]) => {
 		const series = seriesOptions.find(e => e.value === reduceGroupedEvent(editedEvents).changedSeries);
@@ -426,6 +428,28 @@ const EditScheduledEventsEditPage = <T extends RequiredFormProps>({
 			/>
 		</>
 	);
+};
+
+const defaultValuesEditedEvents: EditedEvents = {
+	changedDeviceInputs: [],
+	changedEndTimeHour: "",
+	changedEndTimeMinutes: "",
+	changedLocation: "",
+	changedSeries: "",
+	changedStartTimeHour: "",
+	changedStartTimeMinutes: "",
+	changedTitle: "",
+	changedWeekday: "MO",
+	deviceInputs: "",
+	endTimeHour: "",
+	endTimeMinutes: "",
+	eventId: "",
+	location: "",
+	series: "",
+	startTimeHour: "",
+	startTimeMinutes: "",
+	title: "",
+	weekday: "MO",
 };
 
 export default EditScheduledEventsEditPage;

--- a/src/components/events/partials/ModalTabsAndPages/EditScheduledEventsGeneralPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EditScheduledEventsGeneralPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import cn from "classnames";
-import { getSelectedRows } from "../../../../selectors/tableSelectors";
+import { getSelectedEvents } from "../../../../selectors/tableSelectors";
 import { useSelectionChanges } from "../../../../hooks/wizardHooks";
 import { getUserInformation } from "../../../../selectors/userInfoSelectors";
 import {
@@ -35,7 +35,7 @@ const EditScheduledEventsGeneralPage = <T extends RequiredFormProps>({
 }) => {
 	const { t } = useTranslation();
 
-	const selectedRows = useAppSelector(state => getSelectedRows(state));
+	const selectedRows = useAppSelector(state => getSelectedEvents(state));
 	const user = useAppSelector(state => getUserInformation(state));
 
 	const {
@@ -43,7 +43,6 @@ const EditScheduledEventsGeneralPage = <T extends RequiredFormProps>({
 		allChecked,
 		onChangeSelected,
 		onChangeAllSelected,
-		// @ts-expect-error TS(7006):
 	} = useSelectionChanges(formik, selectedRows);
 
 	useEffect(() => {

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetsTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsAssetsTab.tsx
@@ -85,6 +85,8 @@ const EventDetailsAssetsTab = ({
 	useEffect(() => {
 		dispatch(removeNotificationWizardForm());
 		dispatch(fetchAssets(eventId)).then();
+		// Only run on mount.
+		// Don't update when the id changes (which should not happen anyway) to avoid data inconsistencies
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsCommentsTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsCommentsTab.tsx
@@ -47,6 +47,8 @@ const EventDetailsCommentsTab = ({
 
 	useEffect(() => {
 		dispatch(fetchComments(eventId));
+		// Only run on mount.
+		// Don't update when the id changes (which should not happen anyway) to avoid data inconsistencies
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsPublicationTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsPublicationTab.tsx
@@ -19,7 +19,9 @@ const EventDetailsPublicationTab = ({
 	const publications = useAppSelector(state => getPublications(state));
 
 	useEffect(() => {
-		dispatch(fetchEventPublications(eventId)).then(r => console.info(r));
+		dispatch(fetchEventPublications(eventId));
+		// Only run on mount.
+		// Don't update when the id changes (which should not happen anyway) to avoid data inconsistencies
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsSchedulingTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsSchedulingTab.tsx
@@ -100,7 +100,8 @@ const EventDetailsSchedulingTab = ({
 			startDate: sourceStartDate,
 			endDate: endStartDate,
 			deviceId: source.device.id,
-		})).then();
+		}));
+		// Force an initial conflicts check
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowDetails.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowDetails.tsx
@@ -60,6 +60,8 @@ const EventDetailsWorkflowDetails = ({
 		} else {
 			dispatch(fetchWorkflowDetails({ eventId, workflowId }));
 		}
+	// Only run on mount.
+	// Don't update when the id changes (which should not happen anyway) to avoid data inconsistencies
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
@@ -350,6 +352,8 @@ const OperationsPreview = ({
 
 		// Unmount interval
 		return () => clearInterval(fetchWorkflowOperationsInterval);
+	// Only run on mount.
+	// Don't update when the id changes (which should not happen anyway) to avoid data inconsistencies
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowErrors.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowErrors.tsx
@@ -51,6 +51,8 @@ const EventDetailsWorkflowErrors = ({
 		if (workflowId) {
 			dispatch(fetchWorkflowErrors({ eventId, workflowId })).then();
 		}
+	// Only run on mount.
+	// Don't update when the id changes (which should not happen anyway) to avoid data inconsistencies
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowOperations.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowOperations.tsx
@@ -46,6 +46,8 @@ const EventDetailsWorkflowOperations = ({
 
 		// Unmount interval
 		return () => clearInterval(fetchWorkflowOperationsInterval);
+	// Only run on mount.
+	// Don't update when the id changes (which should not happen anyway) to avoid data inconsistencies
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowSchedulingTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowSchedulingTab.tsx
@@ -56,6 +56,8 @@ const EventDetailsWorkflowSchedulingTab = ({
 	useEffect(() => {
 		dispatch(removeNotificationWizardForm());
 		dispatch(fetchWorkflows(eventId)).then();
+	// Only run on mount.
+	// Don't update when the id changes (which should not happen anyway) to avoid data inconsistencies
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 

--- a/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/EventDetailsWorkflowTab.tsx
@@ -55,6 +55,8 @@ const EventDetailsWorkflowTab = ({
 	useEffect(() => {
 		dispatch(removeNotificationWizardForm());
 		dispatch(fetchWorkflows(eventId)).then();
+		// Only run on mount.
+		// Don't update when the id changes (which should not happen anyway) to avoid data inconsistencies
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 

--- a/src/components/events/partials/ModalTabsAndPages/NewAccessPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewAccessPage.tsx
@@ -81,6 +81,7 @@ const NewAccessPage = <T extends RequiredFormProps>({
 		if (initEventAclWithSeriesAcl && formik.values.metadata["dublincore/episode_isPartOf"]) {
 			dispatch(fetchSeriesDetailsAcls(formik.values.metadata["dublincore/episode_isPartOf"]));
 		}
+	// We only care about the series, not all metadata
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [formik.values.metadata["dublincore/episode_isPartOf"], initEventAclWithSeriesAcl, dispatch]);
 
@@ -89,6 +90,7 @@ const NewAccessPage = <T extends RequiredFormProps>({
 		if (initEventAclWithSeriesAcl && formik.values.metadata["dublincore/episode_isPartOf"] && seriesAcl) {
 			formik.setFieldValue("policies", seriesAcl);
 		}
+	// We only care to set "policies" if the seriesAcl updated
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [initEventAclWithSeriesAcl, seriesAcl]);
 

--- a/src/components/events/partials/ModalTabsAndPages/NewAccessPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewAccessPage.tsx
@@ -25,10 +25,10 @@ import ModalContentTable from "../../../shared/modals/ModalContentTable";
  */
 interface RequiredFormProps {
   metadata: {
-    "dublincore/episode_isPartOf": string,
+    "dublincore/episode_isPartOf"?: string,
   },
   policies: TransformedAcl[],
-  aclTemplate: string,
+  aclTemplate: string, // For TemplateSelector
   // theme: string,
 }
 

--- a/src/components/events/partials/ModalTabsAndPages/NewProcessingPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewProcessingPage.tsx
@@ -46,6 +46,7 @@ const NewProcessingPage = <T extends RequiredFormProps>({
 		if (workflowDefinitions.length === 1) {
 			setDefaultValues(formik, workflowDefinitions, workflowDefinitions[0].id);
 		}
+	// We only care to set default values if workflowDef changes
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [workflowDefinitions]);
 

--- a/src/components/events/partials/ModalTabsAndPages/NewProcessingPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewProcessingPage.tsx
@@ -16,6 +16,7 @@ import RenderWorkflowSelect from "../wizards/RenderWorkflowSelect";
 interface RequiredFormProps {
 	sourceMode: string,
 	workflowId: string,
+	configuration?: { [key: string]: unknown } // For RenderWorkflowConfig
 }
 
 const NewProcessingPage = <T extends RequiredFormProps>({
@@ -83,7 +84,6 @@ const NewProcessingPage = <T extends RequiredFormProps>({
 									<RenderWorkflowConfig
 										displayDescription
 										workflowId={formik.values.workflowId}
-										// @ts-expect-error TS(7006):
 										formik={formik}
 									/>
 								) : null}

--- a/src/components/events/partials/ModalTabsAndPages/NewSourcePage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewSourcePage.tsx
@@ -94,7 +94,8 @@ const NewSourcePage = <T extends RequiredFormProps>({
 		dispatch(fetchRecordings("inputs"));
 
 		// validate form because dependent default values need to be checked
-		formik.validateForm().then(r => console.info(r));
+		formik.validateForm();
+		// Only run on mount
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 

--- a/src/components/events/partials/ModalTabsAndPages/NewTobiraPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/NewTobiraPage.tsx
@@ -96,6 +96,7 @@ const NewTobiraPage = <T extends TobiraFormProps>({
 
 		valid = valid && check("warning", "TOBIRA_PATH_SEGMENT_INVALID", NOTIFICATION_CONTEXT_TOBIRA, () => (
 			newPage.segment.length <= 1 || [
+				// We are explicitly checking that nothing is wrong with the path
 				// eslint-disable-next-line no-control-regex
 				/[\u0000-\u001F\u007F-\u009F]/u,
 				/[\u00A0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000]/u,
@@ -158,6 +159,7 @@ const NewTobiraPage = <T extends TobiraFormProps>({
 			select(undefined);
 			formik.setFieldValue("breadcrumbs", [...formik.values.breadcrumbs, currentPage]);
 		}
+	// Should only trigger on page change
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [currentPage]);
 

--- a/src/components/events/partials/ModalTabsAndPages/SeriesDetailsAccessTab.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/SeriesDetailsAccessTab.tsx
@@ -36,8 +36,7 @@ const SeriesDetailsAccessTab = ({
 
 	useEffect(() => {
 		dispatch(removeNotificationWizardForm());
-	// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
+	}, [dispatch]);
 
 	return (
 		<ResourceDetailsAccessPolicyTab

--- a/src/components/events/partials/ModalTabsAndPages/StartTaskGeneralPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/StartTaskGeneralPage.tsx
@@ -49,6 +49,7 @@ const StartTaskGeneralPage = <T extends RequiredFormProps>({
 		if (formik.values.events.length === 0) {
 			formik.setFieldValue("events", selectedEvents);
 		}
+		// Only run on mount
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 

--- a/src/components/events/partials/ModalTabsAndPages/StartTaskGeneralPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/StartTaskGeneralPage.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import Notifications from "../../../shared/Notifications";
 import cn from "classnames";
-import { getSelectedRows } from "../../../../selectors/tableSelectors";
+import { getSelectedEvents } from "../../../../selectors/tableSelectors";
 import { useSelectionChanges } from "../../../../hooks/wizardHooks";
 import {
 	checkValidityStartTaskEventSelection,
@@ -34,14 +34,13 @@ const StartTaskGeneralPage = <T extends RequiredFormProps>({
 }) => {
 	const { t } = useTranslation();
 
-	const selectedRows = useAppSelector(state => getSelectedRows(state));
+	const selectedRows = useAppSelector(state => getSelectedEvents(state));
 
 	const {
 		selectedEvents,
 		allChecked,
 		onChangeSelected,
 		onChangeAllSelected,
-		// @ts-expect-error TS(7006):
 	} = useSelectionChanges(formik, selectedRows);
 
 	useEffect(() => {

--- a/src/components/events/partials/ModalTabsAndPages/StartTaskWorkflowPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/StartTaskWorkflowPage.tsx
@@ -36,14 +36,14 @@ const StartTaskWorkflowPage = <T extends RequiredFormProps>({
 	useEffect(() => {
 		// Load workflow definitions for selecting
 		dispatch(fetchWorkflowDef("tasks"));
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
+	}, [dispatch]);
 
 	// Preselect the first item
 	useEffect(() => {
 		if (workflowDefinitions.length === 1) {
 			setDefaultValues(formik, workflowDefinitions, workflowDefinitions[0].id);
 		}
+	// We only care to set default values if workflowDef changes
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [workflowDefinitions]);
 

--- a/src/components/events/partials/ModalTabsAndPages/StartTaskWorkflowPage.tsx
+++ b/src/components/events/partials/ModalTabsAndPages/StartTaskWorkflowPage.tsx
@@ -15,6 +15,7 @@ import RenderWorkflowSelect from "../wizards/RenderWorkflowSelect";
  */
 interface RequiredFormProps {
 	workflowId: string,
+	configuration?: { [key: string]: unknown } // For RenderWorkflowConfig
 }
 
 const StartTaskWorkflowPage = <T extends RequiredFormProps>({
@@ -69,7 +70,6 @@ const StartTaskWorkflowPage = <T extends RequiredFormProps>({
 									<RenderWorkflowConfig
 										displayDescription
 										workflowId={formik.values.workflowId}
-										// @ts-expect-error TS(7006):
 										formik={formik}
 									/>
 								</div>

--- a/src/components/events/partials/modals/DeleteEventsModal.tsx
+++ b/src/components/events/partials/modals/DeleteEventsModal.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { getSelectedRows } from "../../../../selectors/tableSelectors";
+import { getSelectedEvents } from "../../../../selectors/tableSelectors";
 import { useAppDispatch, useAppSelector } from "../../../../store";
 import { deleteMultipleEvent } from "../../../../slices/eventSlice";
 import { isEvent } from "../../../../slices/tableSlice";
@@ -19,13 +19,12 @@ const DeleteEventsModal = ({
 	const { t } = useTranslation();
 	const dispatch = useAppDispatch();
 
-	const selectedRows = useAppSelector(state => getSelectedRows(state));
+	const selectedRows = useAppSelector(state => getSelectedEvents(state));
 
 	const [allChecked, setAllChecked] = useState(true);
 	const [selectedEvents, setSelectedEvents] = useState(selectedRows);
 
 	const deleteSelectedEvents = () => {
-		// @ts-expect-error TS(7006): Type guarding array is hard
 		dispatch(deleteMultipleEvent(selectedEvents));
 		close();
 	};

--- a/src/components/events/partials/modals/DeleteSeriesModal.tsx
+++ b/src/components/events/partials/modals/DeleteSeriesModal.tsx
@@ -62,6 +62,7 @@ const DeleteSeriesModal = ({
 			setSelectedSeries(series);
 		}
 		fetchData();
+		// Only run on mount
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 

--- a/src/components/events/partials/modals/DeleteSeriesModal.tsx
+++ b/src/components/events/partials/modals/DeleteSeriesModal.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { getSelectedRows } from "../../../../selectors/tableSelectors";
+import { getSelectedSeries } from "../../../../selectors/tableSelectors";
 import cn from "classnames";
 import { useAppDispatch, useAppSelector } from "../../../../store";
 import {
@@ -27,7 +27,7 @@ const DeleteSeriesModal = ({
 	const { t } = useTranslation();
 	const dispatch = useAppDispatch();
 
-	const selectedRows = useAppSelector(state => getSelectedRows(state));
+	const selectedRows = useAppSelector(state => getSelectedSeries(state));
 	const modifiedSelectedRows = selectedRows.map(row => {
 		return { ...row, hasEvents: false };
 	});
@@ -67,7 +67,6 @@ const DeleteSeriesModal = ({
 	}, []);
 
 	const deleteSelectedSeries = () => {
-		// @ts-expect-error TS(7006): Type guarding array is hard
 		dispatch(deleteMultipleSeries(selectedSeries));
 		close();
 	};

--- a/src/components/events/partials/modals/EditMetadataEventsModal.tsx
+++ b/src/components/events/partials/modals/EditMetadataEventsModal.tsx
@@ -81,6 +81,7 @@ const EditMetadataEventsModal = ({
 			setLoading(false);
 		}
 		fetchData();
+		// Only run on mount
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 

--- a/src/components/events/partials/modals/EditScheduledEventsModal.tsx
+++ b/src/components/events/partials/modals/EditScheduledEventsModal.tsx
@@ -53,8 +53,8 @@ const EditScheduledEventsModal = ({
 	useEffect(() => {
 		// Load recordings that can be used for input
 		dispatch(fetchRecordings("inputs"));
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
+		// Only run on mount
+	}, [dispatch]);
 
 	type StepName = "general" | "edit" | "summary";
 	type Step = WizardStep & {

--- a/src/components/events/partials/modals/EventDetails.tsx
+++ b/src/components/events/partials/modals/EventDetails.tsx
@@ -121,6 +121,8 @@ const EventDetails = ({
 
 
 		dispatch(fetchEventDetailsTobira(eventId));
+		// Only run on mount.
+		// Don't update when the id changes (which should not happen anyway) to avoid data inconsistencies
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 

--- a/src/components/events/partials/modals/SeriesDetails.tsx
+++ b/src/components/events/partials/modals/SeriesDetails.tsx
@@ -70,6 +70,8 @@ const SeriesDetails = ({
 		dispatch(fetchSeriesStatistics(seriesId));
 		dispatch(fetchSeriesDetailsTobira(seriesId));
 		dispatch(setTobiraTabHierarchy("main"));
+		// Only run on mount.
+		// Don't update when the id changes (which should not happen anyway) to avoid data inconsistencies
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 

--- a/src/components/events/partials/wizards/NewEventSummary.tsx
+++ b/src/components/events/partials/wizards/NewEventSummary.tsx
@@ -103,7 +103,6 @@ const NewEventSummary = <T extends RequiredFormProps>({
 				{/* Summary metadata*/}
 				<MetadataSummaryTable
 					metadataCatalogs={[metadataEvents]}
-					// @ts-expect-error: Metadata not correctly typed
 					formikValues={formik.values.metadata}
 					header={"EVENTS.EVENTS.NEW.METADATA.CAPTION"}
 				/>
@@ -112,7 +111,6 @@ const NewEventSummary = <T extends RequiredFormProps>({
 				{!metaDataExtendedHidden && (
 					<MetadataSummaryTable
 						metadataCatalogs={extendedMetadata}
-						// @ts-expect-error: Metadata not correctly typed
 						formikValues={formik.values.metadata}
 						header={"EVENTS.EVENTS.NEW.METADATA_EXTENDED.CAPTION"}
 					/>

--- a/src/components/events/partials/wizards/NewEventWizard.tsx
+++ b/src/components/events/partials/wizards/NewEventWizard.tsx
@@ -48,9 +48,7 @@ const NewEventWizard = ({
 
 	useEffect(() => {
 		dispatch(removeNotificationWizardForm());
-
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
+	}, [dispatch]);
 
 	// Whether the ACL of a new event is initialized with the ACL of its series.
 	let initEventAclWithSeriesAcl = true;

--- a/src/components/events/partials/wizards/NewEventWizard.tsx
+++ b/src/components/events/partials/wizards/NewEventWizard.tsx
@@ -223,11 +223,8 @@ const NewEventWizard = ({
 								)}
 								{steps[page].name === "access" && (
 									<NewAccessPage
-									// @ts-expect-error TS(7006):
 										previousPage={previousPage}
-										// @ts-expect-error TS(7006):
 										nextPage={nextPage}
-										// @ts-expect-error TS(7006):
 										formik={formik}
 										editAccessRole="ROLE_UI_EVENTS_DETAILS_ACL_EDIT"
 										viewUsersAccessRole="ROLE_UI_EVENTS_DETAILS_ACL_USER_ROLES_VIEW"

--- a/src/components/events/partials/wizards/NewPlaylistSummary.tsx
+++ b/src/components/events/partials/wizards/NewPlaylistSummary.tsx
@@ -34,7 +34,6 @@ const NewPlaylistSummary = <T extends RequiredFormProps>({
     <ModalContentTable>
       <MetadataSummaryTable
         metadataCatalogs={[metadataFields]}
-        // @ts-expect-error TS(7006):
         formikValues={formik.values.metadata}
         header={"EVENTS.PLAYLISTS.NEW.METADATA.CAPTION"}
       />

--- a/src/components/events/partials/wizards/NewPlaylistWizard.tsx
+++ b/src/components/events/partials/wizards/NewPlaylistWizard.tsx
@@ -152,7 +152,6 @@ const NewPlaylistWizard = ({
             <NewAccessPage
               nextPage={nextPage}
               previousPage={previousPage}
-              // @ts-expect-error TS(7006):
               formik={formik}
               editAccessRole="ROLE_UI_PLAYLISTS_DETAILS_ACL_EDIT"
               viewUsersAccessRole="ROLE_UI_PLAYLISTS_DETAILS_ACL_USER_ROLES_VIEW"

--- a/src/components/events/partials/wizards/NewSeriesSummary.tsx
+++ b/src/components/events/partials/wizards/NewSeriesSummary.tsx
@@ -47,7 +47,6 @@ const NewSeriesSummary = <T extends RequiredFormProps>({
 						{/* Summary metadata*/}
 						<MetadataSummaryTable
 							metadataCatalogs={[metadataSeries]}
-							// @ts-expect-error TS(7006):
 							formikValues={formik.values.metadata}
 							header={"EVENTS.SERIES.NEW.METADATA.CAPTION"}
 						/>
@@ -56,7 +55,6 @@ const NewSeriesSummary = <T extends RequiredFormProps>({
 						{!metaDataExtendedHidden ? (
 							<MetadataSummaryTable
 								metadataCatalogs={extendedMetadata}
-								// @ts-expect-error TS(7006):
 								formikValues={formik.values.metadata}
 								header={"EVENTS.SERIES.NEW.METADATA_EXTENDED.CAPTION"}
 							/>

--- a/src/components/events/partials/wizards/NewSeriesWizard.tsx
+++ b/src/components/events/partials/wizards/NewSeriesWizard.tsx
@@ -192,7 +192,6 @@ const NewSeriesWizard = ({
 									<NewAccessPage
 										nextPage={nextPage}
 										previousPage={previousPage}
-										// @ts-expect-error TS(7006):
 										formik={formik}
 										editAccessRole="ROLE_UI_SERIES_DETAILS_ACL_EDIT"
 										viewUsersAccessRole="ROLE_UI_SERIES_DETAILS_ACL_USER_ROLES_VIEW"

--- a/src/components/events/partials/wizards/NewSeriesWizard.tsx
+++ b/src/components/events/partials/wizards/NewSeriesWizard.tsx
@@ -48,16 +48,13 @@ const NewSeriesWizard = ({
 
 	useEffect(() => {
 		dispatch(removeNotificationWizardForm());
-
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
+	}, [dispatch]);
 
 	useEffect(() => {
 		// This should set off a web request that will intentionally fail, in order
 		// to check if tobira is available at all
 		dispatch(fetchSeriesDetailsTobiraNew(""));
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
+	}, [dispatch]);
 
 	const themesEnabled = (orgProperties["admin.themes.enabled"] || "false").toLowerCase() === "true";
 

--- a/src/components/events/partials/wizards/summaryTables/MetadataSummaryTable.tsx
+++ b/src/components/events/partials/wizards/summaryTables/MetadataSummaryTable.tsx
@@ -14,7 +14,7 @@ const MetadataSummaryTable = ({
 	header,
 }: {
 	metadataCatalogs: MetadataCatalog[],
-	formikValues: { [key: string]: string | string[] | boolean | Date },
+	formikValues: { [key: string]: unknown },
 	header: ParseKeys,
 }) => {
 	const { t } = useTranslation();
@@ -26,7 +26,7 @@ const MetadataSummaryTable = ({
 		let metadata: {
 			name: string,
 			label: string,
-			value: string | string[] | boolean,
+			value: unknown,
 		}[] = [];
 		for (let i = 0; metadataFields.length > i; i++) {
 			let fieldValue =
@@ -82,7 +82,7 @@ const MetadataSummaryTable = ({
 									<td>
 										{Array.isArray(entry.value)
 											? entry.value.join(", ")
-											: entry.value}
+											: String(entry.value)}
 									</td>
 								</tr>
 							))}

--- a/src/components/shared/DropDown.tsx
+++ b/src/components/shared/DropDown.tsx
@@ -132,19 +132,19 @@ const DropDown = <T, >({
 	 */
 	const MenuList = (props: MenuListProps<DropDownOption<T>, false>) => {
 		const { children, maxHeight } = props;
+		const items = React.Children.toArray(children);
 
 		return Array.isArray(children) ? (
 			<div style={{ paddingTop: 4 }}>
 				<List
 					rowComponent={MenuListRow}
-					rowCount={children.length}
+					rowCount={items.length}
 					rowHeight={itemHeight}
 					style={{
-						height: maxHeight < (children.length * itemHeight) ? maxHeight : children.length * itemHeight,
+						height: maxHeight < (items.length * itemHeight) ? maxHeight : items.length * itemHeight,
 						width: "100%",
 					}}
-					// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-					rowProps={{ names: children }}
+					rowProps={{ names: items }}
 					overscanCount={4}
 				/>
 			</div>
@@ -156,7 +156,7 @@ const DropDown = <T, >({
 		names,
 		style,
 	}: RowComponentProps<{
-		names: string[];
+		names: React.ReactNode[];
 	}>) {
 		const name = names[index];
 		return <div style={style}>{name}</div>;

--- a/src/components/shared/MainNav.tsx
+++ b/src/components/shared/MainNav.tsx
@@ -178,12 +178,12 @@ const MainNav = ({
 		if (linkMapItem?.links && linkMapItem.links.length > 1) {
 			const arrToSort = linkMapItem.links;
 			if (arrToSort != undefined && arrToSort.length > 1) {
-				arrToSort.forEach(item => {
-					// @ts-expect-error: TODO: Someone else can fix this
-					if (item.path === pathname) { item.tmpIndex = 0; } else { item.tmpIndex = 1; }
+				arrToSort.sort((a, b) => {
+					const aPriority = a.path === pathname ? 0 : 1;
+					const bPriority = b.path === pathname ? 0 : 1;
+
+					return aPriority - bPriority;
 				});
-				// @ts-expect-error: TODO: Someone else can fix this
-				arrToSort.sort((a, b) => a.tmpIndex - b.tmpIndex);
 			}
 		}
 	}

--- a/src/components/shared/RegistrationModal.tsx
+++ b/src/components/shared/RegistrationModal.tsx
@@ -684,8 +684,7 @@ const RegistrationModalContent = () => {
 							{states[state].buttons.back && (
 								<BaseButton
 									className="cancel"
-// @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-									onClick={() => setState(states[state].nextState[5])}
+									onClick={() => setState(states[state].nextState[5] as keyof typeof states)}
 								>
 									{t("ADOPTER_REGISTRATION.MODAL.BACK")}
 								</BaseButton>
@@ -701,8 +700,7 @@ const RegistrationModalContent = () => {
 							{states[state].buttons.skip && (
 								<BaseButton
 									className="cancel"
-// @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-									onClick={() => setState(states[state].nextState[2])}
+									onClick={() => setState(states[state].nextState[2] as keyof typeof states)}
 								>
 									{t("ADOPTER_REGISTRATION.MODAL.SKIP")}
 								</BaseButton>

--- a/src/components/shared/RegistrationModal.tsx
+++ b/src/components/shared/RegistrationModal.tsx
@@ -76,8 +76,9 @@ const RegistrationModalContent = () => {
 	}>();
 
 	useEffect(() => {
-		fetchRegistrationInfos().then(r => console.log(r));
+		fetchRegistrationInfos();
 		fetchStatisticSummary();
+		// Only run on mount
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 

--- a/src/components/shared/Stats.tsx
+++ b/src/components/shared/Stats.tsx
@@ -50,20 +50,19 @@ const Stats = () => {
 		dispatch(loadEventsIntoTable());
 	};
 
-	const loadStats = async () => {
-		// Fetching stats from server
-		await dispatch(fetchStats());
-	};
-
 	useEffect(() => {
+		const loadStats = async () => {
+			// Fetching stats from server
+			await dispatch(fetchStats());
+		};
+
 		// Load stats on mount
 		loadStats();
 
 		const fetchEventsInterval = setInterval(() => { loadStats(); }, 5000);
 
 		return () => clearInterval(fetchEventsInterval);
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
+	}, [dispatch]);
 
 	return (
 		<>

--- a/src/components/shared/Table.tsx
+++ b/src/components/shared/Table.tsx
@@ -96,6 +96,7 @@ const Table = <T extends Row, >({
 			allowLoadIntoTable = false;
 			clearInterval(fetchResourceInterval);
 		};
+		// Only run on mount
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [location.hash]);
 
@@ -183,14 +184,14 @@ const MultiSelect = ({ selectAllCheckboxRef }: { selectAllCheckboxRef: React.Ref
 		const selected = e.target.checked;
 		dispatch(changeAllSelected(selected));
 	};
-   	useEffect(() => {
-  	if (isNewEventAdded && multiSelect) {
-   	 if (selectAllCheckboxRef.current?.checked) {
-		selectAllCheckboxRef.current.checked = false;
+
+	useEffect(() => {
+		if (isNewEventAdded && multiSelect) {
+			if (selectAllCheckboxRef.current?.checked) {
+				selectAllCheckboxRef.current.checked = false;
 			}
-		  }
-	// eslint-disable-next-line react-hooks/exhaustive-deps
-		}, [isNewEventAdded, multiSelect]);
+		}
+	}, [isNewEventAdded, multiSelect, selectAllCheckboxRef]);
 
 	return (
 		<>

--- a/src/components/shared/TableFilters.tsx
+++ b/src/components/shared/TableFilters.tsx
@@ -68,6 +68,7 @@ const TableFilters = ({
 
 	useEffect(() => {
 		dispatch(fetchFilters(resource));
+		// Only run on mount
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [location.hash]);
 
@@ -144,26 +145,27 @@ const TableFilters = ({
 		}
 	};
 
-	// Apply the filter changes (in debounced) accomulated in handleChange,
-	// simply by going to first page and then load resources.
-	// This helps increase performance by reducing the number of calls to load resources.
-	const applyFilterChangesDebounced = async () => {
-		console.log("Applying filter changes with value: " + itemValue);
-		// No matter what, we go to page one.
-		dispatch(goToPage(0));
-		// Reload of resource
-		await dispatch(loadResource());
-		dispatch(loadResourceIntoTable());
-	};
-
 	useEffect(() => {
+		// Apply the filter changes (in debounced) accomulated in handleChange,
+		// simply by going to first page and then load resources.
+		// This helps increase performance by reducing the number of calls to load resources.
+		const applyFilterChangesDebounced = async () => {
+			console.log("Applying filter changes with value: " + itemValue);
+			// No matter what, we go to page one.
+			dispatch(goToPage(0));
+			// Reload of resource
+			await dispatch(loadResource());
+			dispatch(loadResourceIntoTable());
+		};
+
 		if (itemValue) {
 			// Call to apply filter changes with 600MS debounce!
 			const applyFilterChangesDebouncedTimeoutId = setTimeout(() => { applyFilterChangesDebounced(); }, 600);
 
 			return () => clearTimeout(applyFilterChangesDebouncedTimeoutId);
 		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
+	// Only run if the filter value changed
+	// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [itemValue]);
 
 	const handleDatepicker = (dates?: [Date | undefined | null, Date | undefined | null]) => {

--- a/src/components/shared/modals/ResourceDetailsAccessPolicyTab.tsx
+++ b/src/components/shared/modals/ResourceDetailsAccessPolicyTab.tsx
@@ -147,6 +147,7 @@ const ResourceDetailsAccessPolicyTab = ({
 		}
 
 		fetchData().then(() => {});
+		// Only run on mount
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
@@ -432,8 +433,7 @@ export const AccessPolicyTable = <T extends AccessPolicyTabFormikProps>({
 
 	useEffect(() => {
 		dispatch(fetchAclDefaults());
-	// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
+	}, [dispatch]);
 
 	const dropdownOptions = useMemo(() => {
 		return roles.length > 0

--- a/src/components/shared/wizard/FileUpload.tsx
+++ b/src/components/shared/wizard/FileUpload.tsx
@@ -65,6 +65,7 @@ const FileUpload = <T extends RequiredFormProps>({
 	// additional rerender which then triggers formik validation.
 	useEffect(() => {
 		formik.validateForm();
+	// Only run validation if these values change
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [formik.values.fileId, formik.values.fileName, loaded]);
 

--- a/src/components/shared/wizard/SelectContainer.tsx
+++ b/src/components/shared/wizard/SelectContainer.tsx
@@ -67,6 +67,7 @@ const SelectContainer = ({
 
 		setItems(initialItems);
 		setDefaultItems(initialItems);
+		// Init on mount
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 

--- a/src/components/statistics/Statistics.tsx
+++ b/src/components/statistics/Statistics.tsx
@@ -34,12 +34,10 @@ const Statistics = () => {
 	// fetch user information for organization id, then fetch statistics
 	useEffect(() => {
 		dispatch(fetchUserInfo());
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
+	}, [dispatch]);
 	useEffect(() => {
-			dispatch(fetchStatisticsPageStatistics(organizationId)).then();
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [organizationId]);
+		dispatch(fetchStatisticsPageStatistics(organizationId));
+	}, [dispatch, organizationId]);
 
 	/* generates file name for download-link for a statistic */
 	const statisticsCsvFileName = (statsTitle: string) => {

--- a/src/configs/modalConfig.ts
+++ b/src/configs/modalConfig.ts
@@ -106,7 +106,7 @@ export const initialFormValuesNewSeries: {
 
 	breadcrumbs: TobiraPage[],
 	selectedPage?: TobiraPage,
-	aclTemplate?: string,
+	aclTemplate: string,
 	metadata: { [key: string]: unknown }
 } = {
 	policies: [
@@ -120,13 +120,14 @@ export const initialFormValuesNewSeries: {
 	theme: "",
 	breadcrumbs: [],
 	selectedPage: undefined,
+	aclTemplate: "",
 	metadata: {},
 };
 
 
 export const initialFormValuesNewPlaylist: {
 	policies: TransformedAcl[],
-	aclTemplate?: string,
+	aclTemplate: string,
 	metadata: { [key: string]: unknown },
 	entries: PlaylistEntry[],
 } = {
@@ -138,6 +139,7 @@ export const initialFormValuesNewPlaylist: {
 			actions: [],
 		},
 	],
+	aclTemplate: "",
 	metadata: {},
 	entries: [],
 };

--- a/src/hooks/wizardHooks.ts
+++ b/src/hooks/wizardHooks.ts
@@ -1,7 +1,6 @@
 import { FormikProps } from "formik";
 import { useEffect, useState } from "react";
 import { Event } from "../slices/eventSlice";
-import { isEvent } from "../slices/tableSlice";
 
 export const usePageFunctions = (initialPage: number) => {
 	const [page, setPage] = useState(initialPage);
@@ -65,7 +64,7 @@ export const useSelectionChanges = <T extends RequiredFormProps>(
 	const onChangeSelected = (e: React.ChangeEvent<HTMLInputElement>, id: string) => {
 		const selected = e.target.checked;
 		const changedEvents = selectedEvents.map(event => {
-			if (isEvent(event) && event.id === id) {
+			if (event.id === id) {
 				return {
 					...event,
 					selected: selected,

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -57,6 +57,7 @@ const myFormatter: FormatterModule = {
 			});
 		}
 
+		// If we are given any by the package, we can only really return any
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 		return value;
 	},

--- a/src/selectors/tableSelectors.ts
+++ b/src/selectors/tableSelectors.ts
@@ -1,6 +1,6 @@
 import { createSelector } from "reselect";
 import { RootState } from "../store";
-import { rowsSelectors, TableState } from "../slices/tableSlice";
+import { isEvent, isSeries, rowsSelectors, TableState } from "../slices/tableSlice";
 
 /**
  * This file contains selectors regarding the table view
@@ -30,4 +30,12 @@ export const getActivatedColumns = (state: RootState) =>
 export const getSelectedRows = createSelector(
 	rowsSelectors.selectAll,
 	rows => rows.filter(row => row.selected),
+);
+export const getSelectedEvents = createSelector(
+	rowsSelectors.selectAll,
+	rows => rows.filter(row => row.selected).filter(isEvent),
+);
+export const getSelectedSeries = createSelector(
+	rowsSelectors.selectAll,
+	rows => rows.filter(row => row.selected).filter(isSeries),
 );

--- a/src/slices/seriesSlice.ts
+++ b/src/slices/seriesSlice.ts
@@ -241,7 +241,7 @@ export const postNewSeries = (params: {
 		});
 
 		tobira.parentPagePath = existingPages.pop()!.path;
-		tobira["newPages"] = newPages;
+		tobira.newPages = newPages;
 	}
 
 

--- a/src/slices/seriesSlice.ts
+++ b/src/slices/seriesSlice.ts
@@ -325,14 +325,8 @@ export const deleteSeries = (id: Series["id"]): AppThunk => dispatch => {
 // delete series with provided ids
 export const deleteMultipleSeries = (
 	series: {
-		contributors: string[],
-		createdBy: string,
-		creation_date: string,
-		hasEvents: false,
 		id: string,
-		organizers: string[],
 		selected: boolean,
-		title: string,
 	}[],
 ): AppThunk => dispatch => {
 	const data = [];

--- a/src/slices/tableSlice.ts
+++ b/src/slices/tableSlice.ts
@@ -71,15 +71,21 @@ export function isRowSelectable(row: Row) {
 	return false;
 }
 
-export function isEvent(row: Row | Event | Series | Recording | Server | Job | Service | User | Group | AclResult | ThemeDetailsType): row is Event {
+export function isEvent(row: Row): row is Row & Event {
 	return (row as Event).event_status !== undefined;
 }
 
-export function isSeries(row: Row | Event | Series | Recording | Server | Job | Service | User | Group | AclResult | ThemeDetailsType): row is Series {
+// export function isEvent(row: Row | Event | Series | Recording | Server | Job | Service | User | Group | AclResult | ThemeDetailsType): row is Event {
+// 	return (row as Event).event_status !== undefined;
+// }
+
+export function isSeries(row: Row): row is Row & Series {
 	return (row as Series).organizers !== undefined;
 }
 
-export type Meh = Event | Series | Recording | Server | Job | Service | User | Group | AclResult | ThemeDetailsType
+// export function isSeries(row: Row | Event | Series | Recording | Server | Job | Service | User | Group | AclResult | ThemeDetailsType): row is Series {
+// 	return (row as Series).organizers !== undefined;
+// }
 
 // TODO: Improve row typing. While this somewhat correctly reflects the current state of our code, it is rather annoying to work with.
 export type Row = {


### PR DESCRIPTION
Fixes #469.

Looks at all the comments that are disabling eslint or typescript and either addresses the underlying issue or adds an additional comment on why disabling the respective rule is actually okay in that case.

### How to test this

Nothing specific to test here, the code review is probably a lot more important.