### PR TITLE
Additional GHA bugs

### DIFF
--- a/.github/workflows/build-container-image.yml
+++ b/.github/workflows/build-container-image.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push images
+      - name: Build image
         uses: docker/build-push-action@v6
         with:
           push: false # This is handled in another workflow!
@@ -30,7 +30,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=docker,dest=${{ runner.temp }}/build.tar
 
-      - name: Upload docker image to GHA
+      - name: Upload docker image to GHA artifacts
         uses: actions/upload-artifact@v4
         with:
           name: build

--- a/.github/workflows/build-container-image.yml
+++ b/.github/workflows/build-container-image.yml
@@ -33,5 +33,5 @@ jobs:
       - name: Upload docker image to GHA artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: build
+          name: ${{ github.run_id }}
           path: ${{ runner.temp }}/build.tar

--- a/.github/workflows/build-container-image.yml
+++ b/.github/workflows/build-container-image.yml
@@ -1,4 +1,4 @@
-name: PRs » Build container image
+name: Build » Container image
 
 on:
   push:

--- a/.github/workflows/pr-build-test-branch.yml
+++ b/.github/workflows/pr-build-test-branch.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Upload build to GHA
         uses: actions/upload-artifact@v4
         with:
-          name: build
+          name: ${{ github.run_id }}
           path: ${{ runner.temp }}/build.tar
 
 

--- a/.github/workflows/pr-deploy-container-image.yml
+++ b/.github/workflows/pr-deploy-container-image.yml
@@ -22,12 +22,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels)
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/${{ github.repository }}
-
       - name: Download docker image from GHA
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/pr-deploy-container-image.yml
+++ b/.github/workflows/pr-deploy-container-image.yml
@@ -32,12 +32,13 @@ jobs:
         with:
           name: build
           path: ${{ runner.temp }}
+          github-token: ${{ github.token }}
           run-id: ${{ github.event.workflow_run.id }}
 
       - name: Load image
         run: |
           docker load --input ${{ runner.temp }}/build.tar
-          docker push ghcr.io/${{ github.repository }}
+          docker push ${{ steps.meta.outputs.tags }}
 
       - name: Add comment
         if: github.event_name == 'pull_request'

--- a/.github/workflows/pr-deploy-container-image.yml
+++ b/.github/workflows/pr-deploy-container-image.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Download docker image from GHA
         uses: actions/download-artifact@v4
         with:
-          name: build
+          name: ${{ github.event.workflow_run.id }}
           path: ${{ runner.temp }}
           github-token: ${{ github.token }}
           run-id: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/pr-deploy-container-image.yml
+++ b/.github/workflows/pr-deploy-container-image.yml
@@ -13,6 +13,7 @@ jobs:
       contents: read
       packages: write
       pull-requests: write
+    if: github.event.workflow_run.event == 'pull_request'
     steps:
       - name: Log in to the container registry
         uses: docker/login-action@v3
@@ -41,7 +42,6 @@ jobs:
           docker push ${{ steps.meta.outputs.tags }}
 
       - name: Add comment
-        if: github.event_name == 'pull_request'
         uses: thollander/actions-comment-pull-request@v3
         with:
           pr-number: ${{ github.event.workflow_run.pull_requests[0].number }}

--- a/.github/workflows/pr-deploy-container-image.yml
+++ b/.github/workflows/pr-deploy-container-image.yml
@@ -2,7 +2,7 @@ name: PRs » Push container image
 
 on:
   workflow_run:
-    workflows: ["PRs » Build container image"]
+    workflows: ["Build » Container image"]
     types:
       - completed
 

--- a/.github/workflows/pr-deploy-container-image.yml
+++ b/.github/workflows/pr-deploy-container-image.yml
@@ -44,6 +44,7 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: thollander/actions-comment-pull-request@v3
         with:
+          pr-number: ${{ github.event.workflow_run.pull_requests[0].number }}
           comment-tag: container-image
           message: |
             Use `docker` or `podman` to test this pull request locally.

--- a/.github/workflows/pr-deploy-container-image.yml
+++ b/.github/workflows/pr-deploy-container-image.yml
@@ -39,7 +39,10 @@ jobs:
       - name: Load image
         run: |
           docker load --input ${{ runner.temp }}/build.tar
-          docker push ${{ steps.meta.outputs.tags }}
+
+      - name: Push main branch image
+        run: |
+          docker push ghcr.io/${{ github.repository_owner }}/admin-interface:pr-${{ github.event.workflow_run.pull_requests[0].number }}
 
       - name: Add comment
         uses: thollander/actions-comment-pull-request@v3

--- a/.github/workflows/pr-deploy-test-branch.yml
+++ b/.github/workflows/pr-deploy-test-branch.yml
@@ -43,7 +43,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: build
-          path: ${{ runner.temp }}/build.tar
+          path: ${{ runner.temp }}/
+          github-token: ${{ github.token }}
           run-id: ${{ github.event.workflow_run.id }}
 
       - name: Store build in the clone

--- a/.github/workflows/pr-deploy-test-branch.yml
+++ b/.github/workflows/pr-deploy-test-branch.yml
@@ -84,6 +84,7 @@ jobs:
       - name: Add comment with deployment location
         uses: thollander/actions-comment-pull-request@v3
         with:
+          pr-number: ${{ github.event.workflow_run.pull_requests[0].number }}
           comment-tag: static-test-deployment
           message: >
             This pull request is deployed at

--- a/.github/workflows/pr-deploy-test-branch.yml
+++ b/.github/workflows/pr-deploy-test-branch.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Fetch build from GHA
         uses: actions/download-artifact@v4
         with:
-          name: build
+          name: ${{ github.event.workflow_run.id }}
           path: ${{ runner.temp }}/
           github-token: ${{ github.token }}
           run-id: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/pr-deploy-test-branch.yml
+++ b/.github/workflows/pr-deploy-test-branch.yml
@@ -74,7 +74,7 @@ jobs:
         working-directory: admin-interface-test
         run: |
           git add .
-          git commit --amend -m "Build ${{ steps.build-path.outputs.build }}"
+          git commit --amend -m "Build ${{ github.event.workflow_run.pull_requests[0].number }}"
 
       - name: Force push admin interface test branch
         working-directory: admin-interface-test

--- a/.github/workflows/pr-remove-test-branch.yml
+++ b/.github/workflows/pr-remove-test-branch.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Clone test repository
         run: |
-          git clone -b gh-pages "git@github.com:opencast/admin-interface-test.git" admin-interface-test
+          git clone -b gh-pages "git@github.com:${{ github.repository_owner }}/admin-interface-test.git" admin-interface-test
 
       - name: Delete build if present
         working-directory: admin-interface-test


### PR DESCRIPTION
This PR resolves a number of issues related to #1619 and #1621.

In short:
- Github token needed to be passed in a few places to actually grant the permissions to the relevant steps.
- The commenting on PRs steps not longer knew which PRs had triggered them due to the workflow changes.
- A workflow was running on pushes that should only run on PRs.
- Various logging and commit message fixes.